### PR TITLE
Rename trunk branch to main.

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -7,7 +7,7 @@
 
 SLUG="square/workflow"
 JDK="oraclejdk8"
-BRANCH="trunk"
+BRANCH="main"
 
 set -e
 

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -3,7 +3,7 @@ name: Kotlin CI
 on:
   push:
     branches:
-      - trunk
+      - main
   pull_request:
 
 env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # workflow
 
-[![Kotlin CI](https://github.com/square/workflow-kotlin/workflows/Kotlin%20CI/badge.svg)](https://github.com/square/workflow-kotlin/actions?query=branch%3Atrunk)
+[![Kotlin CI](https://github.com/square/workflow-kotlin/workflows/Kotlin%20CI/badge.svg)](https://github.com/square/workflow-kotlin/actions?query=branch%3Amain)
 [![Maven Central](https://img.shields.io/maven-central/v/com.squareup.workflow/workflow-core-jvm.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.squareup.workflow%22)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Kotlinlang slack](https://img.shields.io/static/v1?label=kotlinlang&message=squarelibraries&color=brightgreen&logo=slack)](https://kotlinlang.slack.com/archives/C5HT9AL7Q)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@
 ---
 1. Merge an update of [the change log](CHANGELOG.md) with the changes since the last release.
 
-1. Make sure you're on the `trunk` branch (or fix branch, e.g. `v0.1-fixes`).
+1. Make sure you're on the `main` branch (or fix branch, e.g. `v0.1-fixes`).
 
 1. Confirm that the kotlin build is green before committing any changes
    ```bash
@@ -42,7 +42,7 @@
 
 1. Push your commits and tag:
    ```
-   git push origin trunk
+   git push origin main
    # or git push origin fix-branch
    git push origin v0.1.0
    ```
@@ -57,16 +57,16 @@
    1. If this is a pre-release version, check the pre-release box.
    1. Hit "Publish release".
 
-1. If this was a fix release, merge changes to the trunk branch:
+1. If this was a fix release, merge changes to the main branch:
    ```bash
-   git checkout trunk
+   git checkout main
    git pull
    git merge --no-ff v0.1-fixes
-   # Resolve conflicts. Accept trunk's versions of gradle.properties and podspecs.
-   git push origin trunk
+   # Resolve conflicts. Accept main's versions of gradle.properties and podspecs.
+   git push origin main
    ```
 
-1. Publish the website. See https://github.com/square/workflow/blob/trunk/RELEASING.md.
+1. Publish the website. See https://github.com/square/workflow/blob/main/RELEASING.md.
 
 ### Validating Markdown
 


### PR DESCRIPTION
In the last week, the discussion around git branch naming seems to have
settled around "main" being the most popular choice. Github is even
changing their default branch name to this.


## Checklist

- [x] I have made corresponding changes to the documentation
