### PR TITLE
Improve the RenderTester API.

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -11,7 +11,12 @@ public abstract interface annotation class com/squareup/workflow/ExperimentalWor
 }
 
 public abstract interface class com/squareup/workflow/ImpostorWorkflow {
+	public abstract fun describeRealIdentifier ()Ljava/lang/String;
 	public abstract fun getRealIdentifier ()Lcom/squareup/workflow/WorkflowIdentifier;
+}
+
+public final class com/squareup/workflow/ImpostorWorkflow$DefaultImpls {
+	public static fun describeRealIdentifier (Lcom/squareup/workflow/ImpostorWorkflow;)Ljava/lang/String;
 }
 
 public abstract class com/squareup/workflow/LifecycleWorker : com/squareup/workflow/Worker {
@@ -173,9 +178,10 @@ public final class com/squareup/workflow/WorkflowAction$Updater {
 
 public final class com/squareup/workflow/WorkflowIdentifier {
 	public static final field Companion Lcom/squareup/workflow/WorkflowIdentifier$Companion;
+	public final fun describeRealIdentifier ()Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRealIdentifierType ()Lkotlin/reflect/KAnnotatedElement;
 	public fun hashCode ()I
-	public final fun matchesActualIdentifierForTest (Lcom/squareup/workflow/WorkflowIdentifier;)Z
 	public final fun toByteStringOrNull ()Lokio/ByteString;
 	public fun toString ()Ljava/lang/String;
 }

--- a/workflow-core/src/main/java/com/squareup/workflow/ImpostorWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/ImpostorWorkflow.kt
@@ -37,4 +37,9 @@ interface ImpostorWorkflow {
    * [Workflow] that this workflow wraps.
    */
   val realIdentifier: WorkflowIdentifier
+
+  /**
+   * Returns a string that describes how this workflow is related to [realIdentifier].
+   */
+  fun describeRealIdentifier(): String? = null
 }

--- a/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
@@ -146,5 +146,8 @@ fun <PropsT, OutputT, FromRenderingT, ToRenderingT>
       return transform(rendering)
     }
 
+    override fun describeRealIdentifier(): String? =
+      "${this@mapRendering.identifier}.mapRendering()"
+
     override fun toString(): String = "${this@mapRendering}.mapRendering()"
   }

--- a/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
@@ -176,7 +176,13 @@ interface WorkflowAction<in PropsT, StateT, out OutputT> {
     ): WorkflowAction<PropsT, StateT, OutputT> =
       action({ "emitOutput($name, $output)" }) { setOutput(output) }
 
-    private val NO_ACTION = action<Any, Any, Any>({ "noAction" }) { }
+    private val NO_ACTION = object : WorkflowAction<Any?, Any?, Any?> {
+      override fun toString(): String = "WorkflowAction.noAction()"
+
+      override fun Updater<Any?, Any?, Any?>.apply() {
+        // Noop
+      }
+    }
   }
 }
 

--- a/workflow-core/src/test/java/com/squareup/workflow/WorkflowIdentifierTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/WorkflowIdentifierTest.kt
@@ -22,10 +22,8 @@ import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalWorkflowApi::class, ExperimentalStdlibApi::class)
 class WorkflowIdentifierTest {
@@ -45,6 +43,11 @@ class WorkflowIdentifierTest {
             "com.squareup.workflow.WorkflowIdentifierTest\$TestWorkflow1)",
         id.toString()
     )
+  }
+
+  @Test fun `impostor identifier description`() {
+    val id = TestImpostor1(TestWorkflow1).identifier
+    assertEquals("TestImpostor1(TestWorkflow1)", id.describeRealIdentifier())
   }
 
   @Test fun `restored identifier toString`() {
@@ -243,53 +246,24 @@ class WorkflowIdentifierTest {
     assertNotEquals(instanceId, classId)
   }
 
-  @Test fun `matchesActualIdentifierForTest() matches same workflow class`() {
-    val id1 = TestWorkflow1.identifier
-    val id2 = TestWorkflow1.identifier
-    assertTrue(id1.matchesActualIdentifierForTest(id2))
-    assertTrue(id2.matchesActualIdentifierForTest(id1))
+  @Test fun `getRealIdentifierType() returns self for non-impostor workflow`() {
+    val id = TestWorkflow1.identifier
+    assertEquals(TestWorkflow1::class, id.getRealIdentifierType())
   }
 
-  @Test fun `matchesActualIdentifierForTest() doesn't match different workflow types`() {
-    val id1 = TestWorkflow1.identifier
-    val id2 = TestWorkflow2.identifier
-    assertFalse(id1.matchesActualIdentifierForTest(id2))
+  @Test fun `getRealIdentifierType() returns real identifier for impostor workflow`() {
+    val id = TestImpostor1(TestWorkflow1).identifier
+    assertEquals(TestWorkflow1::class, id.getRealIdentifierType())
   }
 
-  @Test fun `matchesActualIdentifierForTest() matches subclass`() {
-    val parentId = Parent::class.workflowIdentifier
-    val childId = Child.identifier
-    assertTrue(parentId.matchesActualIdentifierForTest(childId))
+  @Test fun `getRealIdentifierType() returns leaf real identifier for impostor workflow chain`() {
+    val id = TestImpostor2(TestImpostor1(TestWorkflow1)).identifier
+    assertEquals(TestWorkflow1::class, id.getRealIdentifierType())
   }
 
-  @Test fun `matchesActualIdentifierForTest() doesn't match superclass`() {
-    val parentId = Parent::class.workflowIdentifier
-    val childId = Child.identifier
-    assertFalse(childId.matchesActualIdentifierForTest(parentId))
-  }
-
-  @Test
-  fun `matchesActualIdentifierForTest() matches impostor identifiers with same proxied identifiers`() {
-    val id1 = TestImpostor1(TestWorkflow1).identifier
-    val id2 = TestImpostor1(TestWorkflow1).identifier
-    assertTrue(id1.matchesActualIdentifierForTest(id2))
-    assertTrue(id2.matchesActualIdentifierForTest(id1))
-  }
-
-  @Test
-  fun `matchesActualIdentifierForTest() matches different impostor identifiers with same proxied identifier`() {
-    val id1 = TestImpostor1(TestWorkflow1).identifier
-    val id2 = TestImpostor2(TestWorkflow1).identifier
-    assertTrue(id1.matchesActualIdentifierForTest(id2))
-    assertTrue(id2.matchesActualIdentifierForTest(id1))
-  }
-
-  @Test
-  fun `matchesActualIdentifierForTest() doesn't match impostor identifiers with different proxied identifiers`() {
-    val id1 = TestImpostor1(TestWorkflow1).identifier
-    val id2 = TestImpostor1(TestWorkflow2).identifier
-    assertFalse(id1.matchesActualIdentifierForTest(id2))
-    assertFalse(id2.matchesActualIdentifierForTest(id1))
+  @Test fun `getRealIdentifierType() returns KType of unsnapshottable identifier`() {
+    val id = TestUnsnapshottableImpostor(typeOf<List<String>>()).identifier
+    assertEquals(typeOf<List<String>>(), id.getRealIdentifierType())
   }
 
   private object TestWorkflow1 : Workflow<Nothing, Nothing, Nothing> {
@@ -303,9 +277,10 @@ class WorkflowIdentifierTest {
   }
 
   private class TestImpostor1(
-    proxied: Workflow<*, *, *>
+    private val proxied: Workflow<*, *, *>
   ) : Workflow<Nothing, Nothing, Nothing>, ImpostorWorkflow {
     override val realIdentifier: WorkflowIdentifier = proxied.identifier
+    override fun describeRealIdentifier(): String? = "TestImpostor1(${proxied::class.simpleName})"
     override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, Nothing, Nothing> =
       throw NotImplementedError()
   }

--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -13,24 +13,52 @@ public abstract interface class com/squareup/workflow/testing/RenderTestResult {
 }
 
 public abstract interface class com/squareup/workflow/testing/RenderTester {
-	public abstract fun expectSideEffect (Ljava/lang/String;)Lcom/squareup/workflow/testing/RenderTester;
-	public abstract fun expectWorker (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lcom/squareup/workflow/WorkflowOutput;)Lcom/squareup/workflow/testing/RenderTester;
-	public abstract fun expectWorkflow (Lcom/squareup/workflow/WorkflowIdentifier;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;)Lcom/squareup/workflow/testing/RenderTester;
-	public abstract fun expectWorkflow (Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;)Lcom/squareup/workflow/testing/RenderTester;
+	public abstract fun expectSideEffect (Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/testing/RenderTester;
+	public abstract fun expectWorker (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lcom/squareup/workflow/WorkflowOutput;Ljava/lang/String;)Lcom/squareup/workflow/testing/RenderTester;
+	public abstract fun expectWorkflow (Lcom/squareup/workflow/WorkflowIdentifier;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;Ljava/lang/String;)Lcom/squareup/workflow/testing/RenderTester;
+	public abstract fun expectWorkflow (Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/testing/RenderTester;
+	public abstract fun expectWorkflow (Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;Ljava/lang/String;)Lcom/squareup/workflow/testing/RenderTester;
 	public abstract fun render (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/testing/RenderTestResult;
 }
 
+public abstract class com/squareup/workflow/testing/RenderTester$ChildWorkflowMatch {
+}
+
+public final class com/squareup/workflow/testing/RenderTester$ChildWorkflowMatch$Matched : com/squareup/workflow/testing/RenderTester$ChildWorkflowMatch {
+	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow/WorkflowOutput;)V
+	public synthetic fun <init> (Ljava/lang/Object;Lcom/squareup/workflow/WorkflowOutput;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getChildRendering ()Ljava/lang/Object;
+	public final fun getOutput ()Lcom/squareup/workflow/WorkflowOutput;
+}
+
+public final class com/squareup/workflow/testing/RenderTester$ChildWorkflowMatch$NotMatched : com/squareup/workflow/testing/RenderTester$ChildWorkflowMatch {
+	public static final field INSTANCE Lcom/squareup/workflow/testing/RenderTester$ChildWorkflowMatch$NotMatched;
+}
+
 public final class com/squareup/workflow/testing/RenderTester$DefaultImpls {
-	public static synthetic fun expectWorker$default (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lcom/squareup/workflow/WorkflowOutput;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
-	public static fun expectWorkflow (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;)Lcom/squareup/workflow/testing/RenderTester;
-	public static synthetic fun expectWorkflow$default (Lcom/squareup/workflow/testing/RenderTester;Lcom/squareup/workflow/WorkflowIdentifier;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
-	public static synthetic fun expectWorkflow$default (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static synthetic fun expectSideEffect$default (Lcom/squareup/workflow/testing/RenderTester;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static synthetic fun expectWorker$default (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lcom/squareup/workflow/WorkflowOutput;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static fun expectWorkflow (Lcom/squareup/workflow/testing/RenderTester;Lcom/squareup/workflow/WorkflowIdentifier;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;Ljava/lang/String;)Lcom/squareup/workflow/testing/RenderTester;
+	public static fun expectWorkflow (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;Ljava/lang/String;)Lcom/squareup/workflow/testing/RenderTester;
+	public static synthetic fun expectWorkflow$default (Lcom/squareup/workflow/testing/RenderTester;Lcom/squareup/workflow/WorkflowIdentifier;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static synthetic fun expectWorkflow$default (Lcom/squareup/workflow/testing/RenderTester;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static synthetic fun expectWorkflow$default (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/WorkflowOutput;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
 	public static synthetic fun render$default (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTestResult;
 }
 
+public final class com/squareup/workflow/testing/RenderTester$RenderChildInvocation {
+	public fun <init> (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Lkotlin/reflect/KTypeProjection;Lkotlin/reflect/KTypeProjection;Ljava/lang/String;)V
+	public final fun getOutputType ()Lkotlin/reflect/KTypeProjection;
+	public final fun getProps ()Ljava/lang/Object;
+	public final fun getRenderKey ()Ljava/lang/String;
+	public final fun getRenderingType ()Lkotlin/reflect/KTypeProjection;
+	public final fun getWorkflow ()Lcom/squareup/workflow/Workflow;
+}
+
 public final class com/squareup/workflow/testing/RenderTesterKt {
-	public static final fun expectWorker (Lcom/squareup/workflow/testing/RenderTester;Lcom/squareup/workflow/Worker;Ljava/lang/String;Lcom/squareup/workflow/WorkflowOutput;)Lcom/squareup/workflow/testing/RenderTester;
-	public static synthetic fun expectWorker$default (Lcom/squareup/workflow/testing/RenderTester;Lcom/squareup/workflow/Worker;Ljava/lang/String;Lcom/squareup/workflow/WorkflowOutput;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static final fun expectSideEffect (Lcom/squareup/workflow/testing/RenderTester;Ljava/lang/String;)Lcom/squareup/workflow/testing/RenderTester;
+	public static final fun expectWorker (Lcom/squareup/workflow/testing/RenderTester;Lcom/squareup/workflow/Worker;Ljava/lang/String;Lcom/squareup/workflow/WorkflowOutput;Ljava/lang/String;)Lcom/squareup/workflow/testing/RenderTester;
+	public static synthetic fun expectWorker$default (Lcom/squareup/workflow/testing/RenderTester;Lcom/squareup/workflow/Worker;Ljava/lang/String;Lcom/squareup/workflow/WorkflowOutput;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
 	public static final fun renderTester (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
 	public static final fun renderTester (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
 	public static final fun testRender (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;


### PR DESCRIPTION
- Cleans up the testing API exposed by `WorkflowIdentifier` and makes the type
  checking more precise.
- Adds descriptions to expectations to allow for more readable error messages.
- Adds `RenderTester` methods to match using arbitrary predicate functions.
- Allows Workflow and side effect expectations to be non-exact – such expectations
  are optional, not required to be exclusive, and can match multiple times.