### PR TITLE
Introduce helpers for working with Sinks of WorkflowActions from suspend functions.

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -55,7 +55,9 @@ public abstract interface class com/squareup/workflow/Sink {
 }
 
 public final class com/squareup/workflow/SinkKt {
+	public static final fun collectToSink (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow/Sink;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun contraMap (Lcom/squareup/workflow/Sink;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Sink;
+	public static final fun sendAndAwaitApplication (Lcom/squareup/workflow/Sink;Lcom/squareup/workflow/WorkflowAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/squareup/workflow/Snapshot {

--- a/workflow-core/build.gradle.kts
+++ b/workflow-core/build.gradle.kts
@@ -34,5 +34,6 @@ dependencies {
   // For Snapshot.
   api(Dependencies.okio)
 
+  testImplementation(Dependencies.Kotlin.Coroutines.test)
   testImplementation(Dependencies.Kotlin.Test.jdk)
 }

--- a/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
@@ -43,18 +43,22 @@ interface WorkflowAction<StateT, out OutputT : Any> {
     }
   }
 
-  @Suppress("DEPRECATION")
-  @Deprecated("Implement Updater.apply")
-  fun Mutator<StateT>.apply(): OutputT? {
-    throw UnsupportedOperationException()
-  }
-
+  /**
+   * Executes the logic for this action, including any side effects, updating [state][StateT], and
+   * setting the [OutputT] to emit.
+   */
   @Suppress("DEPRECATION")
   fun Updater<StateT, OutputT>.apply() {
     val mutator = Mutator(nextState)
     mutator.apply()
         ?.let { setOutput(it) }
     nextState = mutator.state
+  }
+
+  @Suppress("DEPRECATION")
+  @Deprecated("Implement Updater.apply")
+  fun Mutator<StateT>.apply(): OutputT? {
+    throw UnsupportedOperationException()
   }
 
   companion object {

--- a/workflow-core/src/test/java/com/squareup/workflow/SinkTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/SinkTest.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runBlockingTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+@OptIn(
+    ExperimentalCoroutinesApi::class,
+    ExperimentalStdlibApi::class,
+    ExperimentalWorkflow::class
+)
+class SinkTest {
+
+  private val sink = RecordingSink()
+
+  @Test fun `collectToActionSink sends action`() {
+    runBlockingTest {
+      val flow = MutableStateFlow(1)
+      val collector = launch {
+        flow.collectToSink(sink) {
+          action {
+            nextState = "$nextState $it"
+            setOutput("output: $it")
+          }
+        }
+      }
+
+      advanceUntilIdle()
+      assertEquals(1, sink.actions.size)
+      sink.actions.removeFirst()
+          .let { action ->
+            val (newState, output) = action.applyTo("state")
+            assertEquals("state 1", newState)
+            assertEquals("output: 1", output)
+          }
+      assertTrue(sink.actions.isEmpty())
+
+      flow.value = 2
+      advanceUntilIdle()
+      assertEquals(1, sink.actions.size)
+      sink.actions.removeFirst()
+          .let { action ->
+            val (newState, output) = action.applyTo("state")
+            assertEquals("state 2", newState)
+            assertEquals("output: 2", output)
+          }
+
+      collector.cancel()
+    }
+  }
+
+  @Test fun `sendAndAwaitApplication applies action`() {
+    var applications = 0
+    val action = action<String, String> {
+      applications++
+      nextState = "$nextState applied"
+      setOutput("output")
+    }
+
+    runBlockingTest {
+      launch { sink.sendAndAwaitApplication(action) }
+      advanceUntilIdle()
+
+      val enqueuedAction = sink.actions.removeFirst()
+      val result = enqueuedAction.applyTo("state")
+      assertEquals(1, applications)
+      assertEquals("state applied", result.first)
+      assertEquals("output", result.second)
+    }
+  }
+
+  @Test fun `sendAndAwaitApplication suspends until after applied`() {
+    runBlockingTest {
+      var resumed = false
+      val action = action<String, String> {
+        assertFalse(resumed)
+      }
+      launch {
+        sink.sendAndAwaitApplication(action)
+        resumed = true
+      }
+      advanceUntilIdle()
+      assertFalse(resumed)
+      assertEquals(1, sink.actions.size)
+
+      val enqueuedAction = sink.actions.removeFirst()
+      pauseDispatcher()
+      enqueuedAction.applyTo("state")
+
+      assertFalse(resumed)
+      resumeDispatcher()
+      advanceUntilIdle()
+      assertTrue(resumed)
+    }
+  }
+
+  @Test fun `sendAndAwaitApplication doesn't apply action when cancelled while suspended`() {
+    runBlockingTest {
+      var applied = false
+      val action = action<String, String> {
+        applied = true
+        fail()
+      }
+      val sendJob = launch { sink.sendAndAwaitApplication(action) }
+      advanceUntilIdle()
+      assertFalse(applied)
+      assertEquals(1, sink.actions.size)
+
+      val enqueuedAction = sink.actions.removeFirst()
+      sendJob.cancel()
+      advanceUntilIdle()
+      val result = enqueuedAction.applyTo("ignored")
+
+      assertFalse(applied)
+      assertEquals("ignored", result.first)
+      assertNull(result.second)
+    }
+  }
+
+  private class RecordingSink : Sink<WorkflowAction<String, String>> {
+    val actions = mutableListOf<WorkflowAction<String, String>>()
+
+    override fun send(value: WorkflowAction<String, String>) {
+      actions += value
+    }
+  }
+}


### PR DESCRIPTION
- `Sink.sendAndAwaitApplication()`
- `Flow.collectToSink()`

These helpers will be used to implement Workers using side effects (#12).
GUWT workers are described in https://github.com/square/workflow/issues/1021.

## Checklist

- [x] Unit Tests
- ~~UI Tests~~
- [x] I have made corresponding changes to the documentation
