### PR TITLE
Improve naming of testing entry methods and types.

### DIFF
--- a/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/RecorderWorkflowTest.kt
+++ b/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/RecorderWorkflowTest.kt
@@ -19,7 +19,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.sample.timemachine.RecorderWorkflow.RecorderProps.PlaybackAt
 import com.squareup.sample.timemachine.RecorderWorkflow.RecorderProps.RecordValue
 import com.squareup.sample.timemachine.RecorderWorkflow.Recording
-import com.squareup.workflow.testing.renderTester
+import com.squareup.workflow.testing.testRender
 import org.junit.Test
 import kotlin.time.ExperimentalTime
 import kotlin.time.TestTimeSource
@@ -72,7 +72,7 @@ class RecorderWorkflowTest {
     val startTime = clock.markNow()
 
     workflow
-        .renderTester(
+        .testRender(
             props = RecordValue("bar"),
             initialState = Recording(
                 startTime = startTime,
@@ -90,7 +90,7 @@ class RecorderWorkflowTest {
     val startTime = clock.markNow()
 
     workflow
-        .renderTester(
+        .testRender(
             props = PlaybackAt(10.milliseconds),
             initialState = Recording(
                 startTime = startTime,

--- a/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
+++ b/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
@@ -23,7 +23,7 @@ import com.squareup.workflow.Sink
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.makeEventSink
 import com.squareup.workflow.stateful
-import com.squareup.workflow.testing.testFromStart
+import com.squareup.workflow.testing.launchForTestingFromStartWith
 import org.junit.Test
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
@@ -49,7 +49,7 @@ class TimeMachineWorkflowTest {
     val clock = TestTimeSource()
     val tmWorkflow = TimeMachineWorkflow(delegateWorkflow, clock)
 
-    tmWorkflow.testFromStart(Recording(Unit) as TimeMachineProps<Unit>) {
+    tmWorkflow.launchForTestingFromStartWith(Recording(Unit) as TimeMachineProps<Unit>) {
       // Record some renderings.
       awaitNextRendering().let { rendering ->
         assertThat(rendering.value.state).isEqualTo("initial")

--- a/samples/tictactoe/common/src/test/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflowTest.kt
+++ b/samples/tictactoe/common/src/test/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflowTest.kt
@@ -21,8 +21,8 @@ import com.squareup.sample.gameworkflow.Ending.Quitted
 import com.squareup.sample.gameworkflow.Ending.Victory
 import com.squareup.sample.gameworkflow.Player.O
 import com.squareup.sample.gameworkflow.Player.X
-import com.squareup.workflow.testing.WorkflowTester
-import com.squareup.workflow.testing.testFromStart
+import com.squareup.workflow.testing.WorkflowTestRuntime
+import com.squareup.workflow.testing.launchForTestingFromStartWith
 import org.junit.Test
 
 class TakeTurnsWorkflowTest {
@@ -35,7 +35,7 @@ class TakeTurnsWorkflowTest {
   }
 
   @Test fun startsGameWithGivenNames() {
-    RealTakeTurnsWorkflow().testFromStart(
+    RealTakeTurnsWorkflow().launchForTestingFromStartWith(
         TakeTurnsProps.newGame(PlayerInfo("higgledy", "piggledy"))
     ) {
       val (x, o) = awaitNextRendering().playerInfo
@@ -48,7 +48,7 @@ class TakeTurnsWorkflowTest {
   }
 
   @Test fun xWins() {
-    RealTakeTurnsWorkflow().testFromStart(
+    RealTakeTurnsWorkflow().launchForTestingFromStartWith(
         TakeTurnsProps.newGame(PlayerInfo("higgledy", "piggledy"))
     ) {
       takeSquare(0, 0)
@@ -71,7 +71,7 @@ class TakeTurnsWorkflowTest {
   }
 
   @Test fun draw() {
-    RealTakeTurnsWorkflow().testFromStart(
+    RealTakeTurnsWorkflow().launchForTestingFromStartWith(
         TakeTurnsProps.newGame(PlayerInfo("higgledy", "piggledy"))
     ) {
       takeSquare(0, 0) // X - -
@@ -102,7 +102,7 @@ class TakeTurnsWorkflowTest {
   @Test fun quiteAndResume() {
     var output: CompletedGame? = null
 
-    RealTakeTurnsWorkflow().testFromStart(
+    RealTakeTurnsWorkflow().launchForTestingFromStartWith(
         TakeTurnsProps.newGame(PlayerInfo("higgledy", "piggledy"))
     ) {
       awaitNextRendering().onQuit()
@@ -111,7 +111,7 @@ class TakeTurnsWorkflowTest {
 
     assertThat(output!!.ending).isSameInstanceAs(Quitted)
 
-    RealTakeTurnsWorkflow().testFromStart(
+    RealTakeTurnsWorkflow().launchForTestingFromStartWith(
         TakeTurnsProps.resumeGame(
             PlayerInfo("higgledy", "piggledy"),
             output!!.lastTurn
@@ -122,6 +122,6 @@ class TakeTurnsWorkflowTest {
   }
 }
 
-private fun WorkflowTester<*, *, GamePlayScreen>.takeSquare(row: Int, col: Int) {
+private fun WorkflowTestRuntime<*, *, GamePlayScreen>.takeSquare(row: Int, col: Int) {
   awaitNextRendering().onClick(row, col)
 }

--- a/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
+++ b/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
@@ -12,7 +12,7 @@ import com.squareup.workflow.Workflow
 import com.squareup.workflow.action
 import com.squareup.workflow.rendering
 import com.squareup.workflow.stateless
-import com.squareup.workflow.testing.testFromStart
+import com.squareup.workflow.testing.launchForTestingFromStartWith
 import com.squareup.workflow.ui.backstack.BackStackScreen
 import org.junit.Test
 
@@ -22,7 +22,7 @@ import org.junit.Test
  */
 class MainWorkflowTest {
   @Test fun `starts in auth over empty game`() {
-    MainWorkflow(authWorkflow(), runGameWorkflow()).testFromStart {
+    MainWorkflow(authWorkflow(), runGameWorkflow()).launchForTestingFromStartWith {
       awaitNextRendering()
           .let { screen ->
             assertThat(screen.panels).hasSize(1)
@@ -42,7 +42,7 @@ class MainWorkflowTest {
       authScreen()
     }
 
-    MainWorkflow(authWorkflow, runGameWorkflow()).testFromStart {
+    MainWorkflow(authWorkflow, runGameWorkflow()).launchForTestingFromStartWith {
       awaitNextRendering()
           .let { screen ->
             assertThat(screen.panels).isEmpty()

--- a/workflow-rx2/src/test/java/com/squareup/workflow/rx2/PublisherWorkerTest.kt
+++ b/workflow-rx2/src/test/java/com/squareup/workflow/rx2/PublisherWorkerTest.kt
@@ -19,7 +19,7 @@ import com.squareup.workflow.Worker
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.action
 import com.squareup.workflow.stateless
-import com.squareup.workflow.testing.testFromStart
+import com.squareup.workflow.testing.launchForTestingFromStartWith
 import io.reactivex.BackpressureStrategy.BUFFER
 import io.reactivex.subjects.PublishSubject
 import org.reactivestreams.Publisher
@@ -41,7 +41,7 @@ class PublisherWorkerTest {
       runningWorker(worker) { action(it) }
     }
 
-    workflow.testFromStart {
+    workflow.launchForTestingFromStartWith {
       assertFalse(hasOutput)
 
       subject.onNext("one")

--- a/workflow-rx2/src/test/java/com/squareup/workflow/rx2/RxWorkersTest.kt
+++ b/workflow-rx2/src/test/java/com/squareup/workflow/rx2/RxWorkersTest.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.workflow.rx2
 
-import com.squareup.workflow.testing.test
+import com.squareup.workflow.testing.launchForTestingWith
 import io.reactivex.BackpressureStrategy.MISSING
 import io.reactivex.Flowable
 import io.reactivex.Maybe
@@ -40,7 +40,7 @@ class RxWorkersTest {
     // Should support out-projected parameters.
     val worker = (subject as Observable<out String?>).asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onNext("foo")
       assertEquals("foo", nextOutput())
 
@@ -53,7 +53,7 @@ class RxWorkersTest {
     val subject = PublishSubject.create<String>()
     val worker = subject.asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onComplete()
       assertFinished()
     }
@@ -63,7 +63,7 @@ class RxWorkersTest {
     val subject = PublishSubject.create<String>()
     val worker = subject.asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onNext("foo")
       assertEquals("foo", nextOutput())
 
@@ -76,7 +76,7 @@ class RxWorkersTest {
     val subject = PublishSubject.create<String>()
     val worker = subject.asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onError(ExpectedException())
       assertTrue(getException() is ExpectedException)
     }
@@ -90,7 +90,7 @@ class RxWorkersTest {
 
     assertEquals(0, subscriptions)
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals(1, subscriptions)
     }
   }
@@ -103,7 +103,7 @@ class RxWorkersTest {
 
     assertEquals(0, disposals)
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals(0, disposals)
       cancelWorker()
       assertEquals(1, disposals)
@@ -119,7 +119,7 @@ class RxWorkersTest {
     val worker = (subject.toFlowable(MISSING) as Flowable<out String?>)
         .asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onNext("foo")
       assertEquals("foo", nextOutput())
 
@@ -133,7 +133,7 @@ class RxWorkersTest {
     val worker = subject.toFlowable(MISSING)
         .asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onComplete()
       assertFinished()
     }
@@ -144,7 +144,7 @@ class RxWorkersTest {
     val worker = subject.toFlowable(MISSING)
         .asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onNext("foo")
       assertEquals("foo", nextOutput())
 
@@ -158,7 +158,7 @@ class RxWorkersTest {
     val worker = subject.toFlowable(MISSING)
         .asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onError(ExpectedException())
       assertTrue(getException() is ExpectedException)
     }
@@ -173,7 +173,7 @@ class RxWorkersTest {
 
     assertEquals(0, subscriptions)
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals(1, subscriptions)
     }
   }
@@ -187,7 +187,7 @@ class RxWorkersTest {
 
     assertEquals(0, cancels)
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals(0, cancels)
       cancelWorker()
       assertEquals(1, cancels)
@@ -202,7 +202,7 @@ class RxWorkersTest {
     val subject = MaybeSubject.create<String>()
     val worker = (subject as Maybe<out String?>).asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onSuccess("foo")
       assertEquals("foo", nextOutput())
       assertFinished()
@@ -213,7 +213,7 @@ class RxWorkersTest {
     val subject = MaybeSubject.create<String>()
     val worker = subject.asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onComplete()
       assertFinished()
     }
@@ -223,7 +223,7 @@ class RxWorkersTest {
     val subject = MaybeSubject.create<String>()
     val worker = subject.asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onError(ExpectedException())
       assertTrue(getException() is ExpectedException)
     }
@@ -237,7 +237,7 @@ class RxWorkersTest {
 
     assertEquals(0, subscriptions)
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals(1, subscriptions)
     }
   }
@@ -250,7 +250,7 @@ class RxWorkersTest {
 
     assertEquals(0, cancels)
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals(0, cancels)
       cancelWorker()
       assertEquals(1, cancels)
@@ -265,7 +265,7 @@ class RxWorkersTest {
     val subject = SingleSubject.create<String>()
     val worker = (subject as Single<out String?>).asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onSuccess("foo")
       assertEquals("foo", nextOutput())
       assertFinished()
@@ -276,7 +276,7 @@ class RxWorkersTest {
     val subject = SingleSubject.create<String>()
     val worker = subject.asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onError(ExpectedException())
       assertTrue(getException() is ExpectedException)
     }
@@ -290,7 +290,7 @@ class RxWorkersTest {
 
     assertEquals(0, subscriptions)
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals(1, subscriptions)
     }
   }
@@ -303,7 +303,7 @@ class RxWorkersTest {
 
     assertEquals(0, cancels)
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals(0, cancels)
       cancelWorker()
       assertEquals(1, cancels)
@@ -318,7 +318,7 @@ class RxWorkersTest {
     val subject = CompletableSubject.create()
     val worker = subject.asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onComplete()
       assertFinished()
     }
@@ -328,7 +328,7 @@ class RxWorkersTest {
     val subject = CompletableSubject.create()
     val worker = subject.asWorker()
 
-    worker.test {
+    worker.launchForTestingWith {
       subject.onError(ExpectedException())
       assertTrue(getException() is ExpectedException)
     }
@@ -342,7 +342,7 @@ class RxWorkersTest {
 
     assertEquals(0, subscriptions)
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals(1, subscriptions)
     }
   }
@@ -355,7 +355,7 @@ class RxWorkersTest {
 
     assertEquals(0, cancels)
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals(0, cancels)
       cancelWorker()
       assertEquals(1, cancels)

--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -37,6 +37,8 @@ public final class com/squareup/workflow/testing/RenderTesterKt {
 	public static synthetic fun expectWorker$default (Lcom/squareup/workflow/testing/RenderTester;Lcom/squareup/workflow/Worker;Ljava/lang/String;Lcom/squareup/workflow/WorkflowOutput;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
 	public static final fun renderTester (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
 	public static final fun renderTester (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static final fun testRender (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static final fun testRender (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
 }
 
 public final class com/squareup/workflow/testing/WorkerSink : com/squareup/workflow/Worker {
@@ -57,8 +59,8 @@ public abstract interface class com/squareup/workflow/testing/WorkerTester {
 }
 
 public final class com/squareup/workflow/testing/WorkerTesterKt {
-	public static final fun test (Lcom/squareup/workflow/Worker;JLkotlin/jvm/functions/Function2;)V
-	public static synthetic fun test$default (Lcom/squareup/workflow/Worker;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static final fun launchForTestingWith (Lcom/squareup/workflow/Worker;JLkotlin/jvm/functions/Function2;)V
+	public static synthetic fun launchForTestingWith$default (Lcom/squareup/workflow/Worker;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 }
 
 public final class com/squareup/workflow/testing/WorkflowTestParams {
@@ -91,25 +93,35 @@ public final class com/squareup/workflow/testing/WorkflowTestParams$StartMode$St
 	public final fun getSnapshot ()Lcom/squareup/workflow/Snapshot;
 }
 
-public final class com/squareup/workflow/testing/WorkflowTester {
-	public static final field Companion Lcom/squareup/workflow/testing/WorkflowTester$Companion;
+public final class com/squareup/workflow/testing/WorkflowTestRuntime {
+	public static final field Companion Lcom/squareup/workflow/testing/WorkflowTestRuntime$Companion;
 	public static final field DEFAULT_TIMEOUT_MS J
 	public final fun awaitNextOutput (Ljava/lang/Long;)Ljava/lang/Object;
-	public static synthetic fun awaitNextOutput$default (Lcom/squareup/workflow/testing/WorkflowTester;Ljava/lang/Long;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun awaitNextOutput$default (Lcom/squareup/workflow/testing/WorkflowTestRuntime;Ljava/lang/Long;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun awaitNextRendering (Ljava/lang/Long;Z)Ljava/lang/Object;
-	public static synthetic fun awaitNextRendering$default (Lcom/squareup/workflow/testing/WorkflowTester;Ljava/lang/Long;ZILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun awaitNextRendering$default (Lcom/squareup/workflow/testing/WorkflowTestRuntime;Ljava/lang/Long;ZILjava/lang/Object;)Ljava/lang/Object;
 	public final fun awaitNextSnapshot (Ljava/lang/Long;Z)Lcom/squareup/workflow/TreeSnapshot;
-	public static synthetic fun awaitNextSnapshot$default (Lcom/squareup/workflow/testing/WorkflowTester;Ljava/lang/Long;ZILjava/lang/Object;)Lcom/squareup/workflow/TreeSnapshot;
+	public static synthetic fun awaitNextSnapshot$default (Lcom/squareup/workflow/testing/WorkflowTestRuntime;Ljava/lang/Long;ZILjava/lang/Object;)Lcom/squareup/workflow/TreeSnapshot;
 	public final fun getHasOutput ()Z
 	public final fun getHasRendering ()Z
 	public final fun getHasSnapshot ()Z
 	public final fun sendProps (Ljava/lang/Object;)V
 }
 
-public final class com/squareup/workflow/testing/WorkflowTester$Companion {
+public final class com/squareup/workflow/testing/WorkflowTestRuntime$Companion {
 }
 
-public final class com/squareup/workflow/testing/WorkflowTesterKt {
+public final class com/squareup/workflow/testing/WorkflowTestRuntimeKt {
+	public static final fun launchForTestingFromStartWith (Lcom/squareup/workflow/Workflow;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun launchForTestingFromStartWith (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun launchForTestingFromStartWith$default (Lcom/squareup/workflow/Workflow;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun launchForTestingFromStartWith$default (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun launchForTestingFromStateWith (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun launchForTestingFromStateWith (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun launchForTestingFromStateWith$default (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun launchForTestingFromStateWith$default (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun launchForTestingWith (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun launchForTestingWith$default (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun test (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static synthetic fun test$default (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun testFromStart (Lcom/squareup/workflow/Workflow;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTestResult.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTestResult.kt
@@ -39,7 +39,7 @@ interface RenderTestResult<StateT, OutputT> {
 
   /**
    * If the render pass handled either a workflow/worker output or a rendering event, "executes" the
-   * action with the state passed to [renderTester], then invokes [block] with the resulting state
+   * action with the state passed to [testRender], then invokes [block] with the resulting state
    * value.
    *
    * If the workflow didn't process any actions, `newState` will be the initial state.
@@ -52,7 +52,7 @@ interface RenderTestResult<StateT, OutputT> {
 
   /**
    * If the render pass handled either a workflow/worker output or a rendering event, "executes" the
-   * action with the state passed to [renderTester], verifies that the action set an output, then
+   * action with the state passed to [testRender], verifies that the action set an output, then
    * invokes [block] with the resulting output value.
    *
    * If the workflow didn't process any actions, or no output was set, an [AssertionError] will be
@@ -66,7 +66,7 @@ interface RenderTestResult<StateT, OutputT> {
 
   /**
    * If the render pass handled either a workflow/worker output or a rendering event, "executes" the
-   * action with the state passed to [renderTester], and then verifies that the action did not set
+   * action with the state passed to [testRender], and then verifies that the action did not set
    * any output.
    *
    * If the workflow didn't process any actions, this method will do nothing.
@@ -79,7 +79,7 @@ interface RenderTestResult<StateT, OutputT> {
 
   /**
    * Asserts that the render pass handled either a workflow/worker output or a rendering event,
-   * "executes" the action with the state passed to [renderTester], then invokes [block] with the
+   * "executes" the action with the state passed to [testRender], then invokes [block] with the
    * resulting state and output values.
    *
    * If the workflow didn't process any actions, `newState` will be the initial state and `output`

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
@@ -22,6 +22,15 @@ import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.WorkflowOutput
 import kotlin.reflect.KClass
 
+@Deprecated(
+    "Renamed to testRender",
+    ReplaceWith("testRender(props)", "com.squareup.workflow.testing.testRender")
+)
+@Suppress("NOTHING_TO_INLINE")
+inline fun <PropsT, OutputT, RenderingT> Workflow<PropsT, OutputT, RenderingT>.renderTester(
+  props: PropsT
+): RenderTester<PropsT, *, OutputT, RenderingT> = testRender(props)
+
 /**
  * Create a [RenderTester] to unit test an individual render pass of this workflow, using the
  * workflow's [initial state][StatefulWorkflow.initialState].
@@ -29,15 +38,30 @@ import kotlin.reflect.KClass
  * See [RenderTester] for usage documentation.
  */
 @Suppress("UNCHECKED_CAST")
-fun <PropsT, OutputT, RenderingT> Workflow<PropsT, OutputT, RenderingT>.renderTester(
+fun <PropsT, OutputT, RenderingT> Workflow<PropsT, OutputT, RenderingT>.testRender(
   props: PropsT
 ): RenderTester<PropsT, *, OutputT, RenderingT> {
   val statefulWorkflow = asStatefulWorkflow() as StatefulWorkflow<PropsT, Any?, OutputT, RenderingT>
-  return statefulWorkflow.renderTester(
+  return statefulWorkflow.testRender(
       props = props,
       initialState = statefulWorkflow.initialState(props, null)
   ) as RenderTester<PropsT, Nothing, OutputT, RenderingT>
 }
+
+@Deprecated(
+    "Renamed to testRender",
+    ReplaceWith(
+        "testRender(props, initialState)",
+        "com.squareup.workflow.testing.testRender"
+    )
+)
+/* ktlint-disable parameter-list-wrapping */
+fun <PropsT, StateT, OutputT, RenderingT>
+    StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.renderTester(
+  props: PropsT,
+  initialState: StateT
+): RenderTester<PropsT, StateT, OutputT, RenderingT> = testRender(props, initialState)
+/* ktlint-enable parameter-list-wrapping */
 
 /**
  * Create a [RenderTester] to unit test an individual render pass of this workflow.
@@ -46,7 +70,7 @@ fun <PropsT, OutputT, RenderingT> Workflow<PropsT, OutputT, RenderingT>.renderTe
  */
 /* ktlint-disable parameter-list-wrapping */
 fun <PropsT, StateT, OutputT, RenderingT>
-    StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.renderTester(
+    StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.testRender(
   props: PropsT,
   initialState: StateT
 ): RenderTester<PropsT, StateT, OutputT, RenderingT> =

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkerSink.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkerSink.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlin.reflect.KClass
 
 /**
- * Implementation of [Worker] for integration tests (using [testFromStart] or [testFromState]) that
+ * Implementation of [Worker] for integration tests (using [launchForTestingFromStartWith] or [launchForTestingFromStateWith]) that
  * need to simply push values into the worker from the test.
  *
  * Instances of this class are considered equivalent if they have matching [type] and [name].

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkerTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkerTester.kt
@@ -18,7 +18,7 @@
 package com.squareup.workflow.testing
 
 import com.squareup.workflow.Worker
-import com.squareup.workflow.testing.WorkflowTester.Companion.DEFAULT_TIMEOUT_MS
+import com.squareup.workflow.testing.WorkflowTestRuntime.Companion.DEFAULT_TIMEOUT_MS
 import kotlinx.coroutines.Dispatchers.Unconfined
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
@@ -68,7 +68,7 @@ interface WorkerTester<T> {
 /**
  * Test a [Worker] by defining assertions on its output within [block].
  */
-fun <T> Worker<T>.test(
+fun <T> Worker<T>.launchForTestingWith(
   timeoutMs: Long = DEFAULT_TIMEOUT_MS,
   block: suspend WorkerTester<T>.() -> Unit
 ) {

--- a/workflow-testing/src/test/java/com/squareup/workflow/FlowWorkersTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow/FlowWorkersTest.kt
@@ -17,7 +17,7 @@
 
 package com.squareup.workflow
 
-import com.squareup.workflow.testing.test
+import com.squareup.workflow.testing.launchForTestingWith
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
@@ -38,7 +38,7 @@ class FlowWorkersTest {
   private val worker by lazy { source.asWorker() }
 
   @Test fun `flow emits`() {
-    worker.test {
+    worker.launchForTestingWith {
       subject.send("foo")
       assertEquals("foo", nextOutput())
 
@@ -48,14 +48,14 @@ class FlowWorkersTest {
   }
 
   @Test fun `flow finishes`() {
-    worker.test {
+    worker.launchForTestingWith {
       subject.close()
       assertFinished()
     }
   }
 
   @Test fun `flow finishes after emitting interleaved`() {
-    worker.test {
+    worker.launchForTestingWith {
       subject.send("foo")
       assertEquals("foo", nextOutput())
 
@@ -65,7 +65,7 @@ class FlowWorkersTest {
   }
 
   @Test fun `flow finishes after emitting grouped`() {
-    worker.test {
+    worker.launchForTestingWith {
       subject.send("foo")
       subject.close()
 
@@ -75,7 +75,7 @@ class FlowWorkersTest {
   }
 
   @Test fun `flow throws`() {
-    worker.test {
+    worker.launchForTestingWith {
       subject.close(ExpectedException())
       assertTrue(getException() is ExpectedException)
     }
@@ -87,7 +87,7 @@ class FlowWorkersTest {
 
     assertEquals(0, collections)
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals(1, collections)
     }
   }
@@ -98,7 +98,7 @@ class FlowWorkersTest {
 
     assertEquals(0, cancellations)
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals(0, cancellations)
       cancelWorker()
       assertEquals(1, cancellations)

--- a/workflow-testing/src/test/java/com/squareup/workflow/LifecycleWorkerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow/LifecycleWorkerTest.kt
@@ -17,7 +17,7 @@
 
 package com.squareup.workflow
 
-import com.squareup.workflow.testing.test
+import com.squareup.workflow.testing.launchForTestingWith
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.Unconfined
 import kotlinx.coroutines.flow.launchIn
@@ -55,7 +55,7 @@ class LifecycleWorkerTest {
       }
     }
 
-    worker.test {
+    worker.launchForTestingWith {
       assertFalse(onCancelledCalled)
       cancelWorker()
 

--- a/workflow-testing/src/test/java/com/squareup/workflow/SnapshottingIntegrationTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow/SnapshottingIntegrationTest.kt
@@ -18,7 +18,7 @@ package com.squareup.workflow
 import com.squareup.workflow.WorkflowAction.Companion.noAction
 import com.squareup.workflow.testing.WorkflowTestParams
 import com.squareup.workflow.testing.WorkflowTestParams.StartMode.StartFromCompleteSnapshot
-import com.squareup.workflow.testing.testFromStart
+import com.squareup.workflow.testing.launchForTestingFromStartWith
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -30,7 +30,7 @@ class SnapshottingIntegrationTest {
     var snapshot = TreeSnapshot.NONE
 
     // Setup initial state and change the state the workflow in the tree.
-    root.testFromStart("initial props") {
+    root.launchForTestingFromStartWith("initial props") {
       awaitNextRendering()
           .let {
             assertEquals("root:initial props", it.data)
@@ -42,7 +42,7 @@ class SnapshottingIntegrationTest {
       snapshot = awaitNextSnapshot()
     }
 
-    root.testFromStart(
+    root.launchForTestingFromStartWith(
         props = "unused props",
         testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot))
     ) {
@@ -54,7 +54,7 @@ class SnapshottingIntegrationTest {
     val root = TreeWorkflow("root")
     val snapshot = TreeSnapshot.NONE
 
-    root.testFromStart(
+    root.launchForTestingFromStartWith(
         props = "initial props",
         testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot))
     ) {
@@ -67,7 +67,7 @@ class SnapshottingIntegrationTest {
     var snapshot = TreeSnapshot.NONE
 
     // Setup initial state and change the state the workflow in the tree.
-    root.testFromStart("initial props") {
+    root.launchForTestingFromStartWith("initial props") {
       awaitNextRendering()
           .let {
             assertEquals("root:initial props", it.data)
@@ -85,7 +85,7 @@ class SnapshottingIntegrationTest {
       snapshot = awaitNextSnapshot()
     }
 
-    root.testFromStart(
+    root.launchForTestingFromStartWith(
         props = "unused props",
         testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot))
     ) {
@@ -113,7 +113,7 @@ class SnapshottingIntegrationTest {
     var snapshot = TreeSnapshot.NONE
 
     // Setup initial state and change the state of two workflows in the tree.
-    root.testFromStart("initial props") {
+    root.launchForTestingFromStartWith("initial props") {
       awaitNextRendering()
           .let {
             assertEquals("root:initial props", it.data)
@@ -141,7 +141,7 @@ class SnapshottingIntegrationTest {
       snapshot = awaitNextSnapshot()
     }
 
-    root.testFromStart(
+    root.launchForTestingFromStartWith(
         props = "unused props",
         testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot))
     ) {
@@ -175,7 +175,7 @@ class SnapshottingIntegrationTest {
       renderChild(workflow, it)
     }
 
-    root.testFromStart("props1") {
+    root.launchForTestingFromStartWith("props1") {
       val snapshot1 = awaitNextSnapshot()
 
       // Change the props (and thus the state) to make a different snapshot.

--- a/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
@@ -19,7 +19,7 @@ package com.squareup.workflow
 
 import com.squareup.workflow.WorkflowAction.Companion.noAction
 import com.squareup.workflow.testing.WorkerSink
-import com.squareup.workflow.testing.testFromStart
+import com.squareup.workflow.testing.launchForTestingFromStartWith
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers.Unconfined
@@ -51,7 +51,7 @@ class WorkerCompositionIntegrationTest {
       if (props) runningWorker(worker) { noAction() }
     }
 
-    workflow.testFromStart(false) {
+    workflow.launchForTestingFromStartWith(false) {
       assertFalse(started)
       sendProps(true)
       assertTrue(started)
@@ -69,7 +69,7 @@ class WorkerCompositionIntegrationTest {
       if (props) runningWorker(worker) { noAction() }
     }
 
-    workflow.testFromStart(true) {
+    workflow.launchForTestingFromStartWith(true) {
       assertFalse(cancelled)
       sendProps(false)
       assertTrue(cancelled)
@@ -90,7 +90,7 @@ class WorkerCompositionIntegrationTest {
     }
     val workflow = Workflow.stateless<Unit, Nothing, Unit> { runningWorker(worker) { noAction() } }
 
-    workflow.testFromStart {
+    workflow.launchForTestingFromStartWith {
       assertEquals(1, starts)
       assertEquals(0, stops)
 
@@ -120,7 +120,7 @@ class WorkerCompositionIntegrationTest {
       if (props) runningWorker(worker) { noAction() }
     }
 
-    workflow.testFromStart(false) {
+    workflow.launchForTestingFromStartWith(false) {
       assertEquals(0, starts)
       assertEquals(0, stops)
 
@@ -144,7 +144,7 @@ class WorkerCompositionIntegrationTest {
       runningWorker(worker) { action { setOutput(it) } }
     }
 
-    workflow.testFromStart {
+    workflow.launchForTestingFromStartWith {
       assertFalse(this.hasOutput)
 
       worker.send("foo")
@@ -163,7 +163,7 @@ class WorkerCompositionIntegrationTest {
     }
 
     assertFailsWith<ExpectedException> {
-      workflow.testFromStart {
+      workflow.launchForTestingFromStartWith {
         assertFalse(this.hasOutput)
 
         channel.cancel(CancellationException(null, ExpectedException()))
@@ -182,7 +182,7 @@ class WorkerCompositionIntegrationTest {
       ) { fail("Expected handler to not be invoked.") }
     }
 
-    workflow.testFromStart {
+    workflow.launchForTestingFromStartWith {
       channel.close()
 
       assertFailsWith<TimeoutCancellationException> {
@@ -209,7 +209,7 @@ class WorkerCompositionIntegrationTest {
         }
     )
 
-    workflow.testFromStart {
+    workflow.launchForTestingFromStartWith {
       triggerOutput.send(Unit)
       assertEquals(0, awaitNextOutput())
 
@@ -235,7 +235,7 @@ class WorkerCompositionIntegrationTest {
     }
 
     assertFailsWith<AssertionError> {
-      workflow.testFromStart {
+      workflow.launchForTestingFromStartWith {
         // Nothing to do.
       }
     }
@@ -248,7 +248,7 @@ class WorkerCompositionIntegrationTest {
       runningWorker(worker)
     }
 
-    workflow.testFromStart {
+    workflow.launchForTestingFromStartWith {
       assertFailsWith<TimeoutCancellationException> {
         awaitNextOutput(timeoutMs = 100)
       }
@@ -265,7 +265,7 @@ class WorkerCompositionIntegrationTest {
     }
     val job = Job()
 
-    workflow.testFromStart(context = job) {
+    workflow.launchForTestingFromStartWith(context = job) {
       val actualWorkerContext = awaitNextOutput()
       assertNotSame(job, actualWorkerContext[Job])
     }
@@ -289,7 +289,7 @@ class WorkerCompositionIntegrationTest {
       ) = Unconfined.dispatch(context, block)
     }
 
-    workflow.testFromStart(context = dispatcher) {
+    workflow.launchForTestingFromStartWith(context = dispatcher) {
       val actualWorkerContext = awaitNextOutput()
       assertSame(dispatcher, actualWorkerContext[ContinuationInterceptor])
     }

--- a/workflow-testing/src/test/java/com/squareup/workflow/WorkerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow/WorkerTest.kt
@@ -17,7 +17,7 @@
 
 package com.squareup.workflow
 
-import com.squareup.workflow.testing.test
+import com.squareup.workflow.testing.launchForTestingWith
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.conflate
@@ -59,7 +59,7 @@ class WorkerTest {
       emit("world")
     }
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals("hello", nextOutput())
       assertEquals("world", nextOutput())
       assertFinished()
@@ -69,7 +69,7 @@ class WorkerTest {
   @Test fun `create finishes without emitting`() {
     val worker = Worker.create<String> {}
 
-    worker.test {
+    worker.launchForTestingWith {
       assertFinished()
     }
   }
@@ -77,7 +77,7 @@ class WorkerTest {
   @Test fun `create propagates exceptions`() {
     val worker = Worker.create<Unit> { throw ExpectedException() }
 
-    worker.test {
+    worker.launchForTestingWith {
       assertTrue(getException() is ExpectedException)
     }
   }
@@ -96,7 +96,7 @@ class WorkerTest {
       ran = true
     }
 
-    worker.test {
+    worker.launchForTestingWith {
       assertTrue(ran)
     }
   }
@@ -104,7 +104,7 @@ class WorkerTest {
   @Test fun `createSideEffect finishes`() {
     val worker = Worker.createSideEffect {}
 
-    worker.test {
+    worker.launchForTestingWith {
       assertFinished()
     }
   }
@@ -112,7 +112,7 @@ class WorkerTest {
   @Test fun `createSideEffect propagates exceptions`() {
     val worker = Worker.createSideEffect { throw ExpectedException() }
 
-    worker.test {
+    worker.launchForTestingWith {
       assertTrue(getException() is ExpectedException)
     }
   }
@@ -120,7 +120,7 @@ class WorkerTest {
   @Test fun `from emits and finishes`() {
     val worker = Worker.from { "foo" }
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals("foo", nextOutput())
       assertFinished()
     }
@@ -129,7 +129,7 @@ class WorkerTest {
   @Test fun `from emits null`() {
     val worker = Worker.from<String?> { null }
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals(null, nextOutput())
       assertFinished()
     }
@@ -138,7 +138,7 @@ class WorkerTest {
   @Test fun `fromNullable emits and finishes`() {
     val worker = Worker.fromNullable { "foo" }
 
-    worker.test {
+    worker.launchForTestingWith {
       assertEquals("foo", nextOutput())
       assertFinished()
     }
@@ -147,7 +147,7 @@ class WorkerTest {
   @Test fun `fromNullable doesn't emit null`() {
     val worker = Worker.fromNullable<String> { null }
 
-    worker.test {
+    worker.launchForTestingWith {
       assertFinished()
     }
   }
@@ -173,7 +173,7 @@ class WorkerTest {
         // Run the timer on the test dispatcher so we can control time.
         .transform { it.flowOn(testDispatcher) }
 
-    worker.test {
+    worker.launchForTestingWith {
       assertNoOutput()
       assertNotFinished()
 

--- a/workflow-testing/src/test/java/com/squareup/workflow/WorkflowCompositionIntegrationTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow/WorkflowCompositionIntegrationTest.kt
@@ -16,7 +16,7 @@
 package com.squareup.workflow
 
 import com.squareup.workflow.testing.WorkerSink
-import com.squareup.workflow.testing.testFromStart
+import com.squareup.workflow.testing.launchForTestingFromStartWith
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -28,7 +28,7 @@ class WorkflowCompositionIntegrationTest {
     val root = TreeWorkflow("root", TreeWorkflow("leaf"))
 
     // Setup initial state and change the state the workflow in the tree.
-    root.testFromStart("initial props") {
+    root.launchForTestingFromStartWith("initial props") {
       awaitNextRendering()
           .let {
             assertEquals("root:initial props", it.data)
@@ -45,7 +45,7 @@ class WorkflowCompositionIntegrationTest {
     )
 
     // Setup initial state and change the state the workflow in the tree.
-    root.testFromStart("initial props") {
+    root.launchForTestingFromStartWith("initial props") {
       awaitNextRendering()
           .let {
             assertEquals("root:initial props", it.data)
@@ -69,7 +69,7 @@ class WorkflowCompositionIntegrationTest {
         )
     )
 
-    root.testFromStart("initial props") {
+    root.launchForTestingFromStartWith("initial props") {
       awaitNextRendering()
           .let {
             assertEquals("root:initial props", it.data)
@@ -91,7 +91,7 @@ class WorkflowCompositionIntegrationTest {
 
     // Setup initial state and change the state the workflow in the tree.
     assertFails {
-      root.testFromStart("initial props") {
+      root.launchForTestingFromStartWith("initial props") {
         awaitNextRendering()
       }
     }.let { error ->
@@ -117,7 +117,7 @@ class WorkflowCompositionIntegrationTest {
         }
     )
 
-    workflow.testFromStart {
+    workflow.launchForTestingFromStartWith {
       triggerChildOutput.send(Unit)
       assertEquals(0, awaitNextOutput())
 

--- a/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
@@ -47,7 +47,7 @@ class RealRenderTesterTest {
   @Test fun `expectWorkflow with output throws when already expecting workflow output`() {
     // Don't need an implementation, the test should fail before even calling render.
     val workflow = Workflow.stateless<Unit, Unit, Unit> {}
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorkflow(
             OutputWhateverChild::class, rendering = Unit,
             output = WorkflowOutput(Unit)
@@ -71,7 +71,7 @@ class RealRenderTesterTest {
   @Test fun `expectWorkflow with output throws when already expecting worker output`() {
     // Don't need an implementation, the test should fail before even calling render.
     val workflow = Workflow.stateless<Unit, Unit, Unit> {}
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorker(matchesWhen = { true }, output = WorkflowOutput(Unit))
 
     val failure = assertFailsWith<IllegalStateException> {
@@ -93,7 +93,7 @@ class RealRenderTesterTest {
   @Test fun `expectWorkflow without output doesn't throw when already expecting output`() {
     // Don't need an implementation, the test should fail before even calling render.
     val workflow = Workflow.stateless<Unit, Unit, Unit> {}
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorkflow(
             OutputWhateverChild::class, rendering = Unit,
             output = WorkflowOutput(Unit)
@@ -106,7 +106,7 @@ class RealRenderTesterTest {
   @Test fun `expectWorker with output throws when already expecting worker output`() {
     // Don't need an implementation, the test should fail before even calling render.
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {}
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorker(matchesWhen = { true }, output = WorkflowOutput(Unit))
 
     val failure = assertFailsWith<IllegalStateException> {
@@ -125,7 +125,7 @@ class RealRenderTesterTest {
   @Test fun `expectWorker with output throws when already expecting workflow output`() {
     // Don't need an implementation, the test should fail before even calling render.
     val workflow = Workflow.stateless<Unit, Unit, Unit> {}
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorkflow(
             workflow::class, rendering = Unit,
             output = WorkflowOutput(Unit)
@@ -148,7 +148,7 @@ class RealRenderTesterTest {
   @Test fun `expectWorker without output doesn't throw when already expecting output`() {
     // Don't need an implementation, the test should fail before even calling render.
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {}
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorker(matchesWhen = { true }, output = WorkflowOutput(Unit))
 
     // Doesn't throw.
@@ -164,7 +164,7 @@ class RealRenderTesterTest {
       runningWorker(worker) { noAction() }
     }
 
-    workflow.renderTester(Unit)
+    workflow.testRender(Unit)
         .expectWorker(worker)
         .render()
   }
@@ -183,7 +183,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningWorker(worker1) { noAction() }
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorker(worker2)
 
     val error = assertFailsWith<AssertionError> {
@@ -198,7 +198,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningSideEffect("the key") {}
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectSideEffect("the key")
 
     val error = assertFailsWith<AssertionError> {
@@ -212,14 +212,14 @@ class RealRenderTesterTest {
       runningSideEffect("the key") {}
     }
 
-    workflow.renderTester(Unit)
+    workflow.testRender(Unit)
         .expectSideEffect("the key")
         .render {}
   }
 
   @Test fun `expectSideEffect doesn't match key`() {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {}
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectSideEffect("the key")
 
     val error = assertFailsWith<AssertionError> {
@@ -247,7 +247,7 @@ class RealRenderTesterTest {
     val action1 = TestAction("1")
     val action2 = TestAction("2")
 
-    workflow.renderTester(Unit)
+    workflow.testRender(Unit)
         .render { sink ->
           sink.send(action1)
 
@@ -277,7 +277,7 @@ class RealRenderTesterTest {
         }
     )
 
-    workflow.renderTester(Unit)
+    workflow.testRender(Unit)
         .expectWorker(matchesWhen = { true }, output = WorkflowOutput(Unit))
         .render { sink ->
           val error = assertFailsWith<IllegalStateException> {
@@ -289,7 +289,7 @@ class RealRenderTesterTest {
 
   @Test fun `failures from render block escape`() {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> { }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
 
     val error = assertFailsWith<AssertionError> {
       tester.render {
@@ -304,7 +304,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       renderChild(child)
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
 
     val error = assertFailsWith<AssertionError> {
       tester.render()
@@ -320,7 +320,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       renderChild(child)
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorkflow(OutputNothingChild::class, rendering = Unit)
 
     val error = assertFailsWith<AssertionError> {
@@ -337,7 +337,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       renderChild(child, key = "key")
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
 
     val error = assertFailsWith<AssertionError> {
       tester.render()
@@ -354,7 +354,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       renderChild(child, key = "key")
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorkflow(OutputNothingChild::class, rendering = Unit)
 
     val error = assertFailsWith<AssertionError> {
@@ -372,7 +372,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       renderChild(child, key = "key")
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorkflow(OutputNothingChild::class, rendering = Unit, key = "wrong key")
 
     val error = assertFailsWith<AssertionError> {
@@ -398,7 +398,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       renderChild(Child())
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorkflow(OutputNothingChild::class, rendering = Unit)
         .expectWorkflow(Child::class, rendering = Unit)
 
@@ -425,7 +425,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningWorker(worker)
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
     tester.render()
   }
 
@@ -439,7 +439,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningWorker(worker)
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorker(matchesWhen = { false })
 
     val error = assertFailsWith<AssertionError> {
@@ -461,7 +461,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningWorker(worker, key = "key")
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
 
     tester.render()
   }
@@ -476,7 +476,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningWorker(worker, key = "key")
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorker(matchesWhen = { true })
 
     val error = assertFailsWith<AssertionError> {
@@ -497,7 +497,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningWorker(worker, key = "key")
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorker(
             matchesWhen = { true },
             key = "wrong key"
@@ -520,7 +520,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningWorker(worker)
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorker(matchesWhen = { true })
         .expectWorker(matchesWhen = { true })
 
@@ -541,7 +541,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       // Do nothing.
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorkflow(OutputNothingChild::class, rendering = Unit)
 
     val error = assertFailsWith<AssertionError> {
@@ -556,7 +556,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       // Do nothing.
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorker(matchesWhen = { true })
 
     val error = assertFailsWith<AssertionError> {
@@ -579,7 +579,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       renderChild(child)
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorkflow(OutputNothingChild::class, rendering = Unit)
 
     tester.render()
@@ -590,7 +590,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       renderChild(child, "wrong props")
     }
-    val tester = workflow.renderTester(Unit)
+    val tester = workflow.testRender(Unit)
         .expectWorkflow(
             workflowType = child::class,
             rendering = Unit,
@@ -612,7 +612,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Sink<TestAction>> {
       actionSink.contraMap { it }
     }
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .render { it.send(TestAction("noop")) }
 
     val error = assertFailsWith<AssertionError> {
@@ -626,7 +626,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       renderChild(child) { TestAction(it) }
     }
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .expectWorkflow(
             workflowType = child::class,
             rendering = Unit,
@@ -645,7 +645,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningWorker(worker) { TestAction(it) }
     }
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .expectWorker(
             matchesWhen = { true },
             output = WorkflowOutput("output")
@@ -662,7 +662,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Sink<TestAction>> {
       actionSink.contraMap { it }
     }
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .render { sink ->
           sink.send(TestAction("event"))
         }
@@ -678,7 +678,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Sink<TestAction>> {
       actionSink.contraMap { it }
     }
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .render {
           // Don't send to sink!
         }
@@ -703,7 +703,7 @@ class RealRenderTesterTest {
         initialState = { "initial" },
         render = { _, _ -> actionSink.contraMap { it } }
     )
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .render { sink ->
           sink.send(TestAction())
         }
@@ -726,7 +726,7 @@ class RealRenderTesterTest {
         initialState = { "initial" },
         render = { _, _ -> actionSink.contraMap { it } }
     )
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .render { sink ->
           sink.send(TestAction())
         }
@@ -747,7 +747,7 @@ class RealRenderTesterTest {
         initialState = { "initial" },
         render = { _, _ -> actionSink.contraMap { it } }
     )
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .render { sink ->
           sink.send(TestAction())
         }
@@ -761,7 +761,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Sink<TestAction>> {
       actionSink.contraMap { it }
     }
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .render {
           // Don't send to sink!
         }
@@ -783,7 +783,7 @@ class RealRenderTesterTest {
         initialState = { "initial" },
         render = { _, _ -> actionSink.contraMap { it } }
     )
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .render { sink ->
           sink.send(TestAction())
         }
@@ -797,7 +797,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Sink<TestAction>> {
       actionSink.contraMap { it }
     }
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .render {
           // Don't send to sink!
         }
@@ -820,7 +820,7 @@ class RealRenderTesterTest {
         initialState = { "initial" },
         render = { _, _ -> actionSink.contraMap { it } }
     )
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .render { sink ->
           sink.send(TestAction())
         }
@@ -834,7 +834,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Sink<TestAction>> {
       actionSink.contraMap { it }
     }
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .render {
           // Don't send to sink!
         }
@@ -854,7 +854,7 @@ class RealRenderTesterTest {
         initialState = { "initial" },
         render = { _, _ -> actionSink.contraMap { it } }
     )
-    val testResult = workflow.renderTester(Unit)
+    val testResult = workflow.testRender(Unit)
         .render { sink ->
           sink.send(TestAction())
         }
@@ -869,7 +869,7 @@ class RealRenderTesterTest {
     var renderCount = 0
     val workflow = Workflow.stateless<Unit, Nothing, Unit> { renderCount++ }
 
-    workflow.renderTester(Unit)
+    workflow.testRender(Unit)
         .render()
 
     assertEquals(2, renderCount)

--- a/workflow-testing/src/test/java/com/squareup/workflow/testing/WorkflowTestRuntimeTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow/testing/WorkflowTestRuntimeTest.kt
@@ -34,7 +34,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
-class WorkflowTesterTest {
+class WorkflowTestRuntimeTest {
 
   private class ExpectedException(message: String? = null) : RuntimeException(message)
 
@@ -43,7 +43,7 @@ class WorkflowTesterTest {
 
     rethrowingUncaughtExceptions {
       assertFailsWith<ExpectedException> {
-        workflow.testFromStart {
+        workflow.launchForTestingFromStartWith {
           throw ExpectedException()
         }
       }
@@ -57,7 +57,7 @@ class WorkflowTesterTest {
 
     rethrowingUncaughtExceptions {
       assertFailsWith<ExpectedException> {
-        workflow.testFromStart {
+        workflow.launchForTestingFromStartWith {
           // Nothing to do.
         }
       }
@@ -70,7 +70,7 @@ class WorkflowTesterTest {
 
     rethrowingUncaughtExceptions {
       assertFailsWith<ExpectedException> {
-        workflow.testFromStart(context = job) {
+        workflow.launchForTestingFromStartWith(context = job) {
           job.cancel(CancellationException(null, ExpectedException()))
         }
       }
@@ -83,7 +83,7 @@ class WorkflowTesterTest {
 
     rethrowingUncaughtExceptions {
       assertFailsWith<CancellationException> {
-        workflow.testFromStart(context = job) {
+        workflow.launchForTestingFromStartWith(context = job) {
           awaitNextRendering()
         }
       }
@@ -96,7 +96,7 @@ class WorkflowTesterTest {
 
     rethrowingUncaughtExceptions {
       assertFailsWith<ExpectedException> {
-        workflow.testFromStart(context = job) {
+        workflow.launchForTestingFromStartWith(context = job) {
           // Nothing to do.
         }
       }
@@ -115,7 +115,7 @@ class WorkflowTesterTest {
 
     rethrowingUncaughtExceptions {
       assertFailsWith<ExpectedException> {
-        workflow.testFromStart {
+        workflow.launchForTestingFromStartWith {
           // Nothing to do.
         }
       }
@@ -131,7 +131,7 @@ class WorkflowTesterTest {
 
     rethrowingUncaughtExceptions {
       assertFailsWith<ExpectedException> {
-        workflow.testFromStart {
+        workflow.launchForTestingFromStartWith {
           // Nothing to do.
         }
       }
@@ -152,7 +152,7 @@ class WorkflowTesterTest {
 
     rethrowingUncaughtExceptions {
       assertFailsWith<ExpectedException> {
-        workflow.testFromStart(
+        workflow.launchForTestingFromStartWith(
             WorkflowTestParams(startFrom = StartFromWorkflowSnapshot(snapshot))
         ) {
           // Nothing to do.
@@ -170,7 +170,7 @@ class WorkflowTesterTest {
 
     rethrowingUncaughtExceptions {
       assertFailsWith<ExpectedException> {
-        workflow.testFromStart {
+        workflow.launchForTestingFromStartWith {
           // Nothing to do.
         }
       }
@@ -181,7 +181,7 @@ class WorkflowTesterTest {
     val workflow = Workflow.stateless<Unit, Unit, Unit> {}
 
     rethrowingUncaughtExceptions {
-      workflow.testFromStart {
+      workflow.launchForTestingFromStartWith {
         // The workflow should never start.
       }
     }
@@ -191,7 +191,7 @@ class WorkflowTesterTest {
     val workflow = Workflow.stateless<String, Nothing, String> { props -> props }
 
     rethrowingUncaughtExceptions {
-      workflow.testFromStart("one") {
+      workflow.launchForTestingFromStartWith("one") {
         assertEquals("one", awaitNextRendering())
         sendProps("two")
         assertEquals("two", awaitNextRendering())
@@ -208,7 +208,7 @@ class WorkflowTesterTest {
     }
 
     rethrowingUncaughtExceptions {
-      workflow.testFromStart(
+      workflow.launchForTestingFromStartWith(
           props,
           testParams = WorkflowTestParams(checkRenderIdempotence = false)
       ) {
@@ -230,7 +230,7 @@ class WorkflowTesterTest {
     }
 
     rethrowingUncaughtExceptions {
-      workflow.testFromStart {
+      workflow.launchForTestingFromStartWith {
         assertEquals(2, renderCount)
       }
     }
@@ -243,7 +243,7 @@ class WorkflowTesterTest {
     }
 
     rethrowingUncaughtExceptions {
-      workflow.testFromStart(testParams = WorkflowTestParams(checkRenderIdempotence = false)) {
+      workflow.launchForTestingFromStartWith(testParams = WorkflowTestParams(checkRenderIdempotence = false)) {
         assertEquals(1, renderCount)
       }
     }
@@ -259,7 +259,7 @@ class WorkflowTesterTest {
 
     rethrowingUncaughtExceptions {
       val firstError = assertFailsWith<ExpectedException> {
-        workflow.testFromStart(props = false) {
+        workflow.launchForTestingFromStartWith(props = false) {
           sendProps(true)
           throw ExpectedException("test body")
         }
@@ -278,7 +278,7 @@ class WorkflowTesterTest {
 
     rethrowingUncaughtExceptions {
       val firstError = assertFailsWith<ExpectedException> {
-        workflow.testFromStart {
+        workflow.launchForTestingFromStartWith {
           throw ExpectedException("test body")
         }
       }
@@ -291,7 +291,7 @@ class WorkflowTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       itLived = true
     }
-    workflow.testFromStart {
+    workflow.launchForTestingFromStartWith {
     }
     assertTrue(itLived)
   }


### PR DESCRIPTION
- `WorkflowTester` -> `WorkflowTestRuntime`
- `Workflow.test()` -> `Workflow.launchForTestingWith()`
- `Workflow.testFromState()` -> `Workflow.launchForTestingFromStateWith()`
- `Workflow.testFromStart()` -> `Workflow.launchForTestingFromStartWith()`
- `Workflow.renderTester()` -> `Workflow.testRender()`

All old names are kept around as deprecated typealiases or inline function
aliases with replacements.

Fixes #58.
