### PR TITLE
Brings back Updater.nextState as a deprecated alias for state

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -163,8 +163,10 @@ public final class com/squareup/workflow/WorkflowAction$Mutator {
 
 public final class com/squareup/workflow/WorkflowAction$Updater {
 	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;)V
+	public final fun getNextState ()Ljava/lang/Object;
 	public final fun getProps ()Ljava/lang/Object;
 	public final fun getState ()Ljava/lang/Object;
+	public final fun setNextState (Ljava/lang/Object;)V
 	public final fun setOutput (Ljava/lang/Object;)V
 	public final fun setState (Ljava/lang/Object;)V
 }

--- a/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
@@ -41,6 +41,13 @@ interface WorkflowAction<in PropsT, StateT, out OutputT> {
     internal var output: WorkflowOutput<@UnsafeVariance O>? = null
       private set
 
+    @Deprecated("Use state instead.", ReplaceWith("state"))
+    var nextState: S
+      get() = state
+      set(value) {
+        state = value
+      }
+
     /**
      * Sets the value the workflow will emit as output when this action is applied.
      * If this method is not called, there will be no output.


### PR DESCRIPTION
For ease of migration.