### PR TITLE
Cleanup the RenderTestResult interface after introducing WorkflowOutput.

### DIFF
--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -9,14 +9,7 @@ public final class com/squareup/workflow/testing/RenderIdempotencyChecker : com/
 
 public abstract interface class com/squareup/workflow/testing/RenderTestResult {
 	public abstract fun verifyAction (Lkotlin/jvm/functions/Function1;)V
-	public abstract fun verifyActionOutput (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/testing/RenderTestResult;
 	public abstract fun verifyActionResult (Lkotlin/jvm/functions/Function2;)V
-	public abstract fun verifyActionState (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/testing/RenderTestResult;
-	public abstract fun verifyNoActionOutput ()Lcom/squareup/workflow/testing/RenderTestResult;
-}
-
-public final class com/squareup/workflow/testing/RenderTestResult$DefaultImpls {
-	public static fun verifyActionResult (Lcom/squareup/workflow/testing/RenderTestResult;Lkotlin/jvm/functions/Function2;)V
 }
 
 public abstract interface class com/squareup/workflow/testing/RenderTester {

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/RealRenderTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/RealRenderTester.kt
@@ -202,30 +202,10 @@ internal class RealRenderTester<PropsT, StateT, OutputT, RenderingT>(
     block(action)
   }
 
-  override fun verifyActionState(block: (newState: StateT) -> Unit) = apply {
-    verifyAction { action ->
-      // Don't care about output.
-      val (newState, _) = action.applyTo(state)
-      block(newState)
-    }
-  }
-
-  override fun verifyActionOutput(block: (output: OutputT) -> Unit) = apply {
-    verifyAction { action ->
-      val (_, output) = action.applyTo(state)
-      if (output == null) {
-        throw AssertionError("Expected action to set an output")
-      }
-      block(output.value)
-    }
-  }
-
-  override fun verifyNoActionOutput() = apply {
-    verifyAction { action ->
-      val (_, output) = action.applyTo(state)
-      if (output != null) {
-        throw AssertionError("Expected no output, but action set output to: ${output.value}")
-      }
+  override fun verifyActionResult(block: (newState: StateT, output: WorkflowOutput<OutputT>?) -> Unit) {
+    verifyAction {
+      val (state, output) = it.applyTo(state)
+      block(state, output)
     }
   }
 

--- a/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTestResult.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTestResult.kt
@@ -16,6 +16,7 @@
 package com.squareup.workflow.testing
 
 import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.WorkflowOutput
 
 /**
  * Result of a [RenderTester.render] call that can be used to verify that a [WorkflowAction] was
@@ -38,46 +39,6 @@ interface RenderTestResult<StateT, OutputT> {
   fun verifyAction(block: (WorkflowAction<StateT, OutputT>) -> Unit)
 
   /**
-   * If the render pass handled either a workflow/worker output or a rendering event, "executes" the
-   * action with the state passed to [testRender], then invokes [block] with the resulting state
-   * value.
-   *
-   * If the workflow didn't process any actions, `newState` will be the initial state.
-   *
-   * Note that by using this method, you're also testing the implementation of your action. This can
-   * be useful if your actions are anonymous. If they are a sealed class or enum, use [verifyAction]
-   * instead and write separate unit tests for your action implementations.
-   */
-  fun verifyActionState(block: (newState: StateT) -> Unit): RenderTestResult<StateT, OutputT>
-
-  /**
-   * If the render pass handled either a workflow/worker output or a rendering event, "executes" the
-   * action with the state passed to [testRender], verifies that the action set an output, then
-   * invokes [block] with the resulting output value.
-   *
-   * If the workflow didn't process any actions, or no output was set, an [AssertionError] will be
-   * thrown.
-   *
-   * Note that by using this method, you're also testing the implementation of your action. This can
-   * be useful if your actions are anonymous. If they are a sealed class or enum, use [verifyAction]
-   * instead and write separate unit tests for your action implementations.
-   */
-  fun verifyActionOutput(block: (output: OutputT) -> Unit): RenderTestResult<StateT, OutputT>
-
-  /**
-   * If the render pass handled either a workflow/worker output or a rendering event, "executes" the
-   * action with the state passed to [testRender], and then verifies that the action did not set
-   * any output.
-   *
-   * If the workflow didn't process any actions, this method will do nothing.
-   *
-   * Note that by using this method, you're also testing the implementation of your action. This can
-   * be useful if your actions are anonymous. If they are a sealed class or enum, use [verifyAction]
-   * instead and write separate unit tests for your action implementations.
-   */
-  fun verifyNoActionOutput(): RenderTestResult<StateT, OutputT>
-
-  /**
    * Asserts that the render pass handled either a workflow/worker output or a rendering event,
    * "executes" the action with the state passed to [testRender], then invokes [block] with the
    * resulting state and output values.
@@ -88,23 +49,6 @@ interface RenderTestResult<StateT, OutputT> {
    * Note that by using this method, you're also testing the implementation of your action. This can
    * be useful if your actions are anonymous. If they are a sealed class or enum, use [verifyAction]
    * instead and write separate unit tests for your action implementations.
-   *
-   * Note that if [OutputT] is nullable, this method does not distinguish between an no output and
-   * null output. Use [RenderTestResult.verifyActionOutput] and
-   * [RenderTestResult.verifyNoActionOutput] instead.
    */
-  @Deprecated("Use verifyActionState and verify(No)ActionOutput")
-  fun verifyActionResult(block: (newState: StateT, output: OutputT?) -> Unit) {
-    var state: StateT? = null
-    var output: OutputT? = null
-    verifyActionState { state = it }
-    try {
-      verifyActionOutput { output = it }
-    } catch (e: AssertionError) {
-      // No output was set, leave as null.
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    block(state as StateT, output)
-  }
+  fun verifyActionResult(block: (newState: StateT, output: WorkflowOutput<OutputT>?) -> Unit)
 }


### PR DESCRIPTION
After #49 made outputs nullable, and introduced new `RenderTestResult`
methods to handle nullable outputs (`verifyActionState`, `verifyActionOutput`,
and `verifyNoActionOutput`), #64 came along and introduced a dedicated
type for nullable outputs, `WorkflowOutput`. This type means that we can
revert the `RenderTestResult` changes made in #49 and return to the simpler
API with only `verifyAction` and `verifyActionResult` methods. This change
does exactly that.