### PR TITLE
Introduce unsnapshottableIdentifier() to allow transient WorkflowIdentifiers.

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -172,12 +172,12 @@ public final class com/squareup/workflow/WorkflowIdentifier {
 	public static final field Companion Lcom/squareup/workflow/WorkflowIdentifier$Companion;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public final fun toByteStringOrNull ()Lokio/ByteString;
 	public fun toString ()Ljava/lang/String;
-	public final fun write (Lokio/BufferedSink;)V
 }
 
 public final class com/squareup/workflow/WorkflowIdentifier$Companion {
-	public final fun read (Lokio/BufferedSource;)Lcom/squareup/workflow/WorkflowIdentifier;
+	public final fun parse (Lokio/ByteString;)Lcom/squareup/workflow/WorkflowIdentifier;
 }
 
 public final class com/squareup/workflow/WorkflowOutput {
@@ -225,6 +225,7 @@ public final class com/squareup/workflow/Workflows {
 	public static synthetic fun stateful$default (Lcom/squareup/workflow/Workflow$Companion;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lcom/squareup/workflow/StatefulWorkflow;
 	public static final fun stateless (Lcom/squareup/workflow/Workflow$Companion;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/Workflow;
 	public static final fun transform (Lcom/squareup/workflow/Worker;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Worker;
+	public static final fun unsnapshottableIdentifier (Lkotlin/reflect/KType;)Lcom/squareup/workflow/WorkflowIdentifier;
 	public static final fun workflowAction (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/WorkflowAction;
 	public static final fun workflowAction (Lcom/squareup/workflow/StatefulWorkflow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/WorkflowAction;
 	public static synthetic fun workflowAction$default (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/WorkflowAction;

--- a/workflow-core/src/test/java/com/squareup/workflow/WorkflowIdentifierTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/WorkflowIdentifierTest.kt
@@ -16,12 +16,16 @@
 package com.squareup.workflow
 
 import okio.Buffer
+import okio.ByteString
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
 
-@OptIn(ExperimentalWorkflowApi::class)
+@OptIn(ExperimentalWorkflowApi::class, ExperimentalStdlibApi::class)
 class WorkflowIdentifierTest {
 
   @Test fun `flat identifier toString`() {
@@ -43,8 +47,8 @@ class WorkflowIdentifierTest {
 
   @Test fun `restored identifier toString`() {
     val id = TestWorkflow1.identifier
-    val serializedId = Buffer().also(id::write)
-    val restoredId = WorkflowIdentifier.read(serializedId)
+    val serializedId = id.toByteStringOrNull()!!
+    val restoredId = WorkflowIdentifier.parse(serializedId)
     assertEquals(id.toString(), restoredId.toString())
   }
 
@@ -82,8 +86,8 @@ class WorkflowIdentifierTest {
 
   @Test fun `identifier restored from source is equal to itself`() {
     val id = TestWorkflow1.identifier
-    val serializedId = Buffer().also(id::write)
-    val restoredId = WorkflowIdentifier.read(serializedId)
+    val serializedId = id.toByteStringOrNull()!!
+    val restoredId = WorkflowIdentifier.parse(serializedId)
     assertEquals(id, restoredId)
     assertEquals(id.hashCode(), restoredId.hashCode())
   }
@@ -91,15 +95,15 @@ class WorkflowIdentifierTest {
   @Test fun `identifier restored from source is not equal to different identifier`() {
     val id1 = TestWorkflow1.identifier
     val id2 = TestWorkflow2.identifier
-    val serializedId = Buffer().also(id1::write)
-    val restoredId = WorkflowIdentifier.read(serializedId)
+    val serializedId = id1.toByteStringOrNull()!!
+    val restoredId = WorkflowIdentifier.parse(serializedId)
     assertNotEquals(id2, restoredId)
   }
 
   @Test fun `impostor identifier restored from source is equal to itself`() {
     val id = TestImpostor1(TestWorkflow1).identifier
-    val serializedId = Buffer().also(id::write)
-    val restoredId = WorkflowIdentifier.read(serializedId)
+    val serializedId = id.toByteStringOrNull()!!
+    val restoredId = WorkflowIdentifier.parse(serializedId)
     assertEquals(id, restoredId)
     assertEquals(id.hashCode(), restoredId.hashCode())
   }
@@ -108,8 +112,8 @@ class WorkflowIdentifierTest {
   fun `impostor identifier restored from source is not equal to impostor with different proxied class`() {
     val id1 = TestImpostor1(TestWorkflow1).identifier
     val id2 = TestImpostor1(TestWorkflow2).identifier
-    val serializedId = Buffer().also(id1::write)
-    val restoredId = WorkflowIdentifier.read(serializedId)
+    val serializedId = id1.toByteStringOrNull()!!
+    val restoredId = WorkflowIdentifier.parse(serializedId)
     assertNotEquals(id2, restoredId)
   }
 
@@ -117,37 +121,81 @@ class WorkflowIdentifierTest {
   fun `impostor identifier restored from source is not equal to different impostor with same proxied class`() {
     val id1 = TestImpostor1(TestWorkflow1).identifier
     val id2 = TestImpostor2(TestWorkflow1).identifier
-    val serializedId = Buffer().also(id1::write)
-    val restoredId = WorkflowIdentifier.read(serializedId)
+    val serializedId = id1.toByteStringOrNull()!!
+    val restoredId = WorkflowIdentifier.parse(serializedId)
     assertNotEquals(id2, restoredId)
   }
 
   @Test fun `read from empty source throws`() {
-    val source = Buffer()
     assertFailsWith<IllegalArgumentException> {
-      WorkflowIdentifier.read(source)
+      WorkflowIdentifier.parse(ByteString.EMPTY)
     }
   }
 
   @Test fun `read from invalid source throws`() {
     val source = Buffer().apply { writeUtf8("invalid data") }
+        .readByteString()
     assertFailsWith<IllegalArgumentException> {
-      WorkflowIdentifier.read(source)
+      WorkflowIdentifier.parse(source)
     }
   }
 
   @Test fun `read from corrupted source throws`() {
-    val source = Buffer().also(TestWorkflow1.identifier::write)
-        .readByteArray()
+    val source = TestWorkflow1.identifier.toByteStringOrNull()!!
+        .toByteArray()
     source.indices.reversed()
         .take(10)
         .forEach { i ->
           source[i] = 0
         }
     val corruptedSource = Buffer().apply { write(source) }
+        .readByteString()
     assertFailsWith<ClassNotFoundException> {
-      WorkflowIdentifier.read(corruptedSource)
+      WorkflowIdentifier.parse(corruptedSource)
     }
+  }
+
+  @Test fun `unsnapshottable identifier returns null ByteString`() {
+    val id = unsnapshottableIdentifier(typeOf<TestWorkflow1>())
+    assertNull(id.toByteStringOrNull())
+  }
+
+  @Test fun `unsnapshottable identifier toString()`() {
+    val id = unsnapshottableIdentifier(typeOf<String>())
+    assertEquals(
+        "WorkflowIdentifier(${String::class.java.name} (Kotlin reflection is not available))",
+        id.toString()
+    )
+  }
+
+  @Test fun `unsnapshottable identifiers for same class are equal`() {
+    val id1 = unsnapshottableIdentifier(typeOf<String>())
+    val id2 = unsnapshottableIdentifier(typeOf<String>())
+    assertEquals(id1, id2)
+  }
+
+  @Test fun `unsnapshottable identifiers for different class are not equal`() {
+    val id1 = unsnapshottableIdentifier(typeOf<String>())
+    val id2 = unsnapshottableIdentifier(typeOf<Int>())
+    assertNotEquals(id1, id2)
+  }
+
+  @Test fun `unsnapshottable impostor identifier returns null ByteString`() {
+    val id = TestUnsnapshottableImpostor(typeOf<String>()).identifier
+    assertNull(id.toByteStringOrNull())
+  }
+
+  @Test fun `impostor of unsnapshottable impostor identifier returns null ByteString`() {
+    val id = TestImpostor1(TestUnsnapshottableImpostor(typeOf<String>())).identifier
+    assertNull(id.toByteStringOrNull())
+  }
+
+  @Test fun `unsnapshottable impostor identifier toString()`() {
+    val id = TestUnsnapshottableImpostor(typeOf<String>()).identifier
+    assertEquals(
+        "WorkflowIdentifier(${TestUnsnapshottableImpostor::class.java.name}, " +
+            "${String::class.java.name} (Kotlin reflection is not available))", id.toString()
+    )
   }
 
   private object TestWorkflow1 : Workflow<Nothing, Nothing, Nothing> {
@@ -172,6 +220,14 @@ class WorkflowIdentifierTest {
     proxied: Workflow<*, *, *>
   ) : Workflow<Nothing, Nothing, Nothing>, ImpostorWorkflow {
     override val realIdentifier: WorkflowIdentifier = proxied.identifier
+    override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, Nothing, Nothing> =
+      throw NotImplementedError()
+  }
+
+  private class TestUnsnapshottableImpostor(
+    type: KType
+  ) : Workflow<Nothing, Nothing, Nothing>, ImpostorWorkflow {
+    override val realIdentifier: WorkflowIdentifier = unsnapshottableIdentifier(type)
     override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, Nothing, Nothing> =
       throw NotImplementedError()
   }


### PR DESCRIPTION
This fixes #79 and unblocks the ability to implement GUWT Workers as Workflows.
`WorkflowIdentifier` can now indicate that it is not serializable by returning
null from `toByteString()`, in which case neither it nor the snapshot of the
workflow it identifies will be serialized. Because these identifiers do not need
to be serialized, they can contain arbitrary values such as `KType`s, which is
how Workers distinguish themselves for example. Workers also do not need to
be snapshotted, so this works out.