### PR TITLE
Remove unnecessary data classes from public, non-experimental APIs.

### DIFF
--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -76,15 +76,8 @@ public final class com/squareup/workflow/testing/WorkflowTestParams {
 	public fun <init> ()V
 	public fun <init> (Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode;Z)V
 	public synthetic fun <init> (Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode;
-	public final fun component2 ()Z
-	public final fun copy (Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode;Z)Lcom/squareup/workflow/testing/WorkflowTestParams;
-	public static synthetic fun copy$default (Lcom/squareup/workflow/testing/WorkflowTestParams;Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode;ZILjava/lang/Object;)Lcom/squareup/workflow/testing/WorkflowTestParams;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCheckRenderIdempotence ()Z
 	public final fun getStartFrom ()Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public abstract class com/squareup/workflow/testing/WorkflowTestParams$StartMode {
@@ -96,35 +89,17 @@ public final class com/squareup/workflow/testing/WorkflowTestParams$StartMode$St
 
 public final class com/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromCompleteSnapshot : com/squareup/workflow/testing/WorkflowTestParams$StartMode {
 	public fun <init> (Lcom/squareup/workflow/TreeSnapshot;)V
-	public final fun component1 ()Lcom/squareup/workflow/TreeSnapshot;
-	public final fun copy (Lcom/squareup/workflow/TreeSnapshot;)Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromCompleteSnapshot;
-	public static synthetic fun copy$default (Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromCompleteSnapshot;Lcom/squareup/workflow/TreeSnapshot;ILjava/lang/Object;)Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromCompleteSnapshot;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getSnapshot ()Lcom/squareup/workflow/TreeSnapshot;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromState : com/squareup/workflow/testing/WorkflowTestParams$StartMode {
 	public fun <init> (Ljava/lang/Object;)V
-	public final fun component1 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/Object;)Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromState;
-	public static synthetic fun copy$default (Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromState;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromState;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getState ()Ljava/lang/Object;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromWorkflowSnapshot : com/squareup/workflow/testing/WorkflowTestParams$StartMode {
 	public fun <init> (Lcom/squareup/workflow/Snapshot;)V
-	public final fun component1 ()Lcom/squareup/workflow/Snapshot;
-	public final fun copy (Lcom/squareup/workflow/Snapshot;)Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromWorkflowSnapshot;
-	public static synthetic fun copy$default (Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromWorkflowSnapshot;Lcom/squareup/workflow/Snapshot;ILjava/lang/Object;)Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromWorkflowSnapshot;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getSnapshot ()Lcom/squareup/workflow/Snapshot;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/squareup/workflow/testing/WorkflowTester {

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTestParams.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTestParams.kt
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.TestOnly
  * deal with the extra passes, you can temporarily set it to false.
  */
 @TestOnly
-data class WorkflowTestParams<out StateT>(
+class WorkflowTestParams<out StateT>(
   val startFrom: StartMode<StateT> = StartFresh,
   val checkRenderIdempotence: Boolean = true
 ) {
@@ -71,7 +71,7 @@ data class WorkflowTestParams<out StateT>(
      * [snapshotState][com.squareup.workflow.StatefulWorkflow.snapshotState]. To test with a
      * complete snapshot of the entire workflow tree, use [StartFromCompleteSnapshot].
      */
-    data class StartFromWorkflowSnapshot(val snapshot: Snapshot) : StartMode<Nothing>()
+    class StartFromWorkflowSnapshot(val snapshot: Snapshot) : StartMode<Nothing>()
 
     /**
      * Starts the workflow from its initial state (as specified by
@@ -86,12 +86,12 @@ data class WorkflowTestParams<out StateT>(
      * [snapshotState][com.squareup.workflow.StatefulWorkflow.snapshotState], use
      * [StartFromWorkflowSnapshot].
      */
-    data class StartFromCompleteSnapshot(val snapshot: TreeSnapshot) : StartMode<Nothing>()
+    class StartFromCompleteSnapshot(val snapshot: TreeSnapshot) : StartMode<Nothing>()
 
     /**
      * Starts the workflow from an exact state. Only applies to
      * [StatefulWorkflow][com.squareup.workflow.StatelessWorkflow]s.
      */
-    data class StartFromState<StateT>(val state: StateT) : StartMode<StateT>()
+    class StartFromState<StateT>(val state: StateT) : StartMode<StateT>()
   }
 }


### PR DESCRIPTION
The only such data classes were `WorkflowTestParams` and `RenderingAndSnapshot`.
The former has no need to be a data class, as it's just passed as configuration
to the test function, and the latter is effectively just an alias for `Pair` and
the shape is fundamental to the workflow runtime design so it won't change.

There are still some data classes in the UI modules, but #55 will mark all those
as `ExperimentalWorkflowApi` before releasing 1.0.0.

Fixes #57.

