### PR TITLE
Update RenderTester to support ImpostorWorkflow.

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -175,6 +175,7 @@ public final class com/squareup/workflow/WorkflowIdentifier {
 	public static final field Companion Lcom/squareup/workflow/WorkflowIdentifier$Companion;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public final fun matchesActualIdentifierForTest (Lcom/squareup/workflow/WorkflowIdentifier;)Z
 	public final fun toByteStringOrNull ()Lokio/ByteString;
 	public fun toString ()Ljava/lang/String;
 }
@@ -205,6 +206,8 @@ public final class com/squareup/workflow/Workflows {
 	public static final fun collectToSink (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow/Sink;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun contraMap (Lcom/squareup/workflow/Sink;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Sink;
 	public static final fun getIdentifier (Lcom/squareup/workflow/Workflow;)Lcom/squareup/workflow/WorkflowIdentifier;
+	public static final fun getWorkflowIdentifier (Lkotlin/reflect/KClass;)Lcom/squareup/workflow/WorkflowIdentifier;
+	public static final fun impostorWorkflowIdentifier (Lkotlin/reflect/KClass;Lcom/squareup/workflow/WorkflowIdentifier;)Lcom/squareup/workflow/WorkflowIdentifier;
 	public static final fun invoke (Lcom/squareup/workflow/EventHandler;)V
 	public static final fun makeEventSink (Lcom/squareup/workflow/RenderContext;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/Sink;
 	public static final fun mapRendering (Lcom/squareup/workflow/Workflow;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Workflow;

--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -15,12 +15,15 @@ public abstract interface class com/squareup/workflow/testing/RenderTestResult {
 public abstract interface class com/squareup/workflow/testing/RenderTester {
 	public abstract fun expectSideEffect (Ljava/lang/String;)Lcom/squareup/workflow/testing/RenderTester;
 	public abstract fun expectWorker (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lcom/squareup/workflow/WorkflowOutput;)Lcom/squareup/workflow/testing/RenderTester;
+	public abstract fun expectWorkflow (Lcom/squareup/workflow/WorkflowIdentifier;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;)Lcom/squareup/workflow/testing/RenderTester;
 	public abstract fun expectWorkflow (Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;)Lcom/squareup/workflow/testing/RenderTester;
 	public abstract fun render (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/testing/RenderTestResult;
 }
 
 public final class com/squareup/workflow/testing/RenderTester$DefaultImpls {
 	public static synthetic fun expectWorker$default (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lcom/squareup/workflow/WorkflowOutput;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static fun expectWorkflow (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;)Lcom/squareup/workflow/testing/RenderTester;
+	public static synthetic fun expectWorkflow$default (Lcom/squareup/workflow/testing/RenderTester;Lcom/squareup/workflow/WorkflowIdentifier;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
 	public static synthetic fun expectWorkflow$default (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
 	public static synthetic fun render$default (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTestResult;
 }


### PR DESCRIPTION
 - Added an overload of `RenderTester.expectWorkflow()` which takes a `WorkflowIdentifier`.
 - Added extension properties on `KClass<Workflow>` and `KClass<ImpostorWorkflow>` to create
   identifiers from the classes.
 - Added a method to `WorkflowIdentifier` that compares identifiers by "leaf real identifiers"
   to support testing.