### PR TITLE
Move implementation of deprecated RenderContext.onEvent into interface

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -37,6 +37,7 @@ public abstract interface class com/squareup/workflow/RenderContext {
 
 public final class com/squareup/workflow/RenderContext$DefaultImpls {
 	public static fun makeActionSink (Lcom/squareup/workflow/RenderContext;)Lcom/squareup/workflow/Sink;
+	public static fun onEvent (Lcom/squareup/workflow/RenderContext;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
 	public static synthetic fun renderChild$default (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun runningWorker$default (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Worker;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }

--- a/workflow-core/src/main/java/com/squareup/workflow/EventHandler.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/EventHandler.kt
@@ -12,7 +12,7 @@ package com.squareup.workflow
  * test assertions for [Workflow] renderings that include event handlers, since you can compare
  * entire rendering types at once and not field-by-field.
  */
-@Deprecated("obsolete")
+@Deprecated("Use RenderContext.actionSink")
 class EventHandler<in EventT>(private val handler: (EventT) -> Unit) : (EventT) -> Unit {
 
   override fun invoke(event: EventT) = handler(event)

--- a/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
@@ -60,9 +60,15 @@ interface RenderContext<StateT, in OutputT> {
   val actionSink: Sink<WorkflowAction<StateT, OutputT>>
 
   @Deprecated("Use RenderContext.actionSink.")
+  @Suppress("DEPRECATION")
   fun <EventT : Any> onEvent(
     handler: (EventT) -> WorkflowAction<StateT, OutputT>
-  ): (EventT) -> Unit
+  ): (EventT) -> Unit = EventHandler { event ->
+    // Run the handler synchronously, so we only have to emit the resulting action and don't
+    // need the update channel to be generic on each event type.
+    val action = handler(event)
+    actionSink.send(action)
+  }
 
   /**
    * Creates a sink that will accept a single [WorkflowAction] of the given type.

--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -78,8 +78,7 @@ public final class com/squareup/workflow/internal/RealRenderContext : com/square
 	public final fun freeze ()V
 	public fun getActionSink ()Lcom/squareup/workflow/Sink;
 	public fun makeActionSink ()Lcom/squareup/workflow/Sink;
-	public fun onEvent (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/EventHandler;
-	public synthetic fun onEvent (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+	public fun onEvent (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
 	public fun renderChild (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public fun runningWorker (Lcom/squareup/workflow/Worker;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
@@ -17,7 +17,6 @@
 
 package com.squareup.workflow.internal
 
-import com.squareup.workflow.EventHandler
 import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Sink
 import com.squareup.workflow.Worker
@@ -25,11 +24,6 @@ import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
 import kotlinx.coroutines.channels.SendChannel
 
-/**
- * An implementation of [RenderContext] that builds a [Behavior] via [freeze].
- *
- * Not for general application use.
- */
 class RealRenderContext<StateT, OutputT>(
   private val renderer: Renderer<StateT, OutputT>,
   private val workerRunner: WorkerRunner<StateT, OutputT>,
@@ -71,18 +65,6 @@ class RealRenderContext<StateT, OutputT>(
   private var frozen = false
 
   override val actionSink: Sink<WorkflowAction<StateT, OutputT>> get() = this
-
-  @Suppress("OverridingDeprecatedMember")
-  override fun <EventT : Any> onEvent(handler: (EventT) -> WorkflowAction<StateT, OutputT>):
-      EventHandler<EventT> {
-    checkNotFrozen()
-    return EventHandler { event ->
-      // Run the handler synchronously, so we only have to emit the resulting action and don't
-      // need the update channel to be generic on each event type.
-      val action = handler(event)
-      send(action)
-    }
-  }
 
   override fun send(value: WorkflowAction<StateT, OutputT>) {
     if (!frozen) {

--- a/workflow-runtime/src/test/java/com/squareup/workflow/WorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/WorkflowInterceptorTest.kt
@@ -60,10 +60,6 @@ class WorkflowInterceptorTest {
     val fakeContext = object : RenderContext<String, String> {
       override val actionSink: Sink<WorkflowAction<String, String>> get() = fail()
 
-      override fun <EventT : Any> onEvent(
-        handler: (EventT) -> WorkflowAction<String, String>
-      ): (EventT) -> Unit = fail()
-
       override fun <ChildPropsT, ChildOutputT, ChildRenderingT> renderChild(
         child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,
         props: ChildPropsT,

--- a/workflow-runtime/src/test/java/com/squareup/workflow/internal/ChainedWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/internal/ChainedWorkflowInterceptorTest.kt
@@ -18,6 +18,7 @@
 package com.squareup.workflow.internal
 
 import com.squareup.workflow.ExperimentalWorkflowApi
+import com.squareup.workflow.NoopWorkflowInterceptor
 import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Sink
 import com.squareup.workflow.Snapshot
@@ -26,7 +27,6 @@ import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.WorkflowIdentifier
 import com.squareup.workflow.WorkflowInterceptor
-import com.squareup.workflow.NoopWorkflowInterceptor
 import com.squareup.workflow.WorkflowInterceptor.WorkflowSession
 import com.squareup.workflow.identifier
 import com.squareup.workflow.parse
@@ -260,12 +260,6 @@ class ChainedWorkflowInterceptorTest {
 
     override val actionSink: Sink<WorkflowAction<String, String>>
       get() = fail()
-
-    override fun <EventT : Any> onEvent(
-      handler: (EventT) -> WorkflowAction<String, String>
-    ): (EventT) -> Unit {
-      fail()
-    }
 
     override fun <ChildPropsT, ChildOutputT, ChildRenderingT> renderChild(
       child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,

--- a/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
@@ -137,7 +137,7 @@ class RealRenderContextTest {
     val expectedUpdate = noAction<String, String>()
 
     @Suppress("DEPRECATION")
-    val handler = context.onEvent<String> { expectedUpdate }
+    val handler = context.onEvent { _: String -> expectedUpdate }
     assertTrue(eventActionsChannel.isEmpty)
 
     context.freeze()
@@ -156,7 +156,7 @@ class RealRenderContextTest {
     }
 
     @Suppress("DEPRECATION")
-    val handler = context.onEvent<String> { expectedUpdate(it) }
+    val handler = context.onEvent { it: String -> expectedUpdate(it) }
     context.freeze()
     handler("one")
 
@@ -251,8 +251,6 @@ class RealRenderContextTest {
     val context = createTestContext()
     context.freeze()
 
-    @Suppress("DEPRECATION")
-    assertFailsWith<IllegalStateException> { context.onEvent<Unit> { fail() } }
     val child = Workflow.stateless<Unit, Nothing, Unit> { fail() }
     assertFailsWith<IllegalStateException> { context.renderChild(child) }
     val worker = Worker.from { Unit }

--- a/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowNodeTest.kt
@@ -274,35 +274,6 @@ class WorkflowNodeTest {
     sink.send(emitOutput("event2"))
   }
 
-  @Test fun `onEvent allows subsequent events on same rendering`() {
-    lateinit var sink: (WorkflowAction<String, String>) -> Unit
-    val workflow = object : StringWorkflow() {
-      override fun initialState(
-        props: String,
-        snapshot: Snapshot?
-      ): String {
-        assertNull(snapshot)
-        return props
-      }
-
-      override fun render(
-        props: String,
-        state: String,
-        context: RenderContext<String, String>
-      ): String {
-        sink = context.onEvent { it }
-        return ""
-      }
-    }
-    val node = WorkflowNode(workflow.id(), workflow, "", TreeSnapshot.NONE, context)
-
-    node.render(workflow, "")
-    sink(emitOutput("event"))
-
-    // Should not throw.
-    sink(emitOutput("event2"))
-  }
-
   @Test fun `worker gets value`() {
     val channel = Channel<String>(capacity = 1)
     var update: String? = null

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/RealRenderTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/RealRenderTester.kt
@@ -189,11 +189,6 @@ internal class RealRenderTester<PropsT, StateT, OutputT, RenderingT>(
     processedAction = value
   }
 
-  @Suppress("OverridingDeprecatedMember")
-  override fun <EventT : Any> onEvent(
-    handler: (EventT) -> WorkflowAction<StateT, OutputT>
-  ): (EventT) -> Unit = { event -> send(handler(event)) }
-
   override fun verifyAction(block: (WorkflowAction<StateT, OutputT>) -> Unit) {
     val action = processedAction ?: noAction()
     block(action)

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderIdempotencyChecker.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderIdempotencyChecker.kt
@@ -84,15 +84,6 @@ private class RecordingRenderContext<StateT, OutputT>(
       }
     }
 
-  @Suppress("OverridingDeprecatedMember", "DEPRECATION")
-  override fun <EventT : Any> onEvent(
-    handler: (EventT) -> WorkflowAction<StateT, OutputT>
-  ): (EventT) -> Unit = if (!replaying) {
-    delegate.onEvent(handler)
-  } else {
-    { /* Noop */ }
-  }
-
   private val childRenderings = LinkedList<Any?>()
 
   override fun <ChildPropsT, ChildOutputT, ChildRenderingT> renderChild(


### PR DESCRIPTION
This means concrete implementations override this interface, e.g. for `WorkflowInterceptor`, don't need to implement it every time.

Fixes #17.


## Checklist

- [x] Unit Tests
- [x] I have made corresponding changes to the documentation
