### PR TITLE
Gives WorkflowViewStub parity with ViewStub and then some.

### DIFF
--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardsListLayoutRunner.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardsListLayoutRunner.kt
@@ -16,6 +16,8 @@
 package com.squareup.sample.dungeon
 
 import android.view.View
+import android.view.View.INVISIBLE
+import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.cardview.widget.CardView
@@ -63,10 +65,20 @@ class BoardsListLayoutRunner(rootView: View) : LayoutRunner<DisplayBoardsListScr
             // The board preview is actually rendered using the same LayoutRunner as the actual
             // live game. It's easy to delegate to it by just putting a WorkflowViewStub in our
             // layout and giving it the Board.
-            val boardPreviewView: WorkflowViewStub = view.findViewById(R.id.board_preview)
+            val boardPreviewView: WorkflowViewStub = view.findViewById(R.id.board_preview_stub)
 
             boardNameView.text = item.board.metadata.name
             boardPreviewView.update(item.board, item.viewEnvironment)
+
+            // Gratuitous, hacky, inline test of WorkflowViewStub features.
+            check(boardPreviewView.actual.visibility == INVISIBLE) {
+              "Expected swizzled board to be INVISIBLE"
+            }
+            boardPreviewView.visibility = VISIBLE
+            check(view.findViewById<View>(R.id.board_preview).visibility == VISIBLE) {
+              "Expected swizzled board to be VISIBLE"
+            }
+
             card.setOnClickListener { item.onClicked() }
           }
         }

--- a/samples/dungeon/app/src/main/res/layout/boards_list_item.xml
+++ b/samples/dungeon/app/src/main/res/layout/boards_list_item.xml
@@ -48,13 +48,15 @@
           />
 
       <com.squareup.workflow.ui.WorkflowViewStub
-          android:id="@+id/board_preview"
+          android:id="@+id/board_preview_stub"
           android:layout_width="0dp"
           android:layout_height="0dp"
           android:layout_marginStart="@dimen/default_gap"
           android:layout_marginTop="@dimen/default_gap"
           android:layout_marginEnd="@dimen/default_gap"
           android:layout_marginBottom="@dimen/default_gap"
+          android:visibility="invisible"
+          app:inflatedId="@+id/board_preview"
           app:layout_constraintBottom_toBottomOf="parent"
           app:layout_constraintDimensionRatio="1:1"
           app:layout_constraintEnd_toEndOf="parent"

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -175,7 +175,11 @@ public final class com/squareup/workflow/ui/WorkflowViewStub : android/view/View
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getActual ()Landroid/view/View;
-	public final fun setActual (Landroid/view/View;)V
+	public final fun getInflatedId ()I
+	public final fun getReplaceOldViewInParent ()Lkotlin/jvm/functions/Function2;
+	public final fun setInflatedId (I)V
+	public final fun setReplaceOldViewInParent (Lkotlin/jvm/functions/Function2;)V
+	public fun setVisibility (I)V
 	public final fun update (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;)Landroid/view/View;
 }
 

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowViewStub.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowViewStub.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.IdRes
 
 /**
  * A placeholder [View] that can replace itself with ones driven by workflow renderings,
@@ -29,29 +30,41 @@ import android.view.ViewGroup
  * In the XML layout for a container view, place a [WorkflowViewStub] where
  * you want child renderings to be displayed. E.g.:
  *
- *    <LinearLayout…>
+ *    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+ *         xmlns:app="http://schemas.android.com/apk/res-auto"
+ *         …>
  *
- *        <com.squareup.workflow.ui.WorkflowViewStub
+ *        <com.squareup.workflow.WorkflowViewStub
  *            android:id="@+id/child_stub"
+ *            app:inflatedId="@+id/child"
  *            />
  *       …
  *
  * Then in your [LayoutRunner],
- *   - pull the view out with `findViewById` like any other view
- *   - and update it in your `showRendering` method:
+ *   - pull the view out with [findViewById] like any other view
+ *   - and [update] it in your [LayoutRunner.showRendering] method:
  *
  * ```
  *     class YourLayoutRunner(view: View) {
- *       private val child = view.findViewById<WorkflowViewStub>(R.id.child_stub)
+ *       private val childStub = view.findViewById<WorkflowViewStub>(R.id.child_stub)
+ *
+ *       // Totally optional, since this view is also accessible as [childStub.actual].
+ *       // Note that R.id.child was set in XML via the square:inflatedId parameter.
+ *       private val child: View by lazy {
+ *         view.findViewById<View>(R.id.child)
+ *       }
  *
  *       override fun showRendering(
  *          rendering: YourRendering,
  *          viewEnvironment: ViewEnvironment
  *       ) {
- *         child.update(rendering.childRendering, viewEnvironment)
+ *         childStub.update(rendering.childRendering, viewEnvironment)
  *       }
  *     }
  * ```
+ *
+ * **NB**: If you're using a stub in a `RelativeLayout` or `ConstraintLayout`, relationships
+ * should be tied to the stub's `app:inflatedId`, not its `android:id`.
  */
 class WorkflowViewStub @JvmOverloads constructor(
   context: Context,
@@ -59,27 +72,73 @@ class WorkflowViewStub @JvmOverloads constructor(
   defStyle: Int = 0,
   defStyleRes: Int = 0
 ) : View(context, attributeSet, defStyle, defStyleRes) {
+  /**
+   * On-demand access to the view created by the last call to [update],
+   * or this [WorkflowViewStub] instance if none has yet been made.
+   */
+  var actual: View = this
+    private set
+
+  /**
+   * The id to be assigned to views created by [update]. If the inflated id is
+   * [View.NO_ID] (its default value), new views keep their original ids.
+   */
+  @IdRes var inflatedId: Int
+
   init {
+    val attrs = context.obtainStyledAttributes(
+        attributeSet, R.styleable.WorkflowViewStub, defStyle, defStyleRes
+    )
+    inflatedId = attrs.getResourceId(R.styleable.WorkflowViewStub_inflatedId, NO_ID)
+    attrs.recycle()
+
     setWillNotDraw(true)
   }
 
   /**
-   * On-demand access to the delegate established by the last call to [update],
-   * or this [WorkflowViewStub] instance if  none has yet been set.
+   * Function called from [update] to replace this stub, or the current [actual],
+   * with a new view. Can be updated to provide custom transition effects.
+   *
+   * Note that this method is responsible for copying the [layoutParams][getLayoutParams]
+   * from the stub to the new view. Also note that in a [WorkflowViewStub] that has never
+   * been updated, [actual] is the stub itself.
    */
-  var actual: View = this
+  var replaceOldViewInParent: (ViewGroup, View) -> Unit = { parent, newView ->
+    val index = parent.indexOfChild(actual)
+    parent.removeView(actual)
+    actual.layoutParams
+        ?.let { parent.addView(newView, index, it) }
+        ?: run { parent.addView(newView, index) }
+  }
+
+  /**
+   * Sets the visibility of this stub as usual, and also that of [actual].
+   * Any new views created by [update] will be assigned this visibility.
+   */
+  override fun setVisibility(visibility: Int) {
+    super.setVisibility(visibility)
+    if (actual != this) actual.visibility = visibility
+  }
 
   /**
    * Replaces this view with one that can display [rendering]. If the receiver
    * has already been replaced, updates the replacement if it [canShowRendering].
-   * If the current replacement can't handle [rendering], a new view is put in place.
+   * If the current replacement can't handle [rendering], a new view is put in its place.
+   *
+   * The [id][View.setId] of any view created by this method will be set to to [inflatedId],
+   * unless that value is [View.NO_ID].
+   *
+   * The [visibility][setVisibility] of any view created by this method will be copied
+   * from [getVisibility].
    *
    * @return the view that showed [rendering]
    *
    * @throws IllegalArgumentException if no binding can be find for the type of [rendering]
    *
-   * @throws IllegalStateException if the matching [ViewFactory] fails to call
-   * [View.bindShowRendering] when constructing the view
+   * @throws IllegalStateException if the matching
+   * [ViewFactory][com.squareup.workflow.ui.ViewFactory] fails to call
+   * [View.bindShowRendering][com.squareup.workflow.ui.bindShowRendering]
+   * when constructing the view
    */
   fun update(
     rendering: Any,
@@ -91,22 +150,17 @@ class WorkflowViewStub @JvmOverloads constructor(
           return it
         }
 
-    return when (val parent = actual.parent) {
-      is ViewGroup -> viewEnvironment[ViewRegistry].buildView(rendering, viewEnvironment, parent)
-          .also { buildNewViewAndReplaceOldView(parent, it) }
-      else -> viewEnvironment[ViewRegistry].buildView(rendering, viewEnvironment, actual.context)
-    }.also { actual = it }
-  }
+    val parent = actual.parent as? ViewGroup
+        ?: throw IllegalStateException(
+            "WorkflowViewStub must have a non-null ViewGroup parent"
+        )
 
-  private fun buildNewViewAndReplaceOldView(
-    parent: ViewGroup,
-    newView: View
-  ) {
-    val index = parent.indexOfChild(actual)
-    parent.removeView(actual)
-
-    actual.layoutParams
-        ?.let { parent.addView(newView, index, it) }
-        ?: run { parent.addView(newView, index) }
+    return viewEnvironment[ViewRegistry].buildView(rendering, viewEnvironment, parent)
+        .also { newView ->
+          if (inflatedId != NO_ID) newView.id = inflatedId
+          newView.visibility = visibility
+          replaceOldViewInParent(parent, newView)
+          actual = newView
+        }
   }
 }

--- a/workflow-ui/core-android/src/main/res/values/attrs.xml
+++ b/workflow-ui/core-android/src/main/res/values/attrs.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2020 Square Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <declare-styleable name="WorkflowViewStub">
+    <!-- Used as the id of views created via a WorkflowViewStub -->
+    <attr name="inflatedId" format="reference"/>
+  </declare-styleable>
+</resources>


### PR DESCRIPTION
Adds `inflatedId`, `setVisible` and `replaceOldViewInParent`. Punches up kdoc.

Issues:

 - Closes https://github.com/square/workflow/issues/1141
 - Closes https://github.com/square/workflow/issues/1138
 - Closes https://github.com/square/workflow/issues/1119

## Checklist

- [ ] Unit Tests
- [x] UI Tests
- [x] I have made corresponding changes to the documentation
