### PR TITLE
Introduce WorkflowInterceptor.

### DIFF
--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -1,8 +1,17 @@
 public final class com/squareup/workflow/LaunchWorkflowKt {
 	public static final fun launchWorkflowIn (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow/Workflow;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow/Snapshot;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public static synthetic fun launchWorkflowIn$default (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow/Workflow;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow/Snapshot;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun renderWorkflowIn (Lcom/squareup/workflow/Workflow;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/flow/StateFlow;Lcom/squareup/workflow/TreeSnapshot;Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/StateFlow;
-	public static synthetic fun renderWorkflowIn$default (Lcom/squareup/workflow/Workflow;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/flow/StateFlow;Lcom/squareup/workflow/TreeSnapshot;Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/flow/StateFlow;
+	public static final fun renderWorkflowIn (Lcom/squareup/workflow/Workflow;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/flow/StateFlow;Lcom/squareup/workflow/TreeSnapshot;Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;Ljava/util/List;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/StateFlow;
+	public static synthetic fun renderWorkflowIn$default (Lcom/squareup/workflow/Workflow;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/flow/StateFlow;Lcom/squareup/workflow/TreeSnapshot;Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;Ljava/util/List;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class com/squareup/workflow/NoopWorkflowInterceptor : com/squareup/workflow/WorkflowInterceptor {
+	public static final field INSTANCE Lcom/squareup/workflow/NoopWorkflowInterceptor;
+	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow/RenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)V
+	public fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow/Snapshot;
 }
 
 public final class com/squareup/workflow/RenderingAndSnapshot {
@@ -18,6 +27,17 @@ public final class com/squareup/workflow/RenderingAndSnapshot {
 	public fun toString ()Ljava/lang/String;
 }
 
+public class com/squareup/workflow/SimpleLoggingWorkflowInterceptor : com/squareup/workflow/WorkflowInterceptor {
+	public fun <init> ()V
+	protected fun logBegin (Ljava/lang/String;)V
+	protected fun logEnd (Ljava/lang/String;)V
+	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow/RenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)V
+	public fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow/Snapshot;
+}
+
 public final class com/squareup/workflow/TreeSnapshot {
 	public static final field Companion Lcom/squareup/workflow/TreeSnapshot$Companion;
 	public fun equals (Ljava/lang/Object;)Z
@@ -29,6 +49,29 @@ public final class com/squareup/workflow/TreeSnapshot$Companion {
 	public final fun forRootOnly (Lcom/squareup/workflow/Snapshot;)Lcom/squareup/workflow/TreeSnapshot;
 	public final fun getNONE ()Lcom/squareup/workflow/TreeSnapshot;
 	public final fun parse (Lokio/ByteString;)Lcom/squareup/workflow/TreeSnapshot;
+}
+
+public abstract interface class com/squareup/workflow/WorkflowInterceptor {
+	public abstract fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public abstract fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public abstract fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow/RenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public abstract fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)V
+	public abstract fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow/Snapshot;
+}
+
+public final class com/squareup/workflow/WorkflowInterceptor$DefaultImpls {
+	public static fun onInitialState (Lcom/squareup/workflow/WorkflowInterceptor;Ljava/lang/Object;Lcom/squareup/workflow/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public static fun onPropsChanged (Lcom/squareup/workflow/WorkflowInterceptor;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public static fun onRender (Lcom/squareup/workflow/WorkflowInterceptor;Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow/RenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public static fun onSessionStarted (Lcom/squareup/workflow/WorkflowInterceptor;Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)V
+	public static fun onSnapshotState (Lcom/squareup/workflow/WorkflowInterceptor;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow/Snapshot;
+}
+
+public abstract interface class com/squareup/workflow/WorkflowInterceptor$WorkflowSession {
+	public abstract fun getIdentifier ()Lcom/squareup/workflow/WorkflowIdentifier;
+	public abstract fun getParent ()Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;
+	public abstract fun getRenderKey ()Ljava/lang/String;
+	public abstract fun getSessionId ()J
 }
 
 public final class com/squareup/workflow/WorkflowSession {

--- a/workflow-runtime/src/main/java/com/squareup/workflow/SimpleLoggingWorkflowInterceptor.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/SimpleLoggingWorkflowInterceptor.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow
+
+import com.squareup.workflow.WorkflowInterceptor.WorkflowSession
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+
+/**
+ * A [WorkflowInterceptor] that just prints all method calls using [println].
+ */
+@OptIn(ExperimentalWorkflowApi::class)
+open class SimpleLoggingWorkflowInterceptor : WorkflowInterceptor {
+  override fun onSessionStarted(
+    workflowScope: CoroutineScope,
+    session: WorkflowSession
+  ) {
+    logBegin("onInstanceStarted($workflowScope, $session)")
+    workflowScope.coroutineContext[Job]!!.invokeOnCompletion {
+      logEnd("onInstanceStarted($session)")
+    }
+  }
+
+  override fun <P, S> onInitialState(
+    props: P,
+    snapshot: Snapshot?,
+    proceed: (P, Snapshot?) -> S,
+    session: WorkflowSession
+  ): S = logMethod("onInitialState", props, snapshot, session) {
+    proceed(props, snapshot)
+  }
+
+  override fun <P, S> onPropsChanged(
+    old: P,
+    new: P,
+    state: S,
+    proceed: (P, P, S) -> S,
+    session: WorkflowSession
+  ): S = logMethod("onPropsChanged", old, new, state, session) {
+    proceed(old, new, state)
+  }
+
+  override fun <P, S, O : Any, R> onRender(
+    props: P,
+    state: S,
+    context: RenderContext<S, O>,
+    proceed: (P, S, RenderContext<S, O>) -> R,
+    session: WorkflowSession
+  ): R = logMethod("onRender", props, state, session) {
+    proceed(props, state, context)
+  }
+
+  override fun <S> onSnapshotState(
+    state: S,
+    proceed: (S) -> Snapshot,
+    session: WorkflowSession
+  ): Snapshot = logMethod("onSnapshotState", state, session) {
+    proceed(state)
+  }
+
+  private inline fun <T> logMethod(
+    name: String,
+    vararg args: Any?,
+    block: () -> T
+  ): T {
+    val text = "$name(${args.joinToString()})"
+    logBegin(text)
+    return block().also {
+      logEnd("$text = $it")
+    }
+  }
+
+  /**
+   * Called with descriptions of every event. Default implementation just calls [kotlin.io.println].
+   */
+  protected open fun logBegin(text: String) {
+    println("START| $text")
+  }
+
+  /**
+   * Called with descriptions of every event. Default implementation just calls [kotlin.io.println].
+   */
+  protected open fun logEnd(text: String) {
+    println("  END| $text")
+  }
+}

--- a/workflow-runtime/src/main/java/com/squareup/workflow/WorkflowInterceptor.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/WorkflowInterceptor.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow
+
+import com.squareup.workflow.WorkflowInterceptor.WorkflowSession
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Provides hooks into the workflow runtime that can be used to instrument or modify the behavior
+ * of workflows.
+ *
+ * This interface's methods mirror the methods of [StatefulWorkflow]. It also has one additional
+ * method, [onSessionStarted], that is notified when a workflow is started. Each method returns the
+ * same thing as the corresponding method on [StatefulWorkflow], and receives the same parameters
+ * as well as two extra parameters:
+ *
+ *  - **`proceed`** – A function that _exactly_ mirrors the corresponding function on
+ *    [StatefulWorkflow], accepting the same parameters and returning the same thing. An interceptor
+ *    can call this function to run the actual workflow, but it may also decide to not call it at
+ *    all, or call it multiple times.
+ *  - **`session`** – A [WorkflowSession] object that can be queried for information about the
+ *    workflow being intercepted.
+ *
+ * All methods have default no-op implementations.
+ *
+ * ## Workflow sessions
+ *
+ * A single workflow may be rendered by different parents at the same time, or the same parent at
+ * different, disjoint times. Each continuous sequence of renderings of a particular workflow type,
+ * with the same key passed to [RenderContext.renderChild], is called an "session" of that
+ * workflow. The workflow's [StatefulWorkflow.initialState] method will be called at the start of
+ * the session, and its state will be maintained by the runtime until the session is finished.
+ * Each session is identified by the [WorkflowSession] object passed into the corresponding method
+ * in a [WorkflowInterceptor].
+ *
+ * In addition to the [WorkflowIdentifier] of the type of the workflow being rendered, this object
+ * also knows the [key][WorkflowSession.renderKey] used to render the workflow and the
+ * [WorkflowSession] of the [parent][WorkflowSession.parent] workflow that is rendering it.
+ *
+ * Each session is also assigned a numerical ID that uniquely identifies the session over the
+ * life of the entire runtime. This value will remain constant as long as the workflow's parent is
+ * rendering it, and then it will never be used again. If this workflow stops being rendered, and
+ * then starts again, the value will be different.
+ */
+@ExperimentalWorkflowApi
+interface WorkflowInterceptor {
+
+  /**
+   * Called when the session is starting, before [onInitialState].
+   *
+   * @param workflowScope The [CoroutineScope] that will be used for any side effects the workflow
+   * runs, as well as the parent for any workflows it renders.
+   */
+  fun onSessionStarted(
+    workflowScope: CoroutineScope,
+    session: WorkflowSession
+  ) = Unit
+
+  /**
+   * Intercepts calls to [StatefulWorkflow.initialState].
+   */
+  fun <P, S> onInitialState(
+    props: P,
+    snapshot: Snapshot?,
+    proceed: (P, Snapshot?) -> S,
+    session: WorkflowSession
+  ): S = proceed(props, snapshot)
+
+  /**
+   * Intercepts calls to [StatefulWorkflow.onPropsChanged].
+   */
+  fun <P, S> onPropsChanged(
+    old: P,
+    new: P,
+    state: S,
+    proceed: (P, P, S) -> S,
+    session: WorkflowSession
+  ): S = proceed(old, new, state)
+
+  /**
+   * Intercepts calls to [StatefulWorkflow.render].
+   */
+  fun <P, S, O : Any, R> onRender(
+    props: P,
+    state: S,
+    context: RenderContext<S, O>,
+    proceed: (P, S, RenderContext<S, O>) -> R,
+    session: WorkflowSession
+  ): R = proceed(props, state, context)
+
+  /**
+   * Intercepts calls to [StatefulWorkflow.snapshotState].
+   */
+  fun <S> onSnapshotState(
+    state: S,
+    proceed: (S) -> Snapshot,
+    session: WorkflowSession
+  ): Snapshot = proceed(state)
+
+  /**
+   * Information about the session of a workflow in the runtime that a [WorkflowInterceptor] method
+   * is intercepting.
+   */
+  @ExperimentalWorkflowApi
+  interface WorkflowSession {
+    /** The [WorkflowIdentifier] that represents the type of this workflow. */
+    val identifier: WorkflowIdentifier
+
+    /**
+     * The string key argument that was passed to [RenderContext.renderChild] to render this
+     * workflow.
+     */
+    val renderKey: String
+
+    /**
+     * A unique value that identifies the currently-running session of this workflow in the
+     * runtime. See the documentation on [WorkflowInterceptor] for more information about what this
+     * value represents.
+     */
+    val sessionId: Long
+
+    /** The parent [WorkflowSession] of this workflow, or null if this is the root workflow. */
+    val parent: WorkflowSession?
+  }
+}
+
+/** A [WorkflowInterceptor] that does not intercept anything. */
+@ExperimentalWorkflowApi
+object NoopWorkflowInterceptor : WorkflowInterceptor
+
+/**
+ * Returns a [StatefulWorkflow] that will intercept all calls to [workflow] via this
+ * [WorkflowInterceptor].
+ */
+@OptIn(ExperimentalWorkflowApi::class)
+internal fun <P, S, O : Any, R> WorkflowInterceptor.intercept(
+  workflow: StatefulWorkflow<P, S, O, R>,
+  workflowSession: WorkflowSession
+): StatefulWorkflow<P, S, O, R> = if (this === NoopWorkflowInterceptor) {
+  workflow
+} else {
+  object : StatefulWorkflow<P, S, O, R>() {
+    override fun initialState(
+      props: P,
+      snapshot: Snapshot?
+    ): S = onInitialState(props, snapshot, workflow::initialState, workflowSession)
+
+    override fun onPropsChanged(
+      old: P,
+      new: P,
+      state: S
+    ): S = onPropsChanged(old, new, state, workflow::onPropsChanged, workflowSession)
+
+    override fun render(
+      props: P,
+      state: S,
+      context: RenderContext<S, O>
+    ): R = onRender(props, state, context, workflow::render, workflowSession)
+
+    override fun snapshotState(state: S): Snapshot =
+      onSnapshotState(state, workflow::snapshotState, workflowSession)
+
+    override fun toString(): String = "InterceptedWorkflow($workflow, $this@intercept)"
+  }
+}

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/ChainedWorkflowInterceptor.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/ChainedWorkflowInterceptor.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.internal
+
+import com.squareup.workflow.ExperimentalWorkflowApi
+import com.squareup.workflow.RenderContext
+import com.squareup.workflow.Snapshot
+import com.squareup.workflow.WorkflowInterceptor
+import com.squareup.workflow.NoopWorkflowInterceptor
+import com.squareup.workflow.WorkflowInterceptor.WorkflowSession
+import kotlinx.coroutines.CoroutineScope
+
+@OptIn(ExperimentalWorkflowApi::class)
+internal fun List<WorkflowInterceptor>.chained(): WorkflowInterceptor =
+  when {
+    isEmpty() -> NoopWorkflowInterceptor
+    size == 1 -> single()
+    else -> ChainedWorkflowInterceptor(this)
+  }
+
+@OptIn(ExperimentalWorkflowApi::class)
+internal class ChainedWorkflowInterceptor(
+  private val interceptors: List<WorkflowInterceptor>
+) : WorkflowInterceptor {
+
+  override fun onSessionStarted(
+    workflowScope: CoroutineScope,
+    session: WorkflowSession
+  ) {
+    interceptors.forEach { it.onSessionStarted(workflowScope, session) }
+  }
+
+  override fun <P, S> onInitialState(
+    props: P,
+    snapshot: Snapshot?,
+    proceed: (P, Snapshot?) -> S,
+    session: WorkflowSession
+  ): S {
+    val chainedProceed = interceptors.foldRight(proceed) { workflowInterceptor, proceedAcc ->
+      { props, snapshot ->
+        workflowInterceptor.onInitialState(props, snapshot, proceedAcc, session)
+      }
+    }
+    return chainedProceed(props, snapshot)
+  }
+
+  override fun <P, S> onPropsChanged(
+    old: P,
+    new: P,
+    state: S,
+    proceed: (P, P, S) -> S,
+    session: WorkflowSession
+  ): S {
+    val chainedProceed = interceptors.foldRight(proceed) { workflowInterceptor, proceedAcc ->
+      { old, new, state ->
+        workflowInterceptor.onPropsChanged(old, new, state, proceedAcc, session)
+      }
+    }
+    return chainedProceed(old, new, state)
+  }
+
+  override fun <P, S, O : Any, R> onRender(
+    props: P,
+    state: S,
+    context: RenderContext<S, O>,
+    proceed: (P, S, RenderContext<S, O>) -> R,
+    session: WorkflowSession
+  ): R {
+    val chainedProceed = interceptors.foldRight(proceed) { workflowInterceptor, proceedAcc ->
+      { props, state, context ->
+        workflowInterceptor.onRender(props, state, context, proceedAcc, session)
+      }
+    }
+    return chainedProceed(props, state, context)
+  }
+
+  override fun <S> onSnapshotState(
+    state: S,
+    proceed: (S) -> Snapshot,
+    session: WorkflowSession
+  ): Snapshot {
+    val chainedProceed = interceptors.foldRight(proceed) { workflowInterceptor, proceedAcc ->
+      { state ->
+        workflowInterceptor.onSnapshotState(state, proceedAcc, session)
+      }
+    }
+    return chainedProceed(state)
+  }
+}

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/IdCounter.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/IdCounter.kt
@@ -1,12 +1,11 @@
-package com.squareup.workflow.diagnostic
+package com.squareup.workflow.internal
 
 /**
- * TODO write documentation
+ * Monotonically-increasing counter that produces longs, used to assign
+ * [com.squareup.workflow.WorkflowInterceptor.WorkflowSession.sessionId].
  */
 internal class IdCounter {
-
   private var nextId = 0L
-
   fun createId(): Long = nextId++
 }
 

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowLoop.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowLoop.kt
@@ -15,11 +15,10 @@
  */
 package com.squareup.workflow.internal
 
+import com.squareup.workflow.ExperimentalWorkflowApi
 import com.squareup.workflow.RenderingAndSnapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.TreeSnapshot
-import com.squareup.workflow.ExperimentalWorkflowApi
-import com.squareup.workflow.diagnostic.IdCounter
 import com.squareup.workflow.diagnostic.WorkflowDiagnosticListener
 import kotlinx.coroutines.channels.consume
 import kotlinx.coroutines.coroutineScope
@@ -82,11 +81,10 @@ internal open class RealWorkflowLoop : WorkflowLoop {
           initialProps = input,
           snapshot = initialSnapshot,
           baseContext = coroutineContext,
-          workerContext = workerContext,
-          parentDiagnosticId = null,
           diagnosticListener = diagnosticListener,
           idCounter = idCounter,
-          initialState = initialState
+          initialState = initialState,
+          workerContext = workerContext
       )
 
       try {

--- a/workflow-runtime/src/test/java/com/squareup/workflow/RecordingWorkflowInterceptor.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/RecordingWorkflowInterceptor.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("SuspiciousCollectionReassignment")
+
+package com.squareup.workflow
+
+/**
+ * Workflow interceptor that records all received events in a list for testing.
+ */
+class RecordingWorkflowInterceptor : SimpleLoggingWorkflowInterceptor() {
+
+  private var events: List<String> = emptyList()
+
+  override fun logBegin(text: String) {
+    events += "BEGIN|$text"
+  }
+
+  override fun logEnd(text: String) {
+    events += "END|$text"
+  }
+
+  fun consumeEvents(): List<String> = events
+      .also { events = emptyList() }
+
+  fun consumeEventNames(): List<String> = consumeEvents().map { it.substringBefore('(') }
+}

--- a/workflow-runtime/src/test/java/com/squareup/workflow/WorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/WorkflowInterceptorTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("OverridingDeprecatedMember")
+
+package com.squareup.workflow
+
+import com.squareup.workflow.WorkflowInterceptor.WorkflowSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.fail
+
+@OptIn(ExperimentalWorkflowApi::class)
+class WorkflowInterceptorTest {
+
+  @Test fun `intercept() returns workflow when Noop`() {
+    val interceptor = NoopWorkflowInterceptor
+    val workflow = Workflow.rendering("hello")
+        .asStatefulWorkflow()
+    val intercepted = interceptor.intercept(workflow, workflow.session)
+    assertSame(workflow, intercepted)
+  }
+
+  @Test fun `intercept() intercepts calls to initialState()`() {
+    val recorder = RecordingWorkflowInterceptor()
+    val intercepted = recorder.intercept(TestWorkflow, TestWorkflow.session)
+
+    val state = intercepted.initialState("props", Snapshot.of("snapshot"))
+
+    assertEquals("props|snapshot", state)
+    assertEquals(listOf("BEGIN|onInitialState", "END|onInitialState"), recorder.consumeEventNames())
+  }
+
+  @Test fun `intercept() intercepts calls to onPropsChanged()`() {
+    val recorder = RecordingWorkflowInterceptor()
+    val intercepted = recorder.intercept(TestWorkflow, TestWorkflow.session)
+
+    val state = intercepted.onPropsChanged("old", "new", "state")
+
+    assertEquals("old|new|state", state)
+    assertEquals(listOf("BEGIN|onPropsChanged", "END|onPropsChanged"), recorder.consumeEventNames())
+  }
+
+  @Test fun `intercept() intercepts calls to render()`() {
+    val recorder = RecordingWorkflowInterceptor()
+    val intercepted = recorder.intercept(TestWorkflow, TestWorkflow.session)
+    val fakeContext = object : RenderContext<String, String> {
+      override val actionSink: Sink<WorkflowAction<String, String>> get() = fail()
+
+      override fun <EventT : Any> onEvent(
+        handler: (EventT) -> WorkflowAction<String, String>
+      ): (EventT) -> Unit = fail()
+
+      override fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> renderChild(
+        child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,
+        props: ChildPropsT,
+        key: String,
+        handler: (ChildOutputT) -> WorkflowAction<String, String>
+      ): ChildRenderingT = fail()
+
+      override fun <T> runningWorker(
+        worker: Worker<T>,
+        key: String,
+        handler: (T) -> WorkflowAction<String, String>
+      ): Unit = fail()
+
+      override fun runningSideEffect(
+        key: String,
+        sideEffect: suspend () -> Unit
+      ): Unit = fail()
+    }
+
+    val rendering = intercepted.render("props", "state", fakeContext)
+
+    assertEquals("props|state", rendering)
+    assertEquals(listOf("BEGIN|onRender", "END|onRender"), recorder.consumeEventNames())
+  }
+
+  @Test fun `intercept() intercepts calls to snapshotState()`() {
+    val recorder = RecordingWorkflowInterceptor()
+    val intercepted = recorder.intercept(TestWorkflow, TestWorkflow.session)
+
+    val snapshot = intercepted.snapshotState("state")
+
+    assertEquals(Snapshot.of("state"), snapshot)
+    assertEquals(
+        listOf("BEGIN|onSnapshotState", "END|onSnapshotState"), recorder.consumeEventNames()
+    )
+  }
+
+  private val Workflow<*, *, *>.session: WorkflowSession
+    get() = object : WorkflowSession {
+      override val identifier: WorkflowIdentifier = this@session.identifier
+      override val renderKey: String = ""
+      override val sessionId: Long = 0
+      override val parent: WorkflowSession? = null
+    }
+
+  private object TestWorkflow : StatefulWorkflow<String, String, String, String>() {
+    override fun initialState(
+      props: String,
+      snapshot: Snapshot?
+    ): String = "$props|${snapshot?.bytes?.parse { it.readUtf8() }}"
+
+    override fun onPropsChanged(
+      old: String,
+      new: String,
+      state: String
+    ): String = "$old|$new|$state"
+
+    override fun render(
+      props: String,
+      state: String,
+      context: RenderContext<String, String>
+    ): String = "$props|$state"
+
+    override fun snapshotState(state: String): Snapshot = Snapshot.of(state)
+  }
+}

--- a/workflow-runtime/src/test/java/com/squareup/workflow/internal/ChainedWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/internal/ChainedWorkflowInterceptorTest.kt
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("UNCHECKED_CAST")
+
+package com.squareup.workflow.internal
+
+import com.squareup.workflow.ExperimentalWorkflowApi
+import com.squareup.workflow.RenderContext
+import com.squareup.workflow.Sink
+import com.squareup.workflow.Snapshot
+import com.squareup.workflow.Worker
+import com.squareup.workflow.Workflow
+import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.WorkflowIdentifier
+import com.squareup.workflow.WorkflowInterceptor
+import com.squareup.workflow.NoopWorkflowInterceptor
+import com.squareup.workflow.WorkflowInterceptor.WorkflowSession
+import com.squareup.workflow.identifier
+import com.squareup.workflow.parse
+import com.squareup.workflow.rendering
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * The chain-ordering tests in this class should use and pass through modified copies of all the
+ * parameters and return value to ensure that all values are being threaded through appropriately.
+ */
+@OptIn(ExperimentalWorkflowApi::class)
+class ChainedWorkflowInterceptorTest {
+
+  @Test fun `chained() returns Noop when list is empty`() {
+    val list = emptyList<WorkflowInterceptor>()
+    val chained = list.chained()
+    assertSame(NoopWorkflowInterceptor, chained)
+  }
+
+  @Test fun `chained() returns single element when list size is 1`() {
+    val interceptor = object : WorkflowInterceptor {}
+    val list = listOf(interceptor)
+    val chained = list.chained()
+    assertSame(interceptor, chained)
+  }
+
+  @Test fun `chained() returns chained element when list size is 2`() {
+    val list = listOf(
+        object : WorkflowInterceptor {},
+        object : WorkflowInterceptor {}
+    )
+    val chained = list.chained()
+    assertTrue(chained is ChainedWorkflowInterceptor)
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test fun `chains calls to onInstanceStarted() in left-to-right order`() {
+    val events = mutableListOf<String>()
+    val interceptor1 = object : WorkflowInterceptor {
+      override fun onSessionStarted(
+        workflowScope: CoroutineScope,
+        session: WorkflowSession
+      ) {
+        events += "started1"
+        workflowScope.coroutineContext[Job]!!.invokeOnCompletion {
+          events += "cancelled1"
+        }
+      }
+    }
+    val interceptor2 = object : WorkflowInterceptor {
+      override fun onSessionStarted(
+        workflowScope: CoroutineScope,
+        session: WorkflowSession
+      ) {
+        events += "started2"
+        workflowScope.coroutineContext[Job]!!.invokeOnCompletion {
+          events += "cancelled2"
+        }
+      }
+    }
+    val chained = listOf(interceptor1, interceptor2).chained()
+    val scope = TestCoroutineScope(Job())
+
+    chained.onSessionStarted(scope, TestSession)
+    scope.advanceUntilIdle()
+    scope.cancel()
+
+    assertEquals(listOf("started1", "started2", "cancelled1", "cancelled2"), events)
+  }
+
+  @Test fun `chains calls to onInitialState() in left-to-right order`() {
+    val interceptor1 = object : WorkflowInterceptor {
+      override fun <P, S> onInitialState(
+        props: P,
+        snapshot: Snapshot?,
+        proceed: (P, Snapshot?) -> S,
+        session: WorkflowSession
+      ): S = ("r1: " +
+          proceed(
+              "props1: $props" as P,
+              Snapshot.of("snap1: ${snapshot.readUtf8()}")
+          )) as S
+    }
+    val interceptor2 = object : WorkflowInterceptor {
+      override fun <P, S> onInitialState(
+        props: P,
+        snapshot: Snapshot?,
+        proceed: (P, Snapshot?) -> S,
+        session: WorkflowSession
+      ): S = ("r2: " +
+          proceed(
+              "props2: $props" as P,
+              Snapshot.of("snap2: ${snapshot.readUtf8()}")
+          )) as S
+    }
+    val chained = listOf(interceptor1, interceptor2).chained()
+    fun initialState(
+      props: String,
+      snapshot: Snapshot?
+    ): String = "($props|${snapshot.readUtf8()})"
+
+    val finalState =
+      chained.onInitialState("props", Snapshot.of("snap"), ::initialState, TestSession)
+
+    assertEquals("r1: r2: (props2: props1: props|snap2: snap1: snap)", finalState)
+  }
+
+  @Test fun `chains calls to onPropsChanged() in left-to-right order`() {
+    val interceptor1 = object : WorkflowInterceptor {
+      override fun <P, S> onPropsChanged(
+        old: P,
+        new: P,
+        state: S,
+        proceed: (P, P, S) -> S,
+        session: WorkflowSession
+      ): S = ("s1: " +
+          proceed(
+              "old1: $old" as P,
+              "new1: $new" as P,
+              "state1: $state" as S
+          )) as S
+    }
+    val interceptor2 = object : WorkflowInterceptor {
+      override fun <P, S> onPropsChanged(
+        old: P,
+        new: P,
+        state: S,
+        proceed: (P, P, S) -> S,
+        session: WorkflowSession
+      ): S = ("s2: " +
+          proceed(
+              "old2: $old" as P,
+              "new2: $new" as P,
+              "state2: $state" as S
+          )) as S
+    }
+    val chained = listOf(interceptor1, interceptor2).chained()
+    fun onPropsChanged(
+      old: String,
+      new: String,
+      state: String
+    ): String = "($old|$new|$state)"
+
+    val finalState = chained.onPropsChanged("old", "new", "state", ::onPropsChanged, TestSession)
+
+    assertEquals("s1: s2: (old2: old1: old|new2: new1: new|state2: state1: state)", finalState)
+  }
+
+  @Test fun `chains calls to onRender() in left-to-right order`() {
+    val interceptor1 = object : WorkflowInterceptor {
+      override fun <P, S, O : Any, R> onRender(
+        props: P,
+        state: S,
+        context: RenderContext<S, O>,
+        proceed: (P, S, RenderContext<S, O>) -> R,
+        session: WorkflowSession
+      ): R = ("r1: " +
+          proceed(
+              "props1: $props" as P,
+              "state1: $state" as S,
+              FakeRenderContext("context1: $context") as RenderContext<S, O>
+          )) as R
+    }
+    val interceptor2 = object : WorkflowInterceptor {
+      override fun <P, S, O : Any, R> onRender(
+        props: P,
+        state: S,
+        context: RenderContext<S, O>,
+        proceed: (P, S, RenderContext<S, O>) -> R,
+        session: WorkflowSession
+      ): R = ("r2: " +
+          proceed(
+              "props2: $props" as P,
+              "state2: $state" as S,
+              FakeRenderContext("context2: $context") as RenderContext<S, O>
+          )) as R
+    }
+    val chained = listOf(interceptor1, interceptor2).chained()
+    fun render(
+      props: String,
+      state: String,
+      context: RenderContext<String, String>
+    ): String = "($props|$state|$context)"
+
+    val finalRendering =
+      chained.onRender("props", "state", FakeRenderContext("context"), ::render, TestSession)
+
+    assertEquals(
+        "r1: r2: (props2: props1: props|state2: state1: state|context2: context1: context)",
+        finalRendering
+    )
+  }
+
+  @Test fun `chains calls to onSnapshotState() in left-to-right order`() {
+    val interceptor1 = object : WorkflowInterceptor {
+      override fun <S> onSnapshotState(
+        state: S,
+        proceed: (S) -> Snapshot,
+        session: WorkflowSession
+      ): Snapshot = Snapshot.of("r1: " + proceed("state1: $state" as S).readUtf8())
+    }
+    val interceptor2 = object : WorkflowInterceptor {
+      override fun <S> onSnapshotState(
+        state: S,
+        proceed: (S) -> Snapshot,
+        session: WorkflowSession
+      ): Snapshot = Snapshot.of("r2: " + proceed("state2: $state" as S).readUtf8())
+    }
+    val chained = listOf(interceptor1, interceptor2).chained()
+    fun snapshotState(state: String): Snapshot = Snapshot.of("($state)")
+
+    val finalSnapshot = chained.onSnapshotState("state", ::snapshotState, TestSession)
+        .readUtf8()
+
+    assertEquals("r1: r2: (state2: state1: state)", finalSnapshot)
+  }
+
+  private fun Snapshot?.readUtf8() = this?.bytes?.parse { it.readUtf8() }
+
+  private class FakeRenderContext(private val name: String) : RenderContext<String, String> {
+    override fun toString(): String = name
+
+    override val actionSink: Sink<WorkflowAction<String, String>>
+      get() = fail()
+
+    override fun <EventT : Any> onEvent(
+      handler: (EventT) -> WorkflowAction<String, String>
+    ): (EventT) -> Unit {
+      fail()
+    }
+
+    override fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> renderChild(
+      child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,
+      props: ChildPropsT,
+      key: String,
+      handler: (ChildOutputT) -> WorkflowAction<String, String>
+    ): ChildRenderingT {
+      fail()
+    }
+
+    override fun <T> runningWorker(
+      worker: Worker<T>,
+      key: String,
+      handler: (T) -> WorkflowAction<String, String>
+    ) {
+      fail()
+    }
+
+    override fun runningSideEffect(
+      key: String,
+      sideEffect: suspend () -> Unit
+    ) {
+      fail()
+    }
+  }
+
+  object TestSession : WorkflowSession {
+    override val identifier: WorkflowIdentifier = Workflow.rendering(Unit).identifier
+    override val renderKey: String = ""
+    override val sessionId: Long = 0
+    override val parent: WorkflowSession? = null
+  }
+}

--- a/workflow-runtime/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
@@ -244,5 +244,5 @@ class SubtreeManagerTest {
     select { tickChildren(this) }
 
   private fun <S, O : Any> subtreeManagerForTest() =
-    SubtreeManager<S, O>(emptyMap(), context, emitActionToParent = { it }, parentDiagnosticId = 0)
+    SubtreeManager<S, O>(emptyMap(), context, emitActionToParent = { it })
 }

--- a/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowRunnerTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowRunnerTest.kt
@@ -15,9 +15,11 @@
  */
 package com.squareup.workflow.internal
 
+import com.squareup.workflow.ExperimentalWorkflowApi
 import com.squareup.workflow.TreeSnapshot
 import com.squareup.workflow.Worker
 import com.squareup.workflow.Workflow
+import com.squareup.workflow.NoopWorkflowInterceptor
 import com.squareup.workflow.action
 import com.squareup.workflow.runningWorker
 import com.squareup.workflow.stateful
@@ -39,7 +41,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalWorkflowApi::class)
 class WorkflowRunnerTest {
 
   private val dispatcher = TestCoroutineDispatcher()
@@ -256,6 +258,8 @@ class WorkflowRunnerTest {
   private fun <P, O : Any, R> WorkflowRunner(
     workflow: Workflow<P, O, R>,
     props: StateFlow<P>
-  ) =
-    WorkflowRunner(scope, workflow, props, TreeSnapshot.NONE, null)
+  ): WorkflowRunner<P, O, R> = WorkflowRunner(
+      scope, workflow, props, snapshot = TreeSnapshot.NONE, interceptor = NoopWorkflowInterceptor,
+      diagnosticListener = null
+  )
 }

--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -9,6 +9,15 @@ public final class com/squareup/workflow/testing/EmittedOutput {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/squareup/workflow/testing/RenderIdempotencyChecker : com/squareup/workflow/WorkflowInterceptor {
+	public static final field INSTANCE Lcom/squareup/workflow/testing/RenderIdempotencyChecker;
+	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow/RenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)V
+	public fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow/Snapshot;
+}
+
 public abstract interface class com/squareup/workflow/testing/RenderTestResult {
 	public abstract fun verifyAction (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun verifyActionResult (Lkotlin/jvm/functions/Function2;)V

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderIdempotencyChecker.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderIdempotencyChecker.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.testing
+
+import com.squareup.workflow.ExperimentalWorkflowApi
+import com.squareup.workflow.RenderContext
+import com.squareup.workflow.Sink
+import com.squareup.workflow.Worker
+import com.squareup.workflow.Workflow
+import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.WorkflowInterceptor
+import com.squareup.workflow.WorkflowInterceptor.WorkflowSession
+import java.util.LinkedList
+
+/**
+ * Intercepts the render pass of the root workflow and runs it twice to ensure that well-written
+ * unit tests catch side effects being incorrectly performed directly in the render method.
+ *
+ * The first render pass is the real one, the second one is a no-op and child workflow renderings
+ * will be played back, in order, to their renderChild calls.
+ */
+@OptIn(ExperimentalWorkflowApi::class)
+object RenderIdempotencyChecker : WorkflowInterceptor {
+  override fun <P, S, O : Any, R> onRender(
+    props: P,
+    state: S,
+    context: RenderContext<S, O>,
+    proceed: (P, S, RenderContext<S, O>) -> R,
+    session: WorkflowSession
+  ): R {
+    val actualContext = RecordingRenderContext(context)
+        .also { recordingContext ->
+          proceed(props, state, recordingContext)
+          recordingContext.startReplaying()
+        }
+    return proceed(props, state, actualContext)
+  }
+}
+
+/**
+ * A [RenderContext] that can record the result of rendering children over a render pass, and then
+ * play them back over a second render pass that doesn't actually perform any actions.
+ */
+private class RecordingRenderContext<StateT, OutputT : Any>(
+  private val delegate: RenderContext<StateT, OutputT>
+) : RenderContext<StateT, OutputT> {
+
+  private var replaying = false
+
+  fun startReplaying() {
+    check(!replaying) { "Expected not to be replaying." }
+    replaying = true
+  }
+
+  override val actionSink: Sink<WorkflowAction<StateT, OutputT>>
+    get() = if (!replaying) {
+      delegate.actionSink
+    } else {
+      object : Sink<WorkflowAction<StateT, OutputT>> {
+        override fun send(value: WorkflowAction<StateT, OutputT>) {
+          // Noop
+        }
+      }
+    }
+
+  @Suppress("OverridingDeprecatedMember", "DEPRECATION")
+  override fun <EventT : Any> onEvent(
+    handler: (EventT) -> WorkflowAction<StateT, OutputT>
+  ): (EventT) -> Unit = if (!replaying) {
+    delegate.onEvent(handler)
+  } else {
+    { /* Noop */ }
+  }
+
+  private val childRenderings = LinkedList<Any?>()
+
+  override fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> renderChild(
+    child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,
+    props: ChildPropsT,
+    key: String,
+    handler: (ChildOutputT) -> WorkflowAction<StateT, OutputT>
+  ): ChildRenderingT = if (!replaying) {
+    delegate.renderChild(child, props, key, handler)
+        .also { childRenderings.addFirst(it) }
+  } else {
+    @Suppress("UNCHECKED_CAST")
+    childRenderings.removeLast() as ChildRenderingT
+  }
+
+  override fun <T> runningWorker(
+    worker: Worker<T>,
+    key: String,
+    handler: (T) -> WorkflowAction<StateT, OutputT>
+  ) {
+    if (!replaying) {
+      delegate.runningWorker(worker, key, handler)
+    }
+    // Else noop.
+  }
+
+  override fun runningSideEffect(
+    key: String,
+    sideEffect: suspend () -> Unit
+  ) {
+    if (!replaying) {
+      delegate.runningSideEffect(key, sideEffect)
+    }
+    // Else noop.
+  }
+}

--- a/workflow-testing/src/test/java/com/squareup/workflow/testing/RenderIdempotencyCheckerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow/testing/RenderIdempotencyCheckerTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.testing
+
+import com.squareup.workflow.Workflow
+import com.squareup.workflow.renderChild
+import com.squareup.workflow.renderWorkflowIn
+import com.squareup.workflow.stateless
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RenderIdempotencyCheckerTest {
+
+  @Test fun `renders tree twice`() {
+    var leafRenders = 0
+    var rootRenders = 0
+    // Use a tree depth of at least two to test that we're not double-rendering every _workflow_.
+    val leafWorkflow = Workflow.stateless<Unit, Nothing, Unit> { leafRenders++ }
+    val rootWorkflow = Workflow.stateless<Unit, Nothing, Unit> {
+      rootRenders++
+      renderChild(leafWorkflow)
+    }
+    val scope = TestCoroutineScope(Job())
+        .apply { pauseDispatcher() }
+
+    renderWorkflowIn(
+        rootWorkflow, scope, MutableStateFlow(Unit), interceptors = listOf(RenderIdempotencyChecker)
+    ) {}
+    assertEquals(2, rootRenders)
+    assertEquals(2, leafRenders)
+  }
+}


### PR DESCRIPTION
See the documentation on the `WorkflowInterceptor` interface for an explanation of what this
type is and how it can be used. It is intended to replace `WorkflowDiagnosticListener`, as
well as the custom double-rendering behavior used to verify render idempotency in testing
infrastructure.

Closes #33.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] I have made corresponding changes to the documentation
