### PR TITLE
Remove non-null upper bound for OutputT.

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -222,7 +222,7 @@ public final class com/squareup/workflow/WorkflowActionKt {
 	public static final fun action (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/WorkflowAction;
 	public static final fun action (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/WorkflowAction;
 	public static synthetic fun action$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/WorkflowAction;
-	public static final fun applyTo (Lcom/squareup/workflow/WorkflowAction;Ljava/lang/Object;)Lkotlin/Pair;
+	public static final fun applyTo (Lcom/squareup/workflow/WorkflowAction;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lkotlin/Pair;
 }
 
 public final class com/squareup/workflow/WorkflowIdentifier {

--- a/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
@@ -51,7 +51,7 @@ import com.squareup.workflow.WorkflowAction.Updater
  *
  * See [renderChild].
  */
-interface RenderContext<StateT, in OutputT : Any> {
+interface RenderContext<StateT, in OutputT> {
 
   /**
    * Accepts a single [WorkflowAction], invokes that action by calling [WorkflowAction.apply]
@@ -94,7 +94,7 @@ interface RenderContext<StateT, in OutputT : Any> {
    * @param key An optional string key that is used to distinguish between workflows of the same
    * type.
    */
-  fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> renderChild(
+  fun <ChildPropsT, ChildOutputT, ChildRenderingT> renderChild(
     child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,
     props: ChildPropsT,
     key: String = "",
@@ -144,7 +144,7 @@ interface RenderContext<StateT, in OutputT : Any> {
  * Convenience alias of [RenderContext.renderChild] for workflows that don't take props.
  */
 /* ktlint-disable parameter-list-wrapping */
-fun <StateT, OutputT : Any, ChildOutputT : Any, ChildRenderingT>
+fun <StateT, OutputT, ChildOutputT, ChildRenderingT>
     RenderContext<StateT, OutputT>.renderChild(
   child: Workflow<Unit, ChildOutputT, ChildRenderingT>,
   key: String = "",
@@ -157,7 +157,7 @@ fun <StateT, OutputT : Any, ChildOutputT : Any, ChildRenderingT>
  * output.
  */
 /* ktlint-disable parameter-list-wrapping */
-fun <PropsT, StateT, OutputT : Any, ChildRenderingT>
+fun <PropsT, StateT, OutputT, ChildRenderingT>
     RenderContext<StateT, OutputT>.renderChild(
   child: Workflow<PropsT, Nothing, ChildRenderingT>,
   props: PropsT,
@@ -170,7 +170,7 @@ fun <PropsT, StateT, OutputT : Any, ChildRenderingT>
  * output.
  */
 /* ktlint-disable parameter-list-wrapping */
-fun <StateT, OutputT : Any, ChildRenderingT>
+fun <StateT, OutputT, ChildRenderingT>
     RenderContext<StateT, OutputT>.renderChild(
   child: Workflow<Unit, Nothing, ChildRenderingT>,
   key: String = ""
@@ -185,7 +185,7 @@ fun <StateT, OutputT : Any, ChildRenderingT>
  *
  * @param key An optional string key that is used to distinguish between identical [Worker]s.
  */
-fun <StateT, OutputT : Any> RenderContext<StateT, OutputT>.runningWorker(
+fun <StateT, OutputT> RenderContext<StateT, OutputT>.runningWorker(
   worker: Worker<Nothing>,
   key: String = ""
 ) {
@@ -199,7 +199,7 @@ fun <StateT, OutputT : Any> RenderContext<StateT, OutputT>.runningWorker(
  * Alternative to [RenderContext.actionSink] that allows externally defined
  * event types to be mapped to anonymous [WorkflowAction]s.
  */
-fun <EventT, StateT, OutputT : Any> RenderContext<StateT, OutputT>.makeEventSink(
+fun <EventT, StateT, OutputT> RenderContext<StateT, OutputT>.makeEventSink(
   update: Updater<StateT, OutputT>.(EventT) -> Unit
 ): Sink<EventT> = actionSink.contraMap { event ->
   action({ "eventSink($event)" }) { update(event) }
@@ -216,7 +216,7 @@ fun <EventT, StateT, OutputT : Any> RenderContext<StateT, OutputT>.makeEventSink
     "Use runningWorker",
     ReplaceWith("runningWorker(worker, key, handler)", "com.squareup.workflow.runningWorker")
 )
-fun <StateT, OutputT : Any, T> RenderContext<StateT, OutputT>.onWorkerOutput(
+fun <StateT, OutputT, T> RenderContext<StateT, OutputT>.onWorkerOutput(
   worker: Worker<T>,
   key: String = "",
   handler: (T) -> WorkflowAction<StateT, OutputT>

--- a/workflow-core/src/main/java/com/squareup/workflow/Sink.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/Sink.kt
@@ -71,7 +71,7 @@ fun <T1, T2> Sink<T1>.contraMap(transform: (T2) -> T1): Sink<T2> {
  * ```
  */
 @ExperimentalWorkflowApi
-suspend fun <T, StateT, OutputT : Any> Flow<T>.collectToSink(
+suspend fun <T, StateT, OutputT> Flow<T>.collectToSink(
   actionSink: Sink<WorkflowAction<StateT, OutputT>>,
   handler: (T) -> WorkflowAction<StateT, OutputT>
 ) {
@@ -93,7 +93,7 @@ suspend fun <T, StateT, OutputT : Any> Flow<T>.collectToSink(
  * This method is intended to be used from [RenderContext.runningSideEffect].
  */
 @ExperimentalWorkflowApi
-suspend fun <StateT, OutputT : Any> Sink<WorkflowAction<StateT, OutputT>>.sendAndAwaitApplication(
+suspend fun <StateT, OutputT> Sink<WorkflowAction<StateT, OutputT>>.sendAndAwaitApplication(
   action: WorkflowAction<StateT, OutputT>
 ) {
   suspendCancellableCoroutine<Unit> { continuation ->

--- a/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
@@ -79,7 +79,7 @@ import com.squareup.workflow.WorkflowAction.Updater
 abstract class StatefulWorkflow<
     in PropsT,
     StateT,
-    out OutputT : Any,
+    out OutputT,
     out RenderingT
     > : Workflow<PropsT, OutputT, RenderingT> {
 
@@ -164,7 +164,7 @@ abstract class StatefulWorkflow<
 /**
  * Returns a stateful [Workflow] implemented via the given functions.
  */
-inline fun <PropsT, StateT, OutputT : Any, RenderingT> Workflow.Companion.stateful(
+inline fun <PropsT, StateT, OutputT, RenderingT> Workflow.Companion.stateful(
   crossinline initialState: (PropsT, Snapshot?) -> StateT,
   crossinline render: RenderContext<StateT, OutputT>.(props: PropsT, state: StateT) -> RenderingT,
   crossinline snapshot: (StateT) -> Snapshot,
@@ -198,7 +198,7 @@ inline fun <PropsT, StateT, OutputT : Any, RenderingT> Workflow.Companion.statef
 /**
  * Returns a stateful [Workflow], with no props, implemented via the given functions.
  */
-inline fun <StateT, OutputT : Any, RenderingT> Workflow.Companion.stateful(
+inline fun <StateT, OutputT, RenderingT> Workflow.Companion.stateful(
   crossinline initialState: (Snapshot?) -> StateT,
   crossinline render: RenderContext<StateT, OutputT>.(state: StateT) -> RenderingT,
   crossinline snapshot: (StateT) -> Snapshot
@@ -213,7 +213,7 @@ inline fun <StateT, OutputT : Any, RenderingT> Workflow.Companion.stateful(
  *
  * This overload does not support snapshotting, but there are other overloads that do.
  */
-inline fun <PropsT, StateT, OutputT : Any, RenderingT> Workflow.Companion.stateful(
+inline fun <PropsT, StateT, OutputT, RenderingT> Workflow.Companion.stateful(
   crossinline initialState: (PropsT) -> StateT,
   crossinline render: RenderContext<StateT, OutputT>.(props: PropsT, state: StateT) -> RenderingT,
   crossinline onPropsChanged: (
@@ -233,7 +233,7 @@ inline fun <PropsT, StateT, OutputT : Any, RenderingT> Workflow.Companion.statef
  *
  * This overload does not support snapshots, but there are others that do.
  */
-inline fun <StateT, OutputT : Any, RenderingT> Workflow.Companion.stateful(
+inline fun <StateT, OutputT, RenderingT> Workflow.Companion.stateful(
   initialState: StateT,
   crossinline render: RenderContext<StateT, OutputT>.(state: StateT) -> RenderingT
 ): StatefulWorkflow<Unit, StateT, OutputT, RenderingT> = stateful(
@@ -249,7 +249,7 @@ inline fun <StateT, OutputT : Any, RenderingT> Workflow.Companion.stateful(
  * @param name A string describing the update for debugging, included in [toString].
  * @param update Function that defines the workflow update.
  */
-fun <PropsT, StateT, OutputT : Any, RenderingT>
+fun <PropsT, StateT, OutputT, RenderingT>
     StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.action(
       name: String = "",
       update: Updater<StateT, OutputT>.() -> Unit
@@ -264,7 +264,7 @@ fun <PropsT, StateT, OutputT : Any, RenderingT>
  * in [toString].
  * @param update Function that defines the workflow update.
  */
-fun <PropsT, StateT, OutputT : Any, RenderingT>
+fun <PropsT, StateT, OutputT, RenderingT>
     StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.action(
       name: () -> String,
       update: Updater<StateT, OutputT>.() -> Unit
@@ -280,7 +280,7 @@ fun <PropsT, StateT, OutputT : Any, RenderingT>
         imports = arrayOf("com.squareup.workflow.action")
     )
 )
-fun <PropsT, StateT, OutputT : Any, RenderingT>
+fun <PropsT, StateT, OutputT, RenderingT>
     StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.workflowAction(
       name: String = "",
       block: Mutator<StateT>.() -> OutputT?
@@ -294,7 +294,7 @@ fun <PropsT, StateT, OutputT : Any, RenderingT>
         imports = arrayOf("com.squareup.workflow.action")
     )
 )
-fun <PropsT, StateT, OutputT : Any, RenderingT>
+fun <PropsT, StateT, OutputT, RenderingT>
     StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.workflowAction(
       name: () -> String,
       block: Mutator<StateT>.() -> OutputT?

--- a/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
@@ -34,7 +34,7 @@ import com.squareup.workflow.WorkflowAction.Updater
  *
  * @see StatefulWorkflow
  */
-abstract class StatelessWorkflow<in PropsT, out OutputT : Any, out RenderingT> :
+abstract class StatelessWorkflow<in PropsT, out OutputT, out RenderingT> :
     Workflow<PropsT, OutputT, RenderingT> {
 
   @Suppress("UNCHECKED_CAST")
@@ -82,7 +82,7 @@ abstract class StatelessWorkflow<in PropsT, out OutputT : Any, out RenderingT> :
  * [props][PropsT] received from its parent, and it may render child workflows that do have
  * their own internal state.
  */
-inline fun <PropsT, OutputT : Any, RenderingT> Workflow.Companion.stateless(
+inline fun <PropsT, OutputT, RenderingT> Workflow.Companion.stateless(
   crossinline render: RenderContext<Nothing, OutputT>.(props: PropsT) -> RenderingT
 ): Workflow<PropsT, OutputT, RenderingT> =
   object : StatelessWorkflow<PropsT, OutputT, RenderingT>() {
@@ -108,7 +108,7 @@ fun <RenderingT> Workflow.Companion.rendering(
  * @param name A string describing the update for debugging, included in [toString].
  * @param update Function that defines the workflow update.
  */
-fun <PropsT, OutputT : Any, RenderingT>
+fun <PropsT, OutputT, RenderingT>
     StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
   name: String = "",
   update: Updater<Nothing, OutputT>.() -> Unit
@@ -123,7 +123,7 @@ fun <PropsT, OutputT : Any, RenderingT>
  * [toString].
  * @param update Function that defines the workflow update.
  */
-fun <PropsT, OutputT : Any, RenderingT>
+fun <PropsT, OutputT, RenderingT>
     StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
   name: () -> String,
   update: Updater<Nothing, OutputT>.() -> Unit

--- a/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -247,7 +247,7 @@ interface Worker<out OutputT> {
      * The returned [Worker] will equate to any other workers created with any of the [Worker]
      * builder functions that have the same output type.
      */
-    inline fun <reified OutputT : Any> fromNullable(
+    inline fun <reified OutputT> fromNullable(
         // This could be crossinline, but there's a coroutines bug that will cause the coroutine
         // to immediately resume on suspension inside block when it is crossinline.
         // See https://youtrack.jetbrains.com/issue/KT-31197.

--- a/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
@@ -104,7 +104,7 @@ package com.squareup.workflow
  * @see StatefulWorkflow
  * @see StatelessWorkflow
  */
-interface Workflow<in PropsT, out OutputT : Any, out RenderingT> {
+interface Workflow<in PropsT, out OutputT, out RenderingT> {
 
   /**
    * Provides a [StatefulWorkflow] view of this workflow. Necessary because [StatefulWorkflow] is
@@ -125,7 +125,7 @@ interface Workflow<in PropsT, out OutputT : Any, out RenderingT> {
  */
 /* ktlint-disable parameter-list-wrapping */
 @OptIn(ExperimentalWorkflowApi::class)
-fun <PropsT, OutputT : Any, FromRenderingT, ToRenderingT>
+fun <PropsT, OutputT, FromRenderingT, ToRenderingT>
     Workflow<PropsT, OutputT, FromRenderingT>.mapRendering(
   transform: (FromRenderingT) -> ToRenderingT
 ): Workflow<PropsT, OutputT, ToRenderingT> =

--- a/workflow-core/src/test/java/com/squareup/workflow/WorkflowActionTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/WorkflowActionTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow
+
+import com.squareup.workflow.WorkflowAction.Updater
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class WorkflowActionTest {
+
+  @Test fun `applyTo works when no output is set`() {
+    val action = object : WorkflowAction<String, String?> {
+      override fun Updater<String, String?>.apply() {
+        nextState = "nextState: $nextState"
+      }
+    }
+    val (nextState, output) = action.applyTo("state", ::OutputHolder)
+    assertEquals("nextState: state", nextState)
+    assertNull(output)
+  }
+
+  @Test fun `applyTo works when null output is set`() {
+    val action = object : WorkflowAction<String, String?> {
+      override fun Updater<String, String?>.apply() {
+        nextState = "nextState: $nextState"
+        setOutput(null)
+      }
+    }
+    val (nextState, output) = action.applyTo("state", ::OutputHolder)
+    assertEquals("nextState: state", nextState)
+    assertNotNull(output)
+    assertNull(output.value)
+  }
+
+  @Test fun `applyTo works when non-null output is set`() {
+    val action = object : WorkflowAction<String, String?> {
+      override fun Updater<String, String?>.apply() {
+        nextState = "nextState: $nextState"
+        setOutput("output")
+      }
+    }
+    val (nextState, output) = action.applyTo("state", ::OutputHolder)
+    assertEquals("nextState: state", nextState)
+    assertNotNull(output)
+    assertEquals("output", output.value)
+  }
+
+  @Test fun `applyTo doens't invoke mapOutput when output is not set`() {
+    val action = object : WorkflowAction<String, String?> {
+      override fun Updater<String, String?>.apply() {
+        nextState = "nextState: $nextState"
+      }
+    }
+    var outputCalls = 0
+    val (nextState, output) = action.applyTo("state") { outputCalls++ }
+    assertEquals("nextState: state", nextState)
+    assertNull(output)
+    assertEquals(0, outputCalls)
+  }
+
+  @Test fun `applyTo only invokes mapOutput once when output is set multiple times`() {
+    val action = object : WorkflowAction<String, String?> {
+      override fun Updater<String, String?>.apply() {
+        setOutput("first output")
+        nextState = "nextState: $nextState"
+        setOutput(null)
+        setOutput("third output")
+      }
+    }
+    val outputs = mutableListOf<String?>()
+    val (nextState, output) = action.applyTo("state") { outputs += it }
+    assertEquals("nextState: state", nextState)
+    assertNotNull(output)
+    assertEquals(listOf<String?>("third output"), outputs)
+  }
+
+  private data class OutputHolder<O>(val value: O)
+}

--- a/workflow-runtime/src/main/java/com/squareup/workflow/RenderWorkflow.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/RenderWorkflow.kt
@@ -117,7 +117,7 @@ import kotlin.coroutines.EmptyCoroutineContext
  * rendering.
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalWorkflowApi::class)
-fun <PropsT, OutputT : Any, RenderingT> renderWorkflowIn(
+fun <PropsT, OutputT, RenderingT> renderWorkflowIn(
   workflow: Workflow<PropsT, OutputT, RenderingT>,
   scope: CoroutineScope,
   props: StateFlow<PropsT>,
@@ -163,19 +163,9 @@ fun <PropsT, OutputT : Any, RenderingT> renderWorkflowIn(
         // After receiving an output, the next render pass must be done before emitting that output,
         // so that the workflow states appear consistent to observers of the outputs and renderings.
         renderingsAndSnapshots.value = runner.nextRendering()
-        output?.let { onOutput(it) }
+        output.withValue { onOutput(it) }
       }
   }
 
   return renderingsAndSnapshots
-}
-
-/**
- * If this is already a [CancellationException], returns it as-is, otherwise wraps it in one with
- * the given message.
- */
-private inline fun Throwable?.toCancellationException(message: () -> String) = when (this) {
-  null -> null
-  is CancellationException -> this
-  else -> CancellationException(message(), this)
 }

--- a/workflow-runtime/src/main/java/com/squareup/workflow/SimpleLoggingWorkflowInterceptor.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/SimpleLoggingWorkflowInterceptor.kt
@@ -53,7 +53,7 @@ open class SimpleLoggingWorkflowInterceptor : WorkflowInterceptor {
     proceed(old, new, state)
   }
 
-  override fun <P, S, O : Any, R> onRender(
+  override fun <P, S, O, R> onRender(
     props: P,
     state: S,
     context: RenderContext<S, O>,

--- a/workflow-runtime/src/main/java/com/squareup/workflow/WorkflowInterceptor.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/WorkflowInterceptor.kt
@@ -93,7 +93,7 @@ interface WorkflowInterceptor {
   /**
    * Intercepts calls to [StatefulWorkflow.render].
    */
-  fun <P, S, O : Any, R> onRender(
+  fun <P, S, O, R> onRender(
     props: P,
     state: S,
     context: RenderContext<S, O>,
@@ -146,7 +146,7 @@ object NoopWorkflowInterceptor : WorkflowInterceptor
  * [WorkflowInterceptor].
  */
 @OptIn(ExperimentalWorkflowApi::class)
-internal fun <P, S, O : Any, R> WorkflowInterceptor.intercept(
+internal fun <P, S, O, R> WorkflowInterceptor.intercept(
   workflow: StatefulWorkflow<P, S, O, R>,
   workflowSession: WorkflowSession
 ): StatefulWorkflow<P, S, O, R> = if (this === NoopWorkflowInterceptor) {

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/ChainedWorkflowInterceptor.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/ChainedWorkflowInterceptor.kt
@@ -72,7 +72,7 @@ internal class ChainedWorkflowInterceptor(
     return chainedProceed(old, new, state)
   }
 
-  override fun <P, S, O : Any, R> onRender(
+  override fun <P, S, O, R> onRender(
     props: P,
     state: S,
     context: RenderContext<S, O>,

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/MaybeOutput.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/MaybeOutput.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.internal
+
+/**
+ * Simple Optional type to hold outputs. Create with either [NONE] or [of].
+ */
+@Suppress("UNCHECKED_CAST")
+internal class MaybeOutput<out O> constructor(private val value: Any?) {
+
+  inline val hasValue: Boolean get() = value !== NO_VALUE
+
+  fun getValueOrThrow(): O {
+    if (value === NO_VALUE) throw NoSuchElementException()
+    return value as O
+  }
+
+  inline fun withValue(block: (O) -> Unit) {
+    if (value !== NO_VALUE) block(value as O)
+  }
+
+  companion object {
+    private val NO_VALUE = Any()
+
+    fun none(): MaybeOutput<Nothing> = MaybeOutput(NO_VALUE)
+    fun <O> of(value: O) = MaybeOutput<O>(value)
+  }
+}

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
@@ -30,15 +30,15 @@ import kotlinx.coroutines.channels.SendChannel
  *
  * Not for general application use.
  */
-class RealRenderContext<StateT, OutputT : Any>(
+class RealRenderContext<StateT, OutputT>(
   private val renderer: Renderer<StateT, OutputT>,
   private val workerRunner: WorkerRunner<StateT, OutputT>,
   private val sideEffectRunner: SideEffectRunner,
   private val eventActionsChannel: SendChannel<WorkflowAction<StateT, OutputT>>
 ) : RenderContext<StateT, OutputT>, Sink<WorkflowAction<StateT, OutputT>> {
 
-  interface Renderer<StateT, OutputT : Any> {
-    fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> render(
+  interface Renderer<StateT, OutputT> {
+    fun <ChildPropsT, ChildOutputT, ChildRenderingT> render(
       child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,
       props: ChildPropsT,
       key: String,
@@ -46,7 +46,7 @@ class RealRenderContext<StateT, OutputT : Any>(
     ): ChildRenderingT
   }
 
-  interface WorkerRunner<StateT, OutputT : Any> {
+  interface WorkerRunner<StateT, OutputT> {
     fun <T> runningWorker(
       worker: Worker<T>,
       key: String,
@@ -93,7 +93,7 @@ class RealRenderContext<StateT, OutputT : Any>(
     eventActionsChannel.offer(value)
   }
 
-  override fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> renderChild(
+  override fun <ChildPropsT, ChildOutputT, ChildRenderingT> renderChild(
     child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,
     props: ChildPropsT,
     key: String,

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkerChildNode.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkerChildNode.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
  * after the worker finishes so that they aren't immediately restarted on the next render pass. This
  * flag indicates that the channel should not be polled on the next tick.
  */
-internal class WorkerChildNode<T, StateT, OutputT : Any>(
+internal class WorkerChildNode<T, StateT, OutputT>(
   val worker: Worker<T>,
   val key: String,
   val channel: ReceiveChannel<ValueOrDone<*>>,
@@ -47,7 +47,7 @@ internal class WorkerChildNode<T, StateT, OutputT : Any>(
   /**
    * Updates the handler function that will be invoked by [acceptUpdate].
    */
-  fun <T2, S, O : Any> setHandler(newHandler: (T2) -> WorkflowAction<S, O>) {
+  fun <T2, S, O> setHandler(newHandler: (T2) -> WorkflowAction<S, O>) {
     @Suppress("UNCHECKED_CAST")
     handler = newHandler as (T) -> WorkflowAction<StateT, OutputT>
   }

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowChildNode.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowChildNode.kt
@@ -29,9 +29,9 @@ import com.squareup.workflow.internal.InlineLinkedList.InlineListNode
 /* ktlint-disable parameter-list-wrapping */
 internal class WorkflowChildNode<
     ChildPropsT,
-    ChildOutputT : Any,
+    ChildOutputT,
     ParentStateT,
-    ParentOutputT : Any
+    ParentOutputT
     >(
   val workflow: Workflow<*, ChildOutputT, *>,
   private var handler: (ChildOutputT) -> WorkflowAction<ParentStateT, ParentOutputT>,
@@ -55,7 +55,7 @@ internal class WorkflowChildNode<
   /**
    * Updates the handler function that will be invoked by [acceptChildOutput].
    */
-  fun <CO, S, O : Any> setHandler(newHandler: (CO) -> WorkflowAction<S, O>) {
+  fun <CO, S, O> setHandler(newHandler: (CO) -> WorkflowAction<S, O>) {
     @Suppress("UNCHECKED_CAST")
     handler = newHandler as (ChildOutputT) -> WorkflowAction<ParentStateT, ParentOutputT>
   }
@@ -78,6 +78,6 @@ internal class WorkflowChildNode<
    * Wrapper around [handler] that allows calling it with erased types.
    */
   @Suppress("UNCHECKED_CAST")
-  fun acceptChildOutput(output: Any): WorkflowAction<ParentStateT, ParentOutputT> =
+  fun acceptChildOutput(output: Any?): WorkflowAction<ParentStateT, ParentOutputT> =
     handler(output as ChildOutputT)
 }

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNodeId.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNodeId.kt
@@ -67,5 +67,5 @@ internal data class WorkflowNodeId(
   }
 }
 
-internal fun <W : Workflow<I, O, R>, I, O : Any, R>
+internal fun <W : Workflow<I, O, R>, I, O, R>
     W.id(key: String = ""): WorkflowNodeId = WorkflowNodeId(this, key)

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowRunner.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowRunner.kt
@@ -32,7 +32,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalWorkflowApi::class)
-internal class WorkflowRunner<PropsT, OutputT : Any, RenderingT>(
+internal class WorkflowRunner<PropsT, OutputT, RenderingT>(
   scope: CoroutineScope,
   protoWorkflow: Workflow<PropsT, OutputT, RenderingT>,
   props: StateFlow<PropsT>,
@@ -83,7 +83,7 @@ internal class WorkflowRunner<PropsT, OutputT : Any, RenderingT>(
 
   // Tick _might_ return an output, but if it returns null, it means the state or a child
   // probably changed, so we should re-render/snapshot and emit again.
-  suspend fun nextOutput(): OutputT? = select {
+  suspend fun nextOutput(): MaybeOutput<OutputT> = select {
     // Stop trying to read from the inputs channel after it's closed.
     if (!propsChannel.isClosedForReceive) {
       // TODO(https://github.com/square/workflow/issues/512) Replace with receiveOrClosed.
@@ -95,7 +95,7 @@ internal class WorkflowRunner<PropsT, OutputT : Any, RenderingT>(
           }
         }
         // Return null to tell the caller to do another render pass, but not emit an output.
-        return@onReceiveOrNull null
+        return@onReceiveOrNull MaybeOutput.none()
       }
     }
 

--- a/workflow-runtime/src/test/java/com/squareup/workflow/RenderWorkflowInTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/RenderWorkflowInTest.kt
@@ -159,6 +159,25 @@ class RenderWorkflowInTest {
     assertEquals(listOf("foo", "bar"), receivedOutputs)
   }
 
+  @Test fun `onOutput is not called when no output emitted`() {
+    val workflow = Workflow.stateless<Int, String, Int> { props -> props }
+    var onOutputCalls = 0
+    val props = MutableStateFlow(0)
+    val renderings = renderWorkflowIn(workflow, scope, props) { onOutputCalls++ }
+    assertEquals(0, renderings.value.rendering)
+    assertEquals(0, onOutputCalls)
+
+    props.value = 1
+    scope.advanceUntilIdle()
+    assertEquals(1, renderings.value.rendering)
+    assertEquals(0, onOutputCalls)
+
+    props.value = 2
+    scope.advanceUntilIdle()
+    assertEquals(2, renderings.value.rendering)
+    assertEquals(0, onOutputCalls)
+  }
+
   /**
    * Since the initial render occurs before launching the coroutine, an exception thrown from it
    * doesn't implicitly cancel the scope. If it did, the reception would be reported twice: once to

--- a/workflow-runtime/src/test/java/com/squareup/workflow/WorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/WorkflowInterceptorTest.kt
@@ -64,7 +64,7 @@ class WorkflowInterceptorTest {
         handler: (EventT) -> WorkflowAction<String, String>
       ): (EventT) -> Unit = fail()
 
-      override fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> renderChild(
+      override fun <ChildPropsT, ChildOutputT, ChildRenderingT> renderChild(
         child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,
         props: ChildPropsT,
         key: String,

--- a/workflow-runtime/src/test/java/com/squareup/workflow/internal/ChainedWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/internal/ChainedWorkflowInterceptorTest.kt
@@ -186,7 +186,7 @@ class ChainedWorkflowInterceptorTest {
 
   @Test fun `chains calls to onRender() in left-to-right order`() {
     val interceptor1 = object : WorkflowInterceptor {
-      override fun <P, S, O : Any, R> onRender(
+      override fun <P, S, O, R> onRender(
         props: P,
         state: S,
         context: RenderContext<S, O>,
@@ -200,7 +200,7 @@ class ChainedWorkflowInterceptorTest {
           )) as R
     }
     val interceptor2 = object : WorkflowInterceptor {
-      override fun <P, S, O : Any, R> onRender(
+      override fun <P, S, O, R> onRender(
         props: P,
         state: S,
         context: RenderContext<S, O>,
@@ -267,7 +267,7 @@ class ChainedWorkflowInterceptorTest {
       fail()
     }
 
-    override fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> renderChild(
+    override fun <ChildPropsT, ChildOutputT, ChildRenderingT> renderChild(
       child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,
       props: ChildPropsT,
       key: String,

--- a/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
@@ -57,7 +57,7 @@ class RealRenderContextTest {
     )
 
     @Suppress("UNCHECKED_CAST")
-    override fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> render(
+    override fun <ChildPropsT, ChildOutputT, ChildRenderingT> render(
       child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,
       props: ChildPropsT,
       key: String,
@@ -105,7 +105,7 @@ class RealRenderContextTest {
   }
 
   private class PoisonRenderer<S, O : Any> : Renderer<S, O> {
-    override fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> render(
+    override fun <ChildPropsT, ChildOutputT, ChildRenderingT> render(
       child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,
       props: ChildPropsT,
       key: String,
@@ -224,9 +224,9 @@ class RealRenderContextTest {
     sink.send("foo")
 
     val update = eventActionsChannel.poll()!!
-    val (state, output) = update.applyTo("state")
+    val (state, output) = update.applyTo("state") { MaybeOutput.of(it) }
     assertEquals("state", state)
-    assertEquals("foo", output)
+    assertEquals("foo", output?.getValueOrThrow())
   }
 
   @Test fun `renderChild works`() {
@@ -242,9 +242,9 @@ class RealRenderContextTest {
     assertEquals("key", key)
 
     val (state, output) = handler.invoke("output")
-        .applyTo("state")
+        .applyTo("state") { MaybeOutput.of(it) }
     assertEquals("state", state)
-    assertEquals("output:output", output)
+    assertEquals("output:output", output?.getValueOrThrow())
   }
 
   @Test fun `all methods throw after freeze`() {

--- a/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowRunnerTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowRunnerTest.kt
@@ -16,10 +16,10 @@
 package com.squareup.workflow.internal
 
 import com.squareup.workflow.ExperimentalWorkflowApi
+import com.squareup.workflow.NoopWorkflowInterceptor
 import com.squareup.workflow.TreeSnapshot
 import com.squareup.workflow.Worker
 import com.squareup.workflow.Workflow
-import com.squareup.workflow.NoopWorkflowInterceptor
 import com.squareup.workflow.action
 import com.squareup.workflow.runningWorker
 import com.squareup.workflow.stateful
@@ -37,6 +37,7 @@ import org.junit.Test
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -100,7 +101,7 @@ class WorkflowRunnerTest {
     dispatcher.resumeDispatcher()
 
     assertTrue(output.isCompleted)
-    assertNull(output.getCompleted())
+    assertFalse(output.getCompleted().hasValue)
     val rendering = runner.nextRendering().rendering
     assertEquals("changed", rendering)
   }
@@ -126,7 +127,7 @@ class WorkflowRunnerTest {
 
     val output = scope.async { runner.nextOutput() }
         .getCompleted()
-    assertEquals("output: work", output)
+    assertEquals("output: work", output.getValueOrThrow())
 
     val updatedRendering = runner.nextRendering().rendering
     assertEquals("state: work", updatedRendering)
@@ -158,13 +159,13 @@ class WorkflowRunnerTest {
     val firstOutput = scope.async { runner.nextOutput() }
         .getCompleted()
     // First update will be props, so no output value.
-    assertNull(firstOutput)
+    assertFalse(firstOutput.hasValue)
     val secondRendering = runner.nextRendering().rendering
     assertEquals("changed props|initial state(initial props)", secondRendering)
 
     val secondOutput = scope.async { runner.nextOutput() }
         .getCompleted()
-    assertEquals("output: work", secondOutput)
+    assertEquals("output: work", secondOutput.getValueOrThrow())
     val thirdRendering = runner.nextRendering().rendering
     assertEquals("changed props|state: work", thirdRendering)
   }

--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -20,7 +20,14 @@ public final class com/squareup/workflow/testing/RenderIdempotencyChecker : com/
 
 public abstract interface class com/squareup/workflow/testing/RenderTestResult {
 	public abstract fun verifyAction (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun verifyActionOutput (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/testing/RenderTestResult;
 	public abstract fun verifyActionResult (Lkotlin/jvm/functions/Function2;)V
+	public abstract fun verifyActionState (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/testing/RenderTestResult;
+	public abstract fun verifyNoActionOutput ()Lcom/squareup/workflow/testing/RenderTestResult;
+}
+
+public final class com/squareup/workflow/testing/RenderTestResult$DefaultImpls {
+	public static fun verifyActionResult (Lcom/squareup/workflow/testing/RenderTestResult;Lkotlin/jvm/functions/Function2;)V
 }
 
 public abstract interface class com/squareup/workflow/testing/RenderTester {

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderIdempotencyChecker.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderIdempotencyChecker.kt
@@ -34,7 +34,7 @@ import java.util.LinkedList
  */
 @OptIn(ExperimentalWorkflowApi::class)
 object RenderIdempotencyChecker : WorkflowInterceptor {
-  override fun <P, S, O : Any, R> onRender(
+  override fun <P, S, O, R> onRender(
     props: P,
     state: S,
     context: RenderContext<S, O>,
@@ -59,7 +59,7 @@ object RenderIdempotencyChecker : WorkflowInterceptor {
  * A [RenderContext] that can record the result of rendering children over a render pass, and then
  * play them back over a second render pass that doesn't actually perform any actions.
  */
-private class RecordingRenderContext<StateT, OutputT : Any>(
+private class RecordingRenderContext<StateT, OutputT>(
   private val delegate: RenderContext<StateT, OutputT>
 ) : RenderContext<StateT, OutputT> {
 
@@ -95,7 +95,7 @@ private class RecordingRenderContext<StateT, OutputT : Any>(
 
   private val childRenderings = LinkedList<Any?>()
 
-  override fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> renderChild(
+  override fun <ChildPropsT, ChildOutputT, ChildRenderingT> renderChild(
     child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,
     props: ChildPropsT,
     key: String,

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTestResult.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTestResult.kt
@@ -24,7 +24,7 @@ import com.squareup.workflow.WorkflowAction
  * @see verifyAction
  * @see verifyActionResult
  */
-interface RenderTestResult<StateT, OutputT : Any> {
+interface RenderTestResult<StateT, OutputT> {
 
   /**
    * Asserts that the render pass handled either a workflow/worker output or a rendering event, and
@@ -38,6 +38,46 @@ interface RenderTestResult<StateT, OutputT : Any> {
   fun verifyAction(block: (WorkflowAction<StateT, OutputT>) -> Unit)
 
   /**
+   * If the render pass handled either a workflow/worker output or a rendering event, "executes" the
+   * action with the state passed to [renderTester], then invokes [block] with the resulting state
+   * value.
+   *
+   * If the workflow didn't process any actions, `newState` will be the initial state.
+   *
+   * Note that by using this method, you're also testing the implementation of your action. This can
+   * be useful if your actions are anonymous. If they are a sealed class or enum, use [verifyAction]
+   * instead and write separate unit tests for your action implementations.
+   */
+  fun verifyActionState(block: (newState: StateT) -> Unit): RenderTestResult<StateT, OutputT>
+
+  /**
+   * If the render pass handled either a workflow/worker output or a rendering event, "executes" the
+   * action with the state passed to [renderTester], verifies that the action set an output, then
+   * invokes [block] with the resulting output value.
+   *
+   * If the workflow didn't process any actions, or no output was set, an [AssertionError] will be
+   * thrown.
+   *
+   * Note that by using this method, you're also testing the implementation of your action. This can
+   * be useful if your actions are anonymous. If they are a sealed class or enum, use [verifyAction]
+   * instead and write separate unit tests for your action implementations.
+   */
+  fun verifyActionOutput(block: (output: OutputT) -> Unit): RenderTestResult<StateT, OutputT>
+
+  /**
+   * If the render pass handled either a workflow/worker output or a rendering event, "executes" the
+   * action with the state passed to [renderTester], and then verifies that the action did not set
+   * any output.
+   *
+   * If the workflow didn't process any actions, this method will do nothing.
+   *
+   * Note that by using this method, you're also testing the implementation of your action. This can
+   * be useful if your actions are anonymous. If they are a sealed class or enum, use [verifyAction]
+   * instead and write separate unit tests for your action implementations.
+   */
+  fun verifyNoActionOutput(): RenderTestResult<StateT, OutputT>
+
+  /**
    * Asserts that the render pass handled either a workflow/worker output or a rendering event,
    * "executes" the action with the state passed to [renderTester], then invokes [block] with the
    * resulting state and output values.
@@ -46,8 +86,25 @@ interface RenderTestResult<StateT, OutputT : Any> {
    * will be null.
    *
    * Note that by using this method, you're also testing the implementation of your action. This can
-   * be useful if your actions anonymous. If they are a sealed class or enum, use [verifyAction]
+   * be useful if your actions are anonymous. If they are a sealed class or enum, use [verifyAction]
    * instead and write separate unit tests for your action implementations.
+   *
+   * Note that if [OutputT] is nullable, this method does not distinguish between an no output and
+   * null output. Use [RenderTestResult.verifyActionOutput] and
+   * [RenderTestResult.verifyNoActionOutput] instead.
    */
-  fun verifyActionResult(block: (newState: StateT, output: OutputT?) -> Unit)
+  @Deprecated("Use verifyActionState and verify(No)ActionOutput")
+  fun verifyActionResult(block: (newState: StateT, output: OutputT?) -> Unit) {
+    var state: StateT? = null
+    var output: OutputT? = null
+    verifyActionState { state = it }
+    try {
+      verifyActionOutput { output = it }
+    } catch (e: AssertionError) {
+      // No output was set, leave as null.
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    block(state as StateT, output)
+  }
 }

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
@@ -28,7 +28,7 @@ import kotlin.reflect.KClass
  * See [RenderTester] for usage documentation.
  */
 @Suppress("UNCHECKED_CAST")
-fun <PropsT, OutputT : Any, RenderingT> Workflow<PropsT, OutputT, RenderingT>.renderTester(
+fun <PropsT, OutputT, RenderingT> Workflow<PropsT, OutputT, RenderingT>.renderTester(
   props: PropsT
 ): RenderTester<PropsT, *, OutputT, RenderingT> {
   val statefulWorkflow = asStatefulWorkflow() as StatefulWorkflow<PropsT, Any?, OutputT, RenderingT>
@@ -44,7 +44,7 @@ fun <PropsT, OutputT : Any, RenderingT> Workflow<PropsT, OutputT, RenderingT>.re
  * See [RenderTester] for usage documentation.
  */
 /* ktlint-disable parameter-list-wrapping */
-fun <PropsT, StateT, OutputT : Any, RenderingT>
+fun <PropsT, StateT, OutputT, RenderingT>
     StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.renderTester(
   props: PropsT,
   initialState: StateT
@@ -190,7 +190,7 @@ fun <PropsT, StateT, OutputT : Any, RenderingT>
  *     rendering.onCancelClicked()
  * ```
  */
-interface RenderTester<PropsT, StateT, OutputT : Any, RenderingT> {
+interface RenderTester<PropsT, StateT, OutputT, RenderingT> {
 
   /**
    * Specifies that this render pass is expected to render a particular child workflow.
@@ -208,7 +208,7 @@ interface RenderTester<PropsT, StateT, OutputT : Any, RenderingT> {
    * rendered. The [WorkflowAction] used to handle this output can be verified using methods on
    * [RenderTestResult].
    */
-  fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> expectWorkflow(
+  fun <ChildPropsT, ChildOutputT, ChildRenderingT> expectWorkflow(
     workflowType: KClass<out Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>>,
     rendering: ChildRenderingT,
     key: String = "",
@@ -273,7 +273,7 @@ interface RenderTester<PropsT, StateT, OutputT : Any, RenderingT> {
  * [RenderTestResult].
  */
 /* ktlint-disable parameter-list-wrapping */
-fun <PropsT, StateT, OutputT : Any, RenderingT>
+fun <PropsT, StateT, OutputT, RenderingT>
     RenderTester<PropsT, StateT, OutputT, RenderingT>.expectWorker(
   doesSameWorkAs: Worker<*>,
   key: String = "",

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTester.kt
@@ -68,7 +68,7 @@ import kotlin.coroutines.EmptyCoroutineContext
  *  - [sendProps]
  *    - Send a new [PropsT] to the root workflow.
  */
-class WorkflowTester<PropsT, OutputT : Any, RenderingT> @TestOnly internal constructor(
+class WorkflowTester<PropsT, OutputT, RenderingT> @TestOnly internal constructor(
   private val props: MutableStateFlow<PropsT>,
   private val renderingsAndSnapshotsFlow: Flow<RenderingAndSnapshot<RenderingT>>,
   private val outputs: ReceiveChannel<OutputT>
@@ -188,7 +188,7 @@ class WorkflowTester<PropsT, OutputT : Any, RenderingT> @TestOnly internal const
  * All workflow-related coroutines are cancelled when the block exits.
  */
 @TestOnly
-fun <T, PropsT, OutputT : Any, RenderingT> Workflow<PropsT, OutputT, RenderingT>.testFromStart(
+fun <T, PropsT, OutputT, RenderingT> Workflow<PropsT, OutputT, RenderingT>.testFromStart(
   props: PropsT,
   testParams: WorkflowTestParams<Nothing> = WorkflowTestParams(),
   context: CoroutineContext = EmptyCoroutineContext,
@@ -201,7 +201,7 @@ fun <T, PropsT, OutputT : Any, RenderingT> Workflow<PropsT, OutputT, RenderingT>
  * All workflow-related coroutines are cancelled when the block exits.
  */
 @TestOnly
-fun <T, OutputT : Any, RenderingT> Workflow<Unit, OutputT, RenderingT>.testFromStart(
+fun <T, OutputT, RenderingT> Workflow<Unit, OutputT, RenderingT>.testFromStart(
   testParams: WorkflowTestParams<Nothing> = WorkflowTestParams(),
   context: CoroutineContext = EmptyCoroutineContext,
   block: WorkflowTester<Unit, OutputT, RenderingT>.() -> T
@@ -216,7 +216,7 @@ fun <T, OutputT : Any, RenderingT> Workflow<Unit, OutputT, RenderingT>.testFromS
  */
 /* ktlint-disable parameter-list-wrapping */
 @TestOnly
-fun <T, PropsT, StateT, OutputT : Any, RenderingT>
+fun <T, PropsT, StateT, OutputT, RenderingT>
     StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.testFromState(
   props: PropsT,
   initialState: StateT,
@@ -234,7 +234,7 @@ fun <T, PropsT, StateT, OutputT : Any, RenderingT>
  */
 /* ktlint-disable parameter-list-wrapping */
 @TestOnly
-fun <StateT, OutputT : Any, RenderingT>
+fun <StateT, OutputT, RenderingT>
     StatefulWorkflow<Unit, StateT, OutputT, RenderingT>.testFromState(
   initialState: StateT,
   context: CoroutineContext = EmptyCoroutineContext,
@@ -250,7 +250,7 @@ fun <StateT, OutputT : Any, RenderingT>
 @OptIn(ExperimentalWorkflowApi::class)
 @TestOnly
 /* ktlint-disable parameter-list-wrapping */
-fun <T, PropsT, StateT, OutputT : Any, RenderingT>
+fun <T, PropsT, StateT, OutputT, RenderingT>
     StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.test(
   props: PropsT,
   testParams: WorkflowTestParams<StateT> = WorkflowTestParams(),

--- a/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
@@ -672,6 +672,7 @@ class RealRenderTesterTest {
     }
   }
 
+  @Suppress("DEPRECATION")
   @Test fun `verifyAction and verifyActionResult pass when no action processed`() {
     val workflow = Workflow.stateless<Unit, Nothing, Sink<TestAction>> {
       actionSink.contraMap { it }
@@ -688,6 +689,7 @@ class RealRenderTesterTest {
     }
   }
 
+  @Suppress("DEPRECATION")
   @Test fun `verifyActionResult works`() {
     class TestAction : WorkflowAction<String, String> {
       override fun Updater<String, String>.apply() {
@@ -709,6 +711,157 @@ class RealRenderTesterTest {
       assertEquals("new state", state)
       assertEquals("output", output)
     }
+  }
+
+  @Test fun `verifyActionState and verifyActionOutput chain`() {
+    class TestAction : WorkflowAction<String, String> {
+      override fun Updater<String, String>.apply() {
+        nextState = "new state"
+        setOutput("output")
+      }
+    }
+
+    val workflow = Workflow.stateful<Unit, String, String, Sink<TestAction>>(
+        initialState = { "initial" },
+        render = { _, _ -> actionSink.contraMap { it } }
+    )
+    val testResult = workflow.renderTester(Unit)
+        .render { sink ->
+          sink.send(TestAction())
+        }
+
+    testResult
+        .verifyActionState { assertEquals("new state", it) }
+        .verifyActionOutput { assertEquals("output", it) }
+  }
+
+  @Test fun `verifyActionState and verifyNoActionOutput chain`() {
+    class TestAction : WorkflowAction<String, String> {
+      override fun Updater<String, String>.apply() {
+        nextState = "new state"
+      }
+    }
+
+    val workflow = Workflow.stateful<Unit, String, String, Sink<TestAction>>(
+        initialState = { "initial" },
+        render = { _, _ -> actionSink.contraMap { it } }
+    )
+    val testResult = workflow.renderTester(Unit)
+        .render { sink ->
+          sink.send(TestAction())
+        }
+
+    testResult
+        .verifyActionState { assertEquals("new state", it) }
+        .verifyNoActionOutput()
+  }
+
+  @Test fun `verifyActionState allows no action`() {
+    val workflow = Workflow.stateless<Unit, Nothing, Sink<TestAction>> {
+      actionSink.contraMap { it }
+    }
+    val testResult = workflow.renderTester(Unit)
+        .render {
+          // Don't send to sink!
+        }
+
+    testResult.verifyAction { assertEquals(noAction(), it) }
+    testResult.verifyActionState { newState ->
+      assertSame(Unit, newState)
+    }
+  }
+
+  @Test fun `verifyActionState handles new state`() {
+    class TestAction : WorkflowAction<String, String> {
+      override fun Updater<String, String>.apply() {
+        nextState = "new state"
+      }
+    }
+
+    val workflow = Workflow.stateful<Unit, String, String, Sink<TestAction>>(
+        initialState = { "initial" },
+        render = { _, _ -> actionSink.contraMap { it } }
+    )
+    val testResult = workflow.renderTester(Unit)
+        .render { sink ->
+          sink.send(TestAction())
+        }
+
+    testResult.verifyActionState { state ->
+      assertEquals("new state", state)
+    }
+  }
+
+  @Test fun `verifyActionOutput allows no action`() {
+    val workflow = Workflow.stateless<Unit, Nothing, Sink<TestAction>> {
+      actionSink.contraMap { it }
+    }
+    val testResult = workflow.renderTester(Unit)
+        .render {
+          // Don't send to sink!
+        }
+
+    testResult.verifyAction { assertEquals(noAction(), it) }
+    val error = assertFailsWith<AssertionError> {
+      testResult.verifyActionOutput {}
+    }
+    assertEquals("Expected action to set an output", error.message)
+  }
+
+  @Test fun `verifyActionOutput handles output`() {
+    class TestAction : WorkflowAction<String, String> {
+      override fun Updater<String, String>.apply() {
+        setOutput("output")
+      }
+    }
+
+    val workflow = Workflow.stateful<Unit, String, String, Sink<TestAction>>(
+        initialState = { "initial" },
+        render = { _, _ -> actionSink.contraMap { it } }
+    )
+    val testResult = workflow.renderTester(Unit)
+        .render { sink ->
+          sink.send(TestAction())
+        }
+
+    testResult.verifyActionOutput { output ->
+      assertEquals("output", output)
+    }
+  }
+
+  @Test fun `verifyNoActionOutput allows no action`() {
+    val workflow = Workflow.stateless<Unit, Nothing, Sink<TestAction>> {
+      actionSink.contraMap { it }
+    }
+    val testResult = workflow.renderTester(Unit)
+        .render {
+          // Don't send to sink!
+        }
+
+    testResult.verifyAction { assertEquals(noAction(), it) }
+    testResult.verifyNoActionOutput()
+  }
+
+  @Test fun `verifyNoActionOutput fails when output is set`() {
+    class TestAction : WorkflowAction<String, String> {
+      override fun Updater<String, String>.apply() {
+        setOutput("output")
+      }
+    }
+
+    val workflow = Workflow.stateful<Unit, String, String, Sink<TestAction>>(
+        initialState = { "initial" },
+        render = { _, _ -> actionSink.contraMap { it } }
+    )
+    val testResult = workflow.renderTester(Unit)
+        .render { sink ->
+          sink.send(TestAction())
+        }
+
+    val error = assertFailsWith<AssertionError> {
+      testResult.verifyNoActionOutput()
+    }
+    assertEquals("Expected no output, but action set output to: output", error.message)
   }
 
   @Test fun `render is executed multiple times`() {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowFragment.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowFragment.kt
@@ -53,7 +53,7 @@ import com.squareup.workflow.ui.WorkflowRunner.Config
  *     }
  *   }
  */
-abstract class WorkflowFragment<PropsT, OutputT : Any> : Fragment() {
+abstract class WorkflowFragment<PropsT, OutputT> : Fragment() {
   private lateinit var _runner: WorkflowRunner<OutputT>
 
   /**

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowRunner.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowRunner.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.flow.StateFlow
  * It is simplest to use [Activity.setContentWorkflow][setContentWorkflow]
  * or subclass [WorkflowFragment] rather than instantiate a [WorkflowRunner] directly.
  */
-interface WorkflowRunner<out OutputT : Any> {
+interface WorkflowRunner<out OutputT> {
 
   /**
    * A stream of the rendering values emitted by the running [Workflow].
@@ -62,7 +62,7 @@ interface WorkflowRunner<out OutputT : Any> {
    * rendered by the runtime.
    */
   @OptIn(ExperimentalCoroutinesApi::class, ExperimentalWorkflowApi::class)
-  class Config<PropsT, OutputT : Any>(
+  class Config<PropsT, OutputT>(
     val workflow: Workflow<PropsT, OutputT, Any>,
     val props: StateFlow<PropsT>,
     val dispatcher: CoroutineDispatcher,
@@ -87,7 +87,7 @@ interface WorkflowRunner<out OutputT : Any> {
      */
     @OptIn(ExperimentalWorkflowApi::class)
     @Suppress("FunctionName")
-    fun <OutputT : Any> Config(
+    fun <OutputT> Config(
       workflow: Workflow<Unit, OutputT, Any>,
       dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate,
       interceptors: List<WorkflowInterceptor> = emptyList()
@@ -103,7 +103,7 @@ interface WorkflowRunner<out OutputT : Any> {
      * @param configure function defining the root workflow and its environment. Called only
      * once per [lifecycle][FragmentActivity.getLifecycle], and always called from the UI thread.
      */
-    fun <PropsT, OutputT : Any> startWorkflow(
+    fun <PropsT, OutputT> startWorkflow(
       activity: FragmentActivity,
       configure: () -> Config<PropsT, OutputT>
     ): WorkflowRunner<OutputT> {
@@ -126,7 +126,7 @@ interface WorkflowRunner<out OutputT : Any> {
      * @param configure function defining the root workflow and its environment. Called only
      * once per [lifecycle][Fragment.getLifecycle], and always called from the UI thread.
      */
-    fun <PropsT, OutputT : Any> startWorkflow(
+    fun <PropsT, OutputT> startWorkflow(
       fragment: Fragment,
       configure: () -> Config<PropsT, OutputT>
     ): WorkflowRunner<OutputT> {
@@ -156,7 +156,7 @@ interface WorkflowRunner<out OutputT : Any> {
  * values, so this is also a good place from which to call [FragmentActivity.finish]. Called
  * only while the activity is active, and always called from the UI thread.
  */
-fun <PropsT, OutputT : Any> FragmentActivity.setContentWorkflow(
+fun <PropsT, OutputT> FragmentActivity.setContentWorkflow(
   viewEnvironment: ViewEnvironment,
   configure: () -> Config<PropsT, OutputT>,
   onResult: (OutputT) -> Unit
@@ -191,7 +191,7 @@ fun <PropsT, OutputT : Any> FragmentActivity.setContentWorkflow(
  * values, so this is also a good place from which to call [FragmentActivity.finish]. Called
  * only while the activity is active, and always called from the UI thread.
  */
-fun <PropsT, OutputT : Any> FragmentActivity.setContentWorkflow(
+fun <PropsT, OutputT> FragmentActivity.setContentWorkflow(
   registry: ViewRegistry,
   configure: () -> Config<PropsT, OutputT>,
   onResult: (OutputT) -> Unit

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowRunnerViewModel.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowRunnerViewModel.kt
@@ -37,7 +37,7 @@ import kotlinx.coroutines.flow.map
 import org.jetbrains.annotations.TestOnly
 
 @OptIn(ExperimentalCoroutinesApi::class)
-internal class WorkflowRunnerViewModel<OutputT : Any>(
+internal class WorkflowRunnerViewModel<OutputT>(
   private val scope: CoroutineScope,
   private val result: Deferred<OutputT>,
   private val renderingsAndSnapshots: StateFlow<RenderingAndSnapshot<Any>>
@@ -64,7 +64,7 @@ internal class WorkflowRunnerViewModel<OutputT : Any>(
     }
   }
 
-  internal class Factory<PropsT, OutputT : Any>(
+  internal class Factory<PropsT, OutputT>(
     private val snapshotSaver: SnapshotSaver,
     private val configure: () -> Config<PropsT, OutputT>
   ) : ViewModelProvider.Factory {


### PR DESCRIPTION
This should be the last unblocker for GUWT workers.

Fixes #59.