### PR TITLE
Emit output before next render pass.

### DIFF
--- a/workflow-runtime/src/main/java/com/squareup/workflow/RenderWorkflow.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/RenderWorkflow.kt
@@ -158,12 +158,10 @@ fun <PropsT, OutputT, RenderingT> renderWorkflowIn(
         // It might look weird to start by consuming the output before getting the rendering below,
         // but remember the first render pass already occurred above, before this coroutine was even
         // launched.
-        val output = runner.nextOutput()
+        runner.nextOutput()
+            ?.let { onOutput(it.value) }
 
-        // After receiving an output, the next render pass must be done before emitting that output,
-        // so that the workflow states appear consistent to observers of the outputs and renderings.
         renderingsAndSnapshots.value = runner.nextRendering()
-        output?.let { onOutput(it.value) }
       }
   }
 

--- a/workflow-runtime/src/test/java/com/squareup/workflow/RenderWorkflowInTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/RenderWorkflowInTest.kt
@@ -391,8 +391,8 @@ class RenderWorkflowInTest {
     assertEquals(
         listOf(
             "rendering({no output})",
-            "rendering(output)",
-            "output(output)"
+            "output(output)",
+            "rendering(output)"
         ),
         events
     )

--- a/workflow-runtime/src/test/java/com/squareup/workflow/RenderWorkflowInTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow/RenderWorkflowInTest.kt
@@ -26,6 +26,8 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -361,6 +363,39 @@ class RenderWorkflowInTest {
     scope.resumeDispatcher()
     scope.advanceUntilIdle()
     assertFalse(scope.isActive)
+  }
+
+  @Test fun `output is emitted before next render pass`() {
+    val outputTrigger = CompletableDeferred<String>()
+    // A workflow whose state and rendering is the last output that it emitted.
+    val workflow = Workflow.stateful<Unit, String, String, String>(
+        initialState = { "{no output}" },
+        render = { _, state ->
+          runningWorker(Worker.from { outputTrigger.await() }) { output ->
+            action {
+              setOutput(output)
+              nextState = output
+            }
+          }
+          return@stateful state
+        }
+    )
+    val scope = TestCoroutineScope()
+    val events = mutableListOf<String>()
+    renderWorkflowIn(workflow, scope, MutableStateFlow(Unit)) { events += "output($it)" }
+        .onEach { events += "rendering(${it.rendering})" }
+        .launchIn(scope)
+    assertEquals(listOf("rendering({no output})"), events)
+
+    outputTrigger.complete("output")
+    assertEquals(
+        listOf(
+            "rendering({no output})",
+            "rendering(output)",
+            "output(output)"
+        ),
+        events
+    )
   }
 
   private class ExpectedException : RuntimeException()


### PR DESCRIPTION


Two commits:
1. Add a passing test for existing behavior.
2. Change behavior and test.

Fixes #54.


## Checklist

- [x] Unit Tests
- [x] I have made corresponding changes to the documentation
