### PR TITLE
Introduce runningSideEffect API

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -27,6 +27,7 @@ public abstract interface class com/squareup/workflow/RenderContext {
 	public abstract fun makeActionSink ()Lcom/squareup/workflow/Sink;
 	public abstract fun onEvent (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
 	public abstract fun renderChild (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public abstract fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun runningWorker (Lcom/squareup/workflow/Worker;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
@@ -116,6 +116,31 @@ interface RenderContext<StateT, in OutputT : Any> {
     key: String = "",
     handler: (T) -> WorkflowAction<StateT, OutputT>
   )
+
+  /**
+   * Ensures [sideEffect] is running with the given [key].
+   *
+   * The first render pass in which this method is called, [sideEffect] will be launched in a new
+   * coroutine that will be scoped to the rendering [Workflow]. Subsequent render passes that invoke
+   * this method with the same [key] will not launch the coroutine again, but let it keep running.
+   * Note that if a different function is passed with the same key, the side effect will *not* be
+   * restarted, the new function will simply be ignored. The next render pass in which the
+   * workflow does not call this method with the same key, the coroutine running [sideEffect] will
+   * be
+   * [cancelled](https://kotlinlang.org/docs/reference/coroutines/cancellation-and-timeouts.html).
+   *
+   * The coroutine will run with the same [CoroutineContext][kotlin.coroutines.CoroutineContext]
+   * that the workflow runtime is running in. The side effect coroutine will not be started until
+   * _after_ the first render call than runs it returns.
+   *
+   * @param key The string key that is used to distinguish between side effects.
+   * @param sideEffect The suspend function that will be launched in a coroutine to perform the
+   * side effect.
+   */
+  fun runningSideEffect(
+    key: String,
+    sideEffect: suspend () -> Unit
+  )
 }
 
 /**

--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -235,13 +235,14 @@ public final class com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Sour
 }
 
 public final class com/squareup/workflow/internal/RealRenderContext : com/squareup/workflow/RenderContext, com/squareup/workflow/Sink {
-	public fun <init> (Lcom/squareup/workflow/internal/RealRenderContext$Renderer;Lcom/squareup/workflow/internal/RealRenderContext$WorkerRunner;Lkotlinx/coroutines/channels/SendChannel;)V
+	public fun <init> (Lcom/squareup/workflow/internal/RealRenderContext$Renderer;Lcom/squareup/workflow/internal/RealRenderContext$WorkerRunner;Lcom/squareup/workflow/internal/RealRenderContext$SideEffectRunner;Lkotlinx/coroutines/channels/SendChannel;)V
 	public final fun freeze ()V
 	public fun getActionSink ()Lcom/squareup/workflow/Sink;
 	public fun makeActionSink ()Lcom/squareup/workflow/Sink;
 	public fun onEvent (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/EventHandler;
 	public synthetic fun onEvent (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
 	public fun renderChild (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public fun runningWorker (Lcom/squareup/workflow/Worker;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public fun send (Lcom/squareup/workflow/WorkflowAction;)V
 	public synthetic fun send (Ljava/lang/Object;)V
@@ -249,6 +250,10 @@ public final class com/squareup/workflow/internal/RealRenderContext : com/square
 
 public abstract interface class com/squareup/workflow/internal/RealRenderContext$Renderer {
 	public abstract fun render (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public abstract interface class com/squareup/workflow/internal/RealRenderContext$SideEffectRunner {
+	public abstract fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract interface class com/squareup/workflow/internal/RealRenderContext$WorkerRunner {

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.channels.SendChannel
 class RealRenderContext<StateT, OutputT : Any>(
   private val renderer: Renderer<StateT, OutputT>,
   private val workerRunner: WorkerRunner<StateT, OutputT>,
+  private val sideEffectRunner: SideEffectRunner,
   private val eventActionsChannel: SendChannel<WorkflowAction<StateT, OutputT>>
 ) : RenderContext<StateT, OutputT>, Sink<WorkflowAction<StateT, OutputT>> {
 
@@ -50,6 +51,13 @@ class RealRenderContext<StateT, OutputT : Any>(
       worker: Worker<T>,
       key: String,
       handler: (T) -> WorkflowAction<StateT, OutputT>
+    )
+  }
+
+  interface SideEffectRunner {
+    fun runningSideEffect(
+      key: String,
+      sideEffect: suspend () -> Unit
     )
   }
 
@@ -102,6 +110,14 @@ class RealRenderContext<StateT, OutputT : Any>(
   ) {
     checkNotFrozen()
     workerRunner.runningWorker(worker, key, handler)
+  }
+
+  override fun runningSideEffect(
+    key: String,
+    sideEffect: suspend () -> Unit
+  ) {
+    checkNotFrozen()
+    sideEffectRunner.runningSideEffect(key, sideEffect)
   }
 
   /**

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/SideEffectNode.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/SideEffectNode.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.internal
+
+import com.squareup.workflow.internal.InlineLinkedList.InlineListNode
+import kotlinx.coroutines.Job
+
+/**
+ * Holds a [Job] that represents a running [side effect][RealRenderContext.runningSideEffect], as
+ * well as the key used to identify that side effect.
+ */
+internal class SideEffectNode(
+  val key: String,
+  val job: Job
+) : InlineListNode<SideEffectNode> {
+
+  override var nextListNode: SideEffectNode? = null
+}

--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -15,6 +15,7 @@ public abstract interface class com/squareup/workflow/testing/RenderTestResult {
 }
 
 public abstract interface class com/squareup/workflow/testing/RenderTester {
+	public abstract fun expectSideEffect (Ljava/lang/String;)Lcom/squareup/workflow/testing/RenderTester;
 	public abstract fun expectWorker (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lcom/squareup/workflow/testing/EmittedOutput;)Lcom/squareup/workflow/testing/RenderTester;
 	public abstract fun expectWorkflow (Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/testing/EmittedOutput;)Lcom/squareup/workflow/testing/RenderTester;
 	public abstract fun render (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/testing/RenderTestResult;

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
@@ -233,6 +233,15 @@ interface RenderTester<PropsT, StateT, OutputT : Any, RenderingT> {
   ): RenderTester<PropsT, StateT, OutputT, RenderingT>
 
   /**
+   * Specifies that this render pass is expected to run a particular side effect.
+   *
+   * @param key The key passed to
+   * [runningSideEffect][com.squareup.workflow.RenderContext.runningSideEffect] when rendering this
+   * workflow.
+   */
+  fun expectSideEffect(key: String): RenderTester<PropsT, StateT, OutputT, RenderingT>
+
+  /**
    * Execute the workflow's `render` method and run [block] to perform assertions on and send events
    * to the resulting rendering.
    *


### PR DESCRIPTION
First part of Kotlin implementation of https://github.com/square/workflow/issues/1021.

Kotlin counterpart to https://github.com/square/workflow/pull/1174.

This implementation intentionally does not run the side effect coroutine
on the `workerContext` `CoroutineContext` that is threaded through the
runtime for testing infrastructure. Initially, workers ran in the same
context as the workflow runtime. The behavior of running workers on a
different dispatcher by default (`Unconfined`) was introduced in
https://github.com/square/workflow/pull/851 as an optimization to reduce
the overhead for running workers that only perform wiring tasks with
other async libraries. This was a theoretical optimization, since running
on the `Unconfined` dispatcher inherently involves less dispatching work,
but the overhead of dispatching wiring coroutines was never actually shown
to be a problem. Additionally, because tests often need to be in full
control of dispatchers, the ability to override the context used for
workers was introduced in https://github.com/square/workflow/pull/940,
which introduced `workerContext`. I am dropping that complexity here
because it adds a decent amount of complexity to worker/side effect
machinery without any proven value. It is also complexity that needs to
be documented, and is probably just more confusing than anything. The
old behavior for workers is maintained for now to reduce the risk of this
change, but side effects will always run in the workflow runtime's
context. This is nice and simple and unsurprising and easy to reason
about.

## Checklist

- [x] Unit Tests
- ~~UI Tests~~ (will be covered by existing UI tests when workers are migrated)
- [x] I have made corresponding changes to the documentation
