### PR TITLE
Give the ExperimentalWorkflow annotation an 'Api' suffix.

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -11,7 +11,7 @@ public final class com/squareup/workflow/EventHandlerKt {
 	public static final fun invoke (Lcom/squareup/workflow/EventHandler;)V
 }
 
-public abstract interface annotation class com/squareup/workflow/ExperimentalWorkflow : java/lang/annotation/Annotation {
+public abstract interface annotation class com/squareup/workflow/ExperimentalWorkflowApi : java/lang/annotation/Annotation {
 }
 
 public abstract class com/squareup/workflow/LifecycleWorker : com/squareup/workflow/Worker {

--- a/workflow-core/src/main/java/com/squareup/workflow/ExperimentalWorkflowApi.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/ExperimentalWorkflowApi.kt
@@ -27,4 +27,4 @@ import kotlin.annotation.AnnotationRetention.BINARY
 @MustBeDocumented
 @Retention(value = BINARY)
 @RequiresOptIn(level = ERROR)
-annotation class ExperimentalWorkflow
+annotation class ExperimentalWorkflowApi

--- a/workflow-core/src/main/java/com/squareup/workflow/Sink.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/Sink.kt
@@ -70,7 +70,7 @@ fun <T1, T2> Sink<T1>.contraMap(transform: (T2) -> T1): Sink<T2> {
  * }
  * ```
  */
-@ExperimentalWorkflow
+@ExperimentalWorkflowApi
 suspend fun <T, StateT, OutputT : Any> Flow<T>.collectToSink(
   actionSink: Sink<WorkflowAction<StateT, OutputT>>,
   handler: (T) -> WorkflowAction<StateT, OutputT>
@@ -92,7 +92,7 @@ suspend fun <T, StateT, OutputT : Any> Flow<T>.collectToSink(
  *
  * This method is intended to be used from [RenderContext.runningSideEffect].
  */
-@ExperimentalWorkflow
+@ExperimentalWorkflowApi
 suspend fun <StateT, OutputT : Any> Sink<WorkflowAction<StateT, OutputT>>.sendAndAwaitApplication(
   action: WorkflowAction<StateT, OutputT>
 ) {

--- a/workflow-core/src/test/java/com/squareup/workflow/SinkTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/SinkTest.kt
@@ -29,7 +29,7 @@ import kotlin.test.fail
 @OptIn(
     ExperimentalCoroutinesApi::class,
     ExperimentalStdlibApi::class,
-    ExperimentalWorkflow::class
+    ExperimentalWorkflowApi::class
 )
 class SinkTest {
 

--- a/workflow-runtime/src/main/java/com/squareup/workflow/LaunchWorkflow.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/LaunchWorkflow.kt
@@ -209,7 +209,7 @@ fun <PropsT, OutputT : Any, RenderingT, RunnerT> launchWorkflowIn(
  * A [StateFlow] of [RenderingAndSnapshot]s that will emit any time the root workflow creates a new
  * rendering.
  */
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalWorkflow::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalWorkflowApi::class)
 fun <PropsT, OutputT : Any, RenderingT> renderWorkflowIn(
   workflow: Workflow<PropsT, OutputT, RenderingT>,
   scope: CoroutineScope,
@@ -268,7 +268,7 @@ fun <PropsT, OutputT : Any, RenderingT> renderWorkflowIn(
 @OptIn(
     ExperimentalCoroutinesApi::class,
     FlowPreview::class,
-    ExperimentalWorkflow::class
+    ExperimentalWorkflowApi::class
 )
 @Suppress("LongParameterList")
 internal fun <PropsT, StateT, OutputT : Any, RenderingT, RunnerT> launchWorkflowImpl(

--- a/workflow-runtime/src/main/java/com/squareup/workflow/diagnostic/ChainedDiagnosticListener.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/diagnostic/ChainedDiagnosticListener.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.workflow.diagnostic
 
-import com.squareup.workflow.ExperimentalWorkflow
+import com.squareup.workflow.ExperimentalWorkflowApi
 import com.squareup.workflow.WorkflowAction
 import kotlinx.coroutines.CoroutineScope
 
@@ -31,7 +31,7 @@ fun WorkflowDiagnosticListener.andThen(
       .apply { addVisitor(next) }
 }
 
-@OptIn(ExperimentalWorkflow::class)
+@OptIn(ExperimentalWorkflowApi::class)
 @Suppress("TooManyFunctions")
 internal class ChainedDiagnosticListener(
   listener: WorkflowDiagnosticListener

--- a/workflow-runtime/src/main/java/com/squareup/workflow/diagnostic/DebugSnapshotRecordingListener.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/diagnostic/DebugSnapshotRecordingListener.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.workflow.diagnostic
 
-import com.squareup.workflow.ExperimentalWorkflow
+import com.squareup.workflow.ExperimentalWorkflowApi
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.diagnostic.WorkflowHierarchyDebugSnapshot.ChildWorker
 import com.squareup.workflow.diagnostic.WorkflowHierarchyDebugSnapshot.ChildWorkflow
@@ -29,7 +29,7 @@ import com.squareup.workflow.diagnostic.WorkflowUpdateDebugInfo.Source.Worker
  * A [WorkflowDiagnosticListener] that records [WorkflowHierarchyDebugSnapshot]s and
  * [WorkflowUpdateDebugInfo]s and sends them to [debugger] after each render pass.
  */
-@ExperimentalWorkflow
+@ExperimentalWorkflowApi
 @Suppress("TooManyFunctions")
 class DebugSnapshotRecordingListener(
   private val debugger: (WorkflowHierarchyDebugSnapshot, WorkflowUpdateDebugInfo?) -> Unit

--- a/workflow-runtime/src/main/java/com/squareup/workflow/diagnostic/SimpleLoggingDiagnosticListener.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/diagnostic/SimpleLoggingDiagnosticListener.kt
@@ -15,14 +15,14 @@
  */
 package com.squareup.workflow.diagnostic
 
-import com.squareup.workflow.ExperimentalWorkflow
+import com.squareup.workflow.ExperimentalWorkflowApi
 import com.squareup.workflow.WorkflowAction
 import kotlinx.coroutines.CoroutineScope
 
 /**
  * A [WorkflowDiagnosticListener] that just prints all events using [println].
  */
-@OptIn(ExperimentalWorkflow::class)
+@OptIn(ExperimentalWorkflowApi::class)
 @Suppress("TooManyFunctions")
 open class SimpleLoggingDiagnosticListener : WorkflowDiagnosticListener {
 

--- a/workflow-runtime/src/main/java/com/squareup/workflow/diagnostic/WorkflowDiagnosticListener.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/diagnostic/WorkflowDiagnosticListener.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.workflow.diagnostic
 
-import com.squareup.workflow.ExperimentalWorkflow
+import com.squareup.workflow.ExperimentalWorkflowApi
 import com.squareup.workflow.WorkflowAction
 import kotlinx.coroutines.CoroutineScope
 
@@ -76,7 +76,7 @@ interface WorkflowDiagnosticListener {
    *
    * Corresponds to [onAfterRenderPass].
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onBeforeRenderPass(props: Any?) = Unit
 
   /**
@@ -85,7 +85,7 @@ interface WorkflowDiagnosticListener {
    * @param workflowId The ID of the workflow for this event. If null, the props for the root
    * workflow changed. [oldState] and [newState] will always be null in that case.
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onPropsChanged(
     workflowId: Long?,
     oldProps: Any?,
@@ -99,7 +99,7 @@ interface WorkflowDiagnosticListener {
    *
    * Corresponds to [onAfterWorkflowRendered].
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onBeforeWorkflowRendered(
     workflowId: Long,
     props: Any?,
@@ -111,7 +111,7 @@ interface WorkflowDiagnosticListener {
    *
    * Corresponds to [onBeforeWorkflowRendered].
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onAfterWorkflowRendered(
     workflowId: Long,
     rendering: Any?
@@ -122,7 +122,7 @@ interface WorkflowDiagnosticListener {
    *
    * Corresponds to [onBeforeRenderPass].
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onAfterRenderPass(rendering: Any?) = Unit
 
   /**
@@ -131,7 +131,7 @@ interface WorkflowDiagnosticListener {
    *
    * Corresponds to [onAfterSnapshotPass].
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onBeforeSnapshotPass() = Unit
 
   /**
@@ -140,7 +140,7 @@ interface WorkflowDiagnosticListener {
    *
    * Corresponds to [onBeforeSnapshotPass].
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onAfterSnapshotPass() = Unit
 
   // endregion
@@ -154,7 +154,7 @@ interface WorkflowDiagnosticListener {
    *
    * Corresponds to [onRuntimeStopped].
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onRuntimeStarted(
     workflowScope: CoroutineScope,
     rootWorkflowType: String
@@ -166,7 +166,7 @@ interface WorkflowDiagnosticListener {
    *
    * Corresponds to [onRuntimeStarted].
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onRuntimeStopped() = Unit
 
   /**
@@ -185,7 +185,7 @@ interface WorkflowDiagnosticListener {
    * [initialState][com.squareup.workflow.StatefulWorkflow.initialState].
    * @param restoredFromSnapshot True iff the snapshot parameter to `initialState` was non-null.
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   @Suppress("LongParameterList")
   fun onWorkflowStarted(
     workflowId: Long,
@@ -204,7 +204,7 @@ interface WorkflowDiagnosticListener {
    *
    * @param workflowId The ID of the workflow that stopped.
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onWorkflowStopped(workflowId: Long) = Unit
 
   /**
@@ -218,7 +218,7 @@ interface WorkflowDiagnosticListener {
    * @param key The key passed to `runningWorker` by [parentWorkflowId].
    * @param description A string description of the worker. Contains the worker's `toString`.
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onWorkerStarted(
     workerId: Long,
     parentWorkflowId: Long,
@@ -235,7 +235,7 @@ interface WorkflowDiagnosticListener {
    * @param workerId The ID of the worker that stopped.
    * @param parentWorkflowId The ID of the workflow that was running this worker.
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onWorkerStopped(
     workerId: Long,
     parentWorkflowId: Long
@@ -255,7 +255,7 @@ interface WorkflowDiagnosticListener {
    * receive the output.
    * @param output The value that the worker output.
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onWorkerOutput(
     workerId: Long,
     parentWorkflowId: Long,
@@ -271,7 +271,7 @@ interface WorkflowDiagnosticListener {
    * corresponding [WorkflowAction].
    * @param action The [WorkflowAction] that will be executed by [workflowId].
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onSinkReceived(
     workflowId: Long,
     action: WorkflowAction<*, *>
@@ -290,7 +290,7 @@ interface WorkflowDiagnosticListener {
    * the state, this will be the same value as [oldState].
    * @param output The output value returned from [action].
    */
-  @ExperimentalWorkflow
+  @ExperimentalWorkflowApi
   fun onWorkflowAction(
     workflowId: Long,
     action: WorkflowAction<*, *>,

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/Workers.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/Workers.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.workflow.internal
 
-import com.squareup.workflow.ExperimentalWorkflow
+import com.squareup.workflow.ExperimentalWorkflowApi
 import com.squareup.workflow.Worker
 import com.squareup.workflow.diagnostic.WorkflowDiagnosticListener
 import kotlinx.coroutines.CoroutineName
@@ -79,7 +79,7 @@ private fun <T> Worker<T>.runWithNullCheck(): Flow<T> =
           "If this is a test mock, make sure you mock the run() method!"
   )
 
-@OptIn(ExperimentalWorkflow::class)
+@OptIn(ExperimentalWorkflowApi::class)
 private fun <T> Flow<T>.wireUpDebugger(
   workerDiagnosticId: Long,
   workflowDiagnosticId: Long,

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowLoop.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowLoop.kt
@@ -18,7 +18,7 @@ package com.squareup.workflow.internal
 import com.squareup.workflow.RenderingAndSnapshot
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
-import com.squareup.workflow.ExperimentalWorkflow
+import com.squareup.workflow.ExperimentalWorkflowApi
 import com.squareup.workflow.diagnostic.IdCounter
 import com.squareup.workflow.diagnostic.WorkflowDiagnosticListener
 import kotlinx.coroutines.channels.consume
@@ -53,7 +53,7 @@ internal interface WorkflowLoop {
   ): Nothing
 }
 
-@OptIn(ExperimentalWorkflow::class)
+@OptIn(ExperimentalWorkflowApi::class)
 internal open class RealWorkflowLoop : WorkflowLoop {
 
   @Suppress("LongMethod")

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
@@ -15,9 +15,9 @@
  */
 package com.squareup.workflow.internal
 
-import com.squareup.workflow.ExperimentalWorkflow
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
+import com.squareup.workflow.ExperimentalWorkflowApi
 import com.squareup.workflow.Worker
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
@@ -54,7 +54,7 @@ import kotlin.coroutines.EmptyCoroutineContext
  * hard-coded values added to worker contexts. It must not contain a [Job] element (it would violate
  * structured concurrency).
  */
-@OptIn(ExperimentalWorkflow::class)
+@OptIn(ExperimentalWorkflowApi::class)
 internal class WorkflowNode<PropsT, StateT, OutputT : Any, RenderingT>(
   val id: WorkflowId<PropsT, OutputT, RenderingT>,
   workflow: StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>,

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowRunner.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowRunner.kt
@@ -18,7 +18,7 @@ package com.squareup.workflow.internal
 import com.squareup.workflow.RenderingAndSnapshot
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
-import com.squareup.workflow.ExperimentalWorkflow
+import com.squareup.workflow.ExperimentalWorkflowApi
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.diagnostic.IdCounter
 import com.squareup.workflow.diagnostic.WorkflowDiagnosticListener
@@ -32,7 +32,7 @@ import kotlinx.coroutines.flow.produceIn
 import kotlinx.coroutines.selects.select
 import kotlin.coroutines.EmptyCoroutineContext
 
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalWorkflow::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalWorkflowApi::class)
 internal class WorkflowRunner<PropsT, OutputT : Any, RenderingT>(
   scope: CoroutineScope,
   protoWorkflow: Workflow<PropsT, OutputT, RenderingT>,

--- a/workflow-runtime/src/test/java/com/squareup/workflow/diagnostic/DebugSnapshotRecordingListenerTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/diagnostic/DebugSnapshotRecordingListenerTest.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.workflow.diagnostic
 
-import com.squareup.workflow.ExperimentalWorkflow
+import com.squareup.workflow.ExperimentalWorkflowApi
 import com.squareup.workflow.WorkflowAction.Companion.noAction
 import com.squareup.workflow.diagnostic.WorkflowHierarchyDebugSnapshot.ChildWorker
 import com.squareup.workflow.diagnostic.WorkflowHierarchyDebugSnapshot.ChildWorkflow
@@ -24,7 +24,7 @@ import com.squareup.workflow.diagnostic.WorkflowUpdateDebugInfo.Source
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalWorkflow::class)
+@OptIn(ExperimentalWorkflowApi::class)
 class DebugSnapshotRecordingListenerTest {
 
   private var snapshot: WorkflowHierarchyDebugSnapshot? = null

--- a/workflow-tracing/src/main/java/com/squareup/workflow/diagnostic/tracing/TracingDiagnosticListener.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow/diagnostic/tracing/TracingDiagnosticListener.kt
@@ -28,7 +28,7 @@ import com.squareup.tracing.TraceEvent.ObjectCreated
 import com.squareup.tracing.TraceEvent.ObjectDestroyed
 import com.squareup.tracing.TraceEvent.ObjectSnapshot
 import com.squareup.tracing.TraceLogger
-import com.squareup.workflow.ExperimentalWorkflow
+import com.squareup.workflow.ExperimentalWorkflowApi
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.diagnostic.WorkflowDiagnosticListener
 import kotlinx.coroutines.CoroutineScope
@@ -95,7 +95,7 @@ internal fun provideLogger(
  *
  * @constructor The primary constructor is internal so that it can inject [GcDetector] for tests.
  */
-@OptIn(ExperimentalWorkflow::class)
+@OptIn(ExperimentalWorkflowApi::class)
 class TracingDiagnosticListener internal constructor(
   private val memoryStats: MemoryStats,
   private val gcDetectorConstructor: GcDetectorConstructor,


### PR DESCRIPTION
This is more idiomatic when compared to other standard experimental API markers.
