### PR TITLE
Make RealRenderContext internal.

### DIFF
--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -73,28 +73,3 @@ public abstract interface class com/squareup/workflow/WorkflowInterceptor$Workfl
 	public abstract fun getSessionId ()J
 }
 
-public final class com/squareup/workflow/internal/RealRenderContext : com/squareup/workflow/RenderContext, com/squareup/workflow/Sink {
-	public fun <init> (Lcom/squareup/workflow/internal/RealRenderContext$Renderer;Lcom/squareup/workflow/internal/RealRenderContext$WorkerRunner;Lcom/squareup/workflow/internal/RealRenderContext$SideEffectRunner;Lkotlinx/coroutines/channels/SendChannel;)V
-	public final fun freeze ()V
-	public fun getActionSink ()Lcom/squareup/workflow/Sink;
-	public fun makeActionSink ()Lcom/squareup/workflow/Sink;
-	public fun onEvent (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
-	public fun renderChild (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public fun runningWorker (Lcom/squareup/workflow/Worker;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public fun send (Lcom/squareup/workflow/WorkflowAction;)V
-	public synthetic fun send (Ljava/lang/Object;)V
-}
-
-public abstract interface class com/squareup/workflow/internal/RealRenderContext$Renderer {
-	public abstract fun render (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-}
-
-public abstract interface class com/squareup/workflow/internal/RealRenderContext$SideEffectRunner {
-	public abstract fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-}
-
-public abstract interface class com/squareup/workflow/internal/RealRenderContext$WorkerRunner {
-	public abstract fun runningWorker (Lcom/squareup/workflow/Worker;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-}
-

--- a/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
@@ -24,7 +24,7 @@ import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
 import kotlinx.coroutines.channels.SendChannel
 
-class RealRenderContext<out PropsT, StateT, OutputT>(
+internal class RealRenderContext<out PropsT, StateT, OutputT>(
   private val renderer: Renderer<PropsT, StateT, OutputT>,
   private val workerRunner: WorkerRunner<PropsT, StateT, OutputT>,
   private val sideEffectRunner: SideEffectRunner,


### PR DESCRIPTION
The only reason it wasn't already was that it used to be that we needed to
access it from the testing module. That is no longer true.