### PR TITLE
Preserve view id when replacing WorkflowViewStubs

### DIFF
--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowViewStub.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowViewStub.kt
@@ -22,7 +22,8 @@ import android.view.ViewGroup
 
 /**
  * A placeholder [View] that can replace itself with ones driven by workflow renderings,
- * similar to [android.view.ViewStub].
+ * similar to [android.view.ViewStub]. Unlike [android.view.ViewStub], it will set the
+ * id declared on the stub onto the view that replaces the stub.
  *
  * ## Usage
  *
@@ -95,7 +96,10 @@ class WorkflowViewStub @JvmOverloads constructor(
       is ViewGroup -> viewEnvironment[ViewRegistry].buildView(rendering, viewEnvironment, parent)
           .also { buildNewViewAndReplaceOldView(parent, it) }
       else -> viewEnvironment[ViewRegistry].buildView(rendering, viewEnvironment, actual.context)
-    }.also { actual = it }
+    }.also {
+      it.id = actual.id
+      actual = it
+    }
   }
 
   private fun buildNewViewAndReplaceOldView(


### PR DESCRIPTION
Fixes https://github.com/square/workflow-kotlin/issues/26

Was not sure when it would be useful for a workflowViewStub and the view that replaces it to have different view ids, so this PR preserves it.

## Checklist

- ~Unit Tests~
- ~UI Tests~
- [x] I have made corresponding changes to the documentation
