### PR TITLE
Use inner types for RenderContext to reduce type boilerplate.

### DIFF
--- a/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemListWorkflow.kt
+++ b/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemListWorkflow.kt
@@ -16,7 +16,6 @@
 package com.squareup.sample.poetryapp
 
 import com.squareup.sample.poetry.model.Poem
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.StatelessWorkflow
 import com.squareup.workflow1.makeEventSink
 
@@ -27,7 +26,7 @@ object PoemListWorkflow : StatelessWorkflow<List<Poem>, Int, PoemListRendering>(
 
   override fun render(
     props: List<Poem>,
-    context: RenderContext<List<Poem>, Nothing, Int>
+    context: RenderContext
   ): PoemListRendering {
     // A sink that emits the given index as the result of this workflow.
     val sink = context.makeEventSink { index: Int -> setOutput(index) }

--- a/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemsBrowserWorkflow.kt
+++ b/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemsBrowserWorkflow.kt
@@ -18,7 +18,6 @@ package com.squareup.sample.poetryapp
 import com.squareup.sample.container.overviewdetail.OverviewDetailScreen
 import com.squareup.sample.poetry.PoemWorkflow
 import com.squareup.sample.poetry.model.Poem
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.action
@@ -42,7 +41,7 @@ object PoemsBrowserWorkflow :
   override fun render(
     props: List<Poem>,
     state: SelectedPoem,
-    context: RenderContext<List<Poem>, SelectedPoem, Nothing>
+    context: RenderContext
   ): OverviewDetailScreen {
     val poems: OverviewDetailScreen =
       context.renderChild(PoemListWorkflow, props) { selected -> choosePoem(selected) }

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/AreYouSureWorkflow.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/AreYouSureWorkflow.kt
@@ -21,7 +21,6 @@ import com.squareup.sample.hellobackbutton.AreYouSureWorkflow.Finished
 import com.squareup.sample.hellobackbutton.AreYouSureWorkflow.State
 import com.squareup.sample.hellobackbutton.AreYouSureWorkflow.State.Quitting
 import com.squareup.sample.hellobackbutton.AreYouSureWorkflow.State.Running
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction.Companion.noAction
@@ -59,7 +58,7 @@ object AreYouSureWorkflow : StatefulWorkflow<Unit, State, Finished, AlertContain
   override fun render(
     props: Unit,
     state: State,
-    context: RenderContext<Unit, State, Finished>
+    context: RenderContext
   ): AlertContainerScreen<*> {
     val ableBakerCharlie = context.renderChild(HelloBackButtonWorkflow, Unit) { noAction() }
 

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
@@ -21,7 +21,6 @@ import com.squareup.sample.hellobackbutton.HelloBackButtonWorkflow.State
 import com.squareup.sample.hellobackbutton.HelloBackButtonWorkflow.State.Able
 import com.squareup.sample.hellobackbutton.HelloBackButtonWorkflow.State.Baker
 import com.squareup.sample.hellobackbutton.HelloBackButtonWorkflow.State.Charlie
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.action
@@ -51,7 +50,7 @@ object HelloBackButtonWorkflow : StatefulWorkflow<Unit, State, Nothing, Renderin
   override fun render(
     props: Unit,
     state: State,
-    context: RenderContext<Unit, State, Nothing>
+    context: RenderContext
   ): Rendering {
     return Rendering(
         message = "$state",

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemWorkflow.kt
@@ -58,7 +58,7 @@ object PoemWorkflow : StatefulWorkflow<Poem, Int, ClosePoem, OverviewDetailScree
   override fun render(
     props: Poem,
     state: Int,
-    context: RenderContext<Poem, Int, ClosePoem>
+    context: RenderContext
   ): OverviewDetailScreen {
     val previousStanzas: List<StanzaRendering> =
       if (state == -1) emptyList()

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
@@ -29,7 +29,7 @@ object StanzaListWorkflow : StatelessWorkflow<Poem, Int, StanzaListRendering>() 
 
   override fun render(
     props: Poem,
-    context: RenderContext<Poem, Nothing, Int>
+    context: RenderContext
   ): StanzaListRendering {
     // A sink that emits the given index as the result of this workflow.
     val sink = context.makeEventSink { index: Int -> setOutput(index) }

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
@@ -42,7 +42,7 @@ object StanzaWorkflow : StatelessWorkflow<Props, Output, StanzaRendering>() {
 
   override fun render(
     props: Props,
-    context: RenderContext<Props, Nothing, Output>
+    context: RenderContext
   ): StanzaRendering {
     with(props) {
       val sink: Sink<Output> = context.makeEventSink { setOutput(it) }

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
@@ -21,7 +21,6 @@ import com.squareup.sample.dungeon.DungeonAppWorkflow.State.ChoosingBoard
 import com.squareup.sample.dungeon.DungeonAppWorkflow.State.LoadingBoardList
 import com.squareup.sample.dungeon.DungeonAppWorkflow.State.PlayingGame
 import com.squareup.sample.dungeon.board.Board
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.action
@@ -57,7 +56,7 @@ class DungeonAppWorkflow(
   override fun render(
     props: Props,
     state: State,
-    context: RenderContext<Props, State, Nothing>
+    context: RenderContext
   ): AlertContainerScreen<Any> = when (state) {
 
     LoadingBoardList -> {

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameSessionWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameSessionWorkflow.kt
@@ -24,7 +24,6 @@ import com.squareup.sample.dungeon.GameSessionWorkflow.State.Running
 import com.squareup.sample.dungeon.GameWorkflow.Output.PlayerWasEaten
 import com.squareup.sample.dungeon.GameWorkflow.Output.Vibrate
 import com.squareup.sample.dungeon.board.Board
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction
@@ -68,7 +67,7 @@ class GameSessionWorkflow(
   override fun render(
     props: Props,
     state: State,
-    context: RenderContext<Props, State, Nothing>
+    context: RenderContext
   ): AlertContainerScreen<Any> = when (state) {
 
     Loading -> {

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/TimeMachineAppWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/TimeMachineAppWorkflow.kt
@@ -21,7 +21,6 @@ import com.squareup.sample.timemachine.TimeMachineWorkflow
 import com.squareup.sample.timemachine.shakeable.ShakeableTimeMachineRendering
 import com.squareup.sample.timemachine.shakeable.ShakeableTimeMachineWorkflow
 import com.squareup.sample.timemachine.shakeable.ShakeableTimeMachineWorkflow.PropsFactory
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.StatelessWorkflow
 import com.squareup.workflow1.renderChild
 import kotlin.time.ExperimentalTime
@@ -43,7 +42,7 @@ class TimeMachineAppWorkflow(
 
   override fun render(
     props: BoardPath,
-    context: RenderContext<BoardPath, Nothing, Nothing>
+    context: RenderContext
   ): ShakeableTimeMachineRendering {
     val propsFactory = PropsFactory { recording ->
       Props(paused = !recording)

--- a/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/AiWorkflow.kt
+++ b/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/AiWorkflow.kt
@@ -23,7 +23,6 @@ import com.squareup.sample.dungeon.Direction.LEFT
 import com.squareup.sample.dungeon.Direction.RIGHT
 import com.squareup.sample.dungeon.Direction.UP
 import com.squareup.sample.dungeon.board.BoardCell
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.Worker
@@ -68,7 +67,7 @@ class AiWorkflow(
   override fun render(
     props: ActorProps,
     state: State,
-    context: RenderContext<ActorProps, State, Nothing>
+    context: RenderContext
   ): ActorRendering {
     context.runningWorker(state.directionTicker) { updateDirection }
 

--- a/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/GameWorkflow.kt
+++ b/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/GameWorkflow.kt
@@ -106,7 +106,7 @@ class GameWorkflow(
   override fun render(
     props: Props,
     state: State,
-    context: RenderContext<Props, State, Output>
+    context: RenderContext
   ): GameRendering {
     val running = !props.paused && !state.game.isPlayerEaten
     // Stop actors from ticking if the game is paused or finished.

--- a/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/PlayerWorkflow.kt
+++ b/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/PlayerWorkflow.kt
@@ -64,7 +64,7 @@ class PlayerWorkflow(
   override fun render(
     props: ActorProps,
     state: Movement,
-    context: RenderContext<ActorProps, Movement, Nothing>
+    context: RenderContext
   ): Rendering = Rendering(
       actorRendering = ActorRendering(avatar = avatar, movement = state),
       onStartMoving = { context.actionSink.send(StartMoving(it)) },

--- a/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineWorkflow.kt
+++ b/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineWorkflow.kt
@@ -22,7 +22,6 @@ import com.squareup.sample.timemachine.shakeable.ShakeableTimeMachineWorkflow.Pr
 import com.squareup.sample.timemachine.shakeable.ShakeableTimeMachineWorkflow.State
 import com.squareup.sample.timemachine.shakeable.ShakeableTimeMachineWorkflow.State.PlayingBack
 import com.squareup.sample.timemachine.shakeable.ShakeableTimeMachineWorkflow.State.Recording
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction
@@ -70,7 +69,7 @@ class ShakeableTimeMachineWorkflow<in P, O : Any, out R : Any>(
   override fun render(
     props: PropsFactory<P>,
     state: State,
-    context: RenderContext<PropsFactory<P>, State, O>
+    context: RenderContext
   ): ShakeableTimeMachineRendering {
     // Only listen to shakes when recording.
     if (state === Recording) context.runningWorker(shakeWorker) { onShake }

--- a/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/RecorderWorkflow.kt
+++ b/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/RecorderWorkflow.kt
@@ -19,7 +19,6 @@ import com.squareup.sample.timemachine.RecorderWorkflow.RecorderProps
 import com.squareup.sample.timemachine.RecorderWorkflow.RecorderProps.PlaybackAt
 import com.squareup.sample.timemachine.RecorderWorkflow.RecorderProps.RecordValue
 import com.squareup.sample.timemachine.RecorderWorkflow.Recording
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import kotlin.time.Duration
@@ -92,7 +91,7 @@ internal class RecorderWorkflow<T>(
   override fun render(
     props: RecorderProps<T>,
     state: Recording<T>,
-    context: RenderContext<RecorderProps<T>, Recording<T>, Nothing>
+    context: RenderContext
   ): TimeMachineRendering<T> {
     val value = when (props) {
       is RecordValue -> props.value

--- a/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/TimeMachineWorkflow.kt
+++ b/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/TimeMachineWorkflow.kt
@@ -84,7 +84,7 @@ class TimeMachineWorkflow<P, O : Any, out R>(
 
   override fun render(
     props: TimeMachineProps<P>,
-    context: RenderContext<TimeMachineProps<P>, Nothing, O>
+    context: RenderContext
   ): TimeMachineRendering<R> {
     // Always render the delegate, even if in playback mode, to keep it alive.
     val delegateRendering =

--- a/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
+++ b/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.sample.helloterminal
 
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.Worker
@@ -51,7 +50,7 @@ class BlinkingCursorWorkflow(
   override fun render(
     props: Unit,
     state: Boolean,
-    context: RenderContext<Unit, Boolean, Nothing>
+    context: RenderContext
   ): String {
     context.runningWorker(intervalWorker) { setCursorShowing(it) }
     return if (state) cursorString else ""

--- a/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/HelloTerminalWorkflow.kt
+++ b/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/HelloTerminalWorkflow.kt
@@ -23,7 +23,6 @@ import com.squareup.sample.helloterminal.terminalworkflow.TerminalProps
 import com.squareup.sample.helloterminal.terminalworkflow.TerminalRendering
 import com.squareup.sample.helloterminal.terminalworkflow.TerminalRendering.Color.GREEN
 import com.squareup.sample.helloterminal.terminalworkflow.TerminalWorkflow
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction
@@ -53,7 +52,7 @@ class HelloTerminalWorkflow : TerminalWorkflow,
   override fun render(
     props: TerminalProps,
     state: State,
-    context: RenderContext<TerminalProps, State, ExitCode>
+    context: RenderContext
   ): TerminalRendering {
     val (rows, columns) = props.size
     val header = """

--- a/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
+++ b/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
@@ -8,7 +8,6 @@ import com.squareup.sample.helloterminal.terminalworkflow.KeyStroke.KeyType.Char
 import com.squareup.sample.helloterminal.terminalworkflow.TerminalProps
 import com.squareup.sample.hellotodo.EditTextWorkflow.EditTextProps
 import com.squareup.sample.hellotodo.EditTextWorkflow.EditTextState
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.action
@@ -48,7 +47,7 @@ class EditTextWorkflow : StatefulWorkflow<EditTextProps, EditTextState, String, 
   override fun render(
     props: EditTextProps,
     state: EditTextState,
-    context: RenderContext<EditTextProps, EditTextState, String>
+    context: RenderContext
   ): String {
     context.runningWorker(props.terminalProps.keyStrokes) { key -> onKeystroke(props, key) }
 

--- a/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/TodoWorkflow.kt
+++ b/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/TodoWorkflow.kt
@@ -26,7 +26,7 @@ import com.squareup.sample.helloterminal.terminalworkflow.TerminalWorkflow
 import com.squareup.sample.hellotodo.EditTextWorkflow.EditTextProps
 import com.squareup.sample.hellotodo.TodoWorkflow.TodoList
 import com.squareup.sample.hellotodo.TodoWorkflow.TodoList.Companion.TITLE_FIELD_INDEX
-import com.squareup.workflow1.RenderContext
+import com.squareup.workflow1.BaseRenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction
@@ -76,14 +76,14 @@ class TodoWorkflow : TerminalWorkflow,
   override fun render(
     props: TerminalProps,
     state: TodoList,
-    context: RenderContext<TerminalProps, TodoList, ExitCode>
+    context: RenderContext
   ): TerminalRendering {
 
     context.runningWorker(props.keyStrokes) { onKeystroke(it) }
 
     return TerminalRendering(buildString {
       @Suppress("UNCHECKED_CAST")
-      appendln(state.renderTitle(props, context as RenderContext<TerminalProps, TodoList, Nothing>))
+      appendln(state.renderTitle(props, context))
       appendln(renderSelection(state.titleSeparator, false))
       appendln(state.renderItems(props, context))
     })
@@ -118,7 +118,7 @@ private fun setLabel(
 
 private fun TodoList.renderTitle(
   props: TerminalProps,
-  context: RenderContext<TerminalProps, TodoList, Nothing>
+  context: BaseRenderContext<TerminalProps, TodoList, *>
 ): String {
   val isSelected = focusedField == TITLE_FIELD_INDEX
   val titleString = if (isSelected) {
@@ -137,7 +137,7 @@ private val TodoList.titleSeparator get() = "–".repeat(title.length + 1)
 
 private fun TodoList.renderItems(
   props: TerminalProps,
-  context: RenderContext<TerminalProps, TodoList, Nothing>
+  context: BaseRenderContext<TerminalProps, TodoList, *>
 ): String =
   items
       .mapIndexed { index, item ->

--- a/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
+++ b/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
@@ -19,7 +19,6 @@ import com.squareup.sample.helloworkflowfragment.HelloWorkflow.Rendering
 import com.squareup.sample.helloworkflowfragment.HelloWorkflow.State
 import com.squareup.sample.helloworkflowfragment.HelloWorkflow.State.Goodbye
 import com.squareup.sample.helloworkflowfragment.HelloWorkflow.State.Hello
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.action
@@ -45,7 +44,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
   override fun render(
     props: Unit,
     state: State,
-    context: RenderContext<Unit, State, Nothing>
+    context: RenderContext
   ): Rendering {
     return Rendering(
         message = state.name,

--- a/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
+++ b/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
@@ -19,7 +19,6 @@ import com.squareup.sample.helloworkflow.HelloWorkflow.Rendering
 import com.squareup.sample.helloworkflow.HelloWorkflow.State
 import com.squareup.sample.helloworkflow.HelloWorkflow.State.Goodbye
 import com.squareup.sample.helloworkflow.HelloWorkflow.State.Hello
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.action
@@ -45,7 +44,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
   override fun render(
     props: Unit,
     state: State,
-    context: RenderContext<Unit, State, Nothing>
+    context: RenderContext
   ): Rendering {
     return Rendering(
         message = state.name,

--- a/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/AppWorkflow.kt
+++ b/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/AppWorkflow.kt
@@ -28,7 +28,6 @@ import com.squareup.sample.recyclerview.inputrows.DropdownInputRow
 import com.squareup.sample.recyclerview.inputrows.InputRow
 import com.squareup.sample.recyclerview.inputrows.SwitchInputRow
 import com.squareup.sample.recyclerview.inputrows.TextInputRow
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction
@@ -96,7 +95,7 @@ object AppWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
   override fun render(
     props: Unit,
     state: State,
-    context: RenderContext<Unit, State, Nothing>
+    context: RenderContext
   ): Rendering {
     val listRendering = context.renderChild(EditableListWorkflow, Props(state.rows))
     val baseScreen = BaseScreen(

--- a/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/editablelistworkflow/EditableListWorkflow.kt
+++ b/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/editablelistworkflow/EditableListWorkflow.kt
@@ -19,7 +19,6 @@ import com.squareup.sample.recyclerview.editablelistworkflow.EditableListWorkflo
 import com.squareup.sample.recyclerview.editablelistworkflow.EditableListWorkflow.Rendering
 import com.squareup.sample.recyclerview.editablelistworkflow.EditableListWorkflow.State
 import com.squareup.sample.recyclerview.inputrows.InputRow
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.action
@@ -61,7 +60,7 @@ object EditableListWorkflow : StatefulWorkflow<Props, State, Nothing, Rendering>
   override fun render(
     props: Props,
     state: State,
-    context: RenderContext<Props, State, Nothing>
+    context: RenderContext
   ): Rendering {
     return Rendering(
         rowValues = state.rowValues,

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
@@ -150,7 +150,7 @@ class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
   override fun render(
     props: Unit,
     state: AuthState,
-    context: RenderContext<Unit, AuthState, AuthResult>
+    context: RenderContext
   ): BackStackScreen<Any> = when (state) {
     is LoginPrompt -> {
       BackStackScreen(

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
@@ -40,7 +40,6 @@ import com.squareup.sample.gameworkflow.RunGameState.Playing
 import com.squareup.sample.gameworkflow.SyncState.SAVED
 import com.squareup.sample.gameworkflow.SyncState.SAVE_FAILED
 import com.squareup.sample.gameworkflow.SyncState.SAVING
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.Workflow
@@ -182,7 +181,7 @@ class RealRunGameWorkflow(
   override fun render(
     props: Unit,
     state: RunGameState,
-    context: RenderContext<Unit, RunGameState, RunGameResult>
+    context: RenderContext
   ): RunGameScreen = when (state) {
     is NewGame -> {
       val emptyGameScreen = GamePlayScreen()

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
@@ -20,7 +20,6 @@ import com.squareup.sample.gameworkflow.Ending.Quitted
 import com.squareup.sample.gameworkflow.Ending.Victory
 import com.squareup.sample.gameworkflow.RealTakeTurnsWorkflow.Action.Quit
 import com.squareup.sample.gameworkflow.RealTakeTurnsWorkflow.Action.TakeSquare
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.Workflow
@@ -86,7 +85,7 @@ class RealTakeTurnsWorkflow : TakeTurnsWorkflow,
   override fun render(
     props: TakeTurnsProps,
     state: Turn,
-    context: RenderContext<TakeTurnsProps, Turn, CompletedGame>
+    context: RenderContext
   ): GamePlayScreen = GamePlayScreen(
       playerInfo = props.playerInfo,
       gameState = state,

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainWorkflow.kt
@@ -28,7 +28,6 @@ import com.squareup.sample.gameworkflow.RunGameScreen
 import com.squareup.sample.gameworkflow.RunGameWorkflow
 import com.squareup.sample.mainworkflow.MainState.Authenticating
 import com.squareup.sample.mainworkflow.MainState.RunningGame
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.Workflow
@@ -67,7 +66,7 @@ class MainWorkflow(
   override fun render(
     props: Unit,
     state: MainState,
-    context: RenderContext<Unit, MainState, Unit>
+    context: RenderContext
   ): RunGameScreen = when (state) {
     is Authenticating -> {
       val authScreen = context.renderChild(authWorkflow) { handleAuthResult(it) }

--- a/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
+++ b/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
@@ -22,7 +22,6 @@ import com.squareup.sample.todo.TodoAction.ListAction.TextChanged
 import com.squareup.sample.todo.TodoAction.ListAction.TitleChanged
 import com.squareup.sample.todo.TodoEditorOutput.Done
 import com.squareup.sample.todo.TodoEditorOutput.ListUpdated
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Sink
 import com.squareup.workflow1.StatelessWorkflow
 import com.squareup.workflow1.WorkflowAction
@@ -95,7 +94,7 @@ class TodoEditorWorkflow : StatelessWorkflow<TodoList, TodoEditorOutput, TodoRen
 
   override fun render(
     props: TodoList,
-    context: RenderContext<TodoList, Nothing, TodoEditorOutput>
+    context: RenderContext
   ): TodoRendering {
     // Make event handling idempotent until https://github.com/square/workflow/issues/541 is fixed.
     var eventFired = false

--- a/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
+++ b/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
@@ -21,7 +21,6 @@ import com.squareup.sample.todo.TodoEditorOutput.ListUpdated
 import com.squareup.sample.todo.TodoListsAppState.EditingList
 import com.squareup.sample.todo.TodoListsAppState.ShowingLists
 import com.squareup.sample.todo.TodoListsAppWorkflow.render
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction
@@ -82,7 +81,7 @@ object TodoListsAppWorkflow :
   override fun render(
     props: Unit,
     state: TodoListsAppState,
-    context: RenderContext<Unit, TodoListsAppState, Nothing>
+    context: RenderContext
   ): OverviewDetailScreen {
     val listOfLists: TodoListsScreen = context.renderChild(
         listsWorkflow,

--- a/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
+++ b/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.sample.todo
 
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Sink
 import com.squareup.workflow1.StatelessWorkflow
 import com.squareup.workflow1.makeEventSink
@@ -23,7 +22,7 @@ import com.squareup.workflow1.makeEventSink
 class TodoListsWorkflow : StatelessWorkflow<List<TodoList>, Int, TodoListsScreen>() {
   override fun render(
     props: List<TodoList>,
-    context: RenderContext<List<TodoList>, Nothing, Int>
+    context: RenderContext
   ): TodoListsScreen {
     // A sink that emits the given index as the output of this workflow.
     val sink: Sink<Int> = context.makeEventSink { index: Int -> setOutput(index) }

--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -1,3 +1,17 @@
+public abstract interface class com/squareup/workflow1/BaseRenderContext {
+	public abstract fun getActionSink ()Lcom/squareup/workflow1/Sink;
+	public abstract fun makeActionSink ()Lcom/squareup/workflow1/Sink;
+	public abstract fun onEvent (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+	public abstract fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public abstract fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class com/squareup/workflow1/BaseRenderContext$DefaultImpls {
+	public static fun makeActionSink (Lcom/squareup/workflow1/BaseRenderContext;)Lcom/squareup/workflow1/Sink;
+	public static fun onEvent (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+	public static synthetic fun renderChild$default (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class com/squareup/workflow1/EventHandler : kotlin/jvm/functions/Function1 {
 	public fun <init> (Lkotlin/jvm/functions/Function1;)V
 	public fun equals (Ljava/lang/Object;)Z
@@ -25,20 +39,6 @@ public abstract class com/squareup/workflow1/LifecycleWorker : com/squareup/work
 	public fun onStarted ()V
 	public fun onStopped ()V
 	public final fun run ()Lkotlinx/coroutines/flow/Flow;
-}
-
-public abstract interface class com/squareup/workflow1/RenderContext {
-	public abstract fun getActionSink ()Lcom/squareup/workflow1/Sink;
-	public abstract fun makeActionSink ()Lcom/squareup/workflow1/Sink;
-	public abstract fun onEvent (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
-	public abstract fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public abstract fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-}
-
-public final class com/squareup/workflow1/RenderContext$DefaultImpls {
-	public static fun makeActionSink (Lcom/squareup/workflow1/RenderContext;)Lcom/squareup/workflow1/Sink;
-	public static fun onEvent (Lcom/squareup/workflow1/RenderContext;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
-	public static synthetic fun renderChild$default (Lcom/squareup/workflow1/RenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/squareup/workflow1/Sink {
@@ -93,14 +93,30 @@ public abstract class com/squareup/workflow1/StatefulWorkflow : com/squareup/wor
 	public final fun asStatefulWorkflow ()Lcom/squareup/workflow1/StatefulWorkflow;
 	public abstract fun initialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;)Ljava/lang/Object;
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun render (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/RenderContext;)Ljava/lang/Object;
+	public abstract fun render (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/StatefulWorkflow$RenderContext;)Ljava/lang/Object;
 	public abstract fun snapshotState (Ljava/lang/Object;)Lcom/squareup/workflow1/Snapshot;
+}
+
+public final class com/squareup/workflow1/StatefulWorkflow$RenderContext : com/squareup/workflow1/BaseRenderContext {
+	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
+	public fun makeActionSink ()Lcom/squareup/workflow1/Sink;
+	public fun onEvent (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+	public fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract class com/squareup/workflow1/StatelessWorkflow : com/squareup/workflow1/Workflow {
 	public fun <init> ()V
 	public final fun asStatefulWorkflow ()Lcom/squareup/workflow1/StatefulWorkflow;
-	public abstract fun render (Ljava/lang/Object;Lcom/squareup/workflow1/RenderContext;)Ljava/lang/Object;
+	public abstract fun render (Ljava/lang/Object;Lcom/squareup/workflow1/StatelessWorkflow$RenderContext;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow1/StatelessWorkflow$RenderContext : com/squareup/workflow1/BaseRenderContext {
+	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
+	public fun makeActionSink ()Lcom/squareup/workflow1/Sink;
+	public fun onEvent (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+	public fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/squareup/workflow1/TypedWorker : com/squareup/workflow1/Worker {
@@ -197,6 +213,8 @@ public final class com/squareup/workflow1/WorkflowOutput {
 }
 
 public final class com/squareup/workflow1/Workflows {
+	public static final fun RenderContext (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/StatefulWorkflow;)Lcom/squareup/workflow1/StatefulWorkflow$RenderContext;
+	public static final fun RenderContext (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/StatelessWorkflow;)Lcom/squareup/workflow1/StatelessWorkflow$RenderContext;
 	public static final fun action (Lcom/squareup/workflow1/StatefulWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lcom/squareup/workflow1/StatefulWorkflow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lcom/squareup/workflow1/StatelessWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
@@ -212,18 +230,18 @@ public final class com/squareup/workflow1/Workflows {
 	public static final fun getIdentifier (Lcom/squareup/workflow1/Workflow;)Lcom/squareup/workflow1/WorkflowIdentifier;
 	public static final fun getWorkflowIdentifier (Lkotlin/reflect/KClass;)Lcom/squareup/workflow1/WorkflowIdentifier;
 	public static final fun invoke (Lcom/squareup/workflow1/EventHandler;)V
-	public static final fun makeEventSink (Lcom/squareup/workflow1/RenderContext;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow1/Sink;
+	public static final fun makeEventSink (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow1/Sink;
 	public static final fun mapRendering (Lcom/squareup/workflow1/Workflow;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/Workflow;
-	public static final fun renderChild (Lcom/squareup/workflow1/RenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;
-	public static final fun renderChild (Lcom/squareup/workflow1/RenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/String;)Ljava/lang/Object;
-	public static final fun renderChild (Lcom/squareup/workflow1/RenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static synthetic fun renderChild$default (Lcom/squareup/workflow1/RenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun renderChild$default (Lcom/squareup/workflow1/RenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun renderChild$default (Lcom/squareup/workflow1/RenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun renderChild (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;
+	public static final fun renderChild (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/String;)Ljava/lang/Object;
+	public static final fun renderChild (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun renderChild$default (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun renderChild$default (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun renderChild$default (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun rendering (Lcom/squareup/workflow1/Workflow$Companion;Ljava/lang/Object;)Lcom/squareup/workflow1/Workflow;
-	public static final fun runningWorker (Lcom/squareup/workflow1/RenderContext;Lcom/squareup/workflow1/Worker;Ljava/lang/String;)V
-	public static final fun runningWorker (Lcom/squareup/workflow1/RenderContext;Lcom/squareup/workflow1/Worker;Lkotlin/reflect/KType;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun runningWorker$default (Lcom/squareup/workflow1/RenderContext;Lcom/squareup/workflow1/Worker;Ljava/lang/String;ILjava/lang/Object;)V
+	public static final fun runningWorker (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Worker;Ljava/lang/String;)V
+	public static final fun runningWorker (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Worker;Lkotlin/reflect/KType;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun runningWorker$default (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Worker;Ljava/lang/String;ILjava/lang/Object;)V
 	public static final fun sendAndAwaitApplication (Lcom/squareup/workflow1/Sink;Lcom/squareup/workflow1/WorkflowAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun stateful (Lcom/squareup/workflow1/Workflow$Companion;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow1/StatefulWorkflow;
 	public static final fun stateful (Lcom/squareup/workflow1/Workflow$Companion;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/StatefulWorkflow;

--- a/workflow-core/src/main/java/com/squareup/workflow1/RenderContext.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/RenderContext.kt
@@ -55,7 +55,7 @@ import kotlin.reflect.typeOf
  *
  * See [renderChild].
  */
-interface RenderContext<out PropsT, StateT, in OutputT> {
+interface BaseRenderContext<out PropsT, StateT, in OutputT> {
 
   /**
    * Accepts a single [WorkflowAction], invokes that action by calling [WorkflowAction.apply]
@@ -142,7 +142,7 @@ interface RenderContext<out PropsT, StateT, in OutputT> {
  */
 /* ktlint-disable parameter-list-wrapping */
 fun <PropsT, StateT, OutputT, ChildOutputT, ChildRenderingT>
-    RenderContext<PropsT, StateT, OutputT>.renderChild(
+    BaseRenderContext<PropsT, StateT, OutputT>.renderChild(
   child: Workflow<Unit, ChildOutputT, ChildRenderingT>,
   key: String = "",
   handler: (ChildOutputT) -> WorkflowAction<PropsT, StateT, OutputT>
@@ -154,7 +154,7 @@ fun <PropsT, StateT, OutputT, ChildOutputT, ChildRenderingT>
  */
 /* ktlint-disable parameter-list-wrapping */
 fun <PropsT, ChildPropsT, StateT, OutputT, ChildRenderingT>
-    RenderContext<PropsT, StateT, OutputT>.renderChild(
+    BaseRenderContext<PropsT, StateT, OutputT>.renderChild(
   child: Workflow<ChildPropsT, Nothing, ChildRenderingT>,
   props: ChildPropsT,
   key: String = ""
@@ -167,7 +167,7 @@ fun <PropsT, ChildPropsT, StateT, OutputT, ChildRenderingT>
  */
 /* ktlint-disable parameter-list-wrapping */
 fun <PropsT, StateT, OutputT, ChildRenderingT>
-    RenderContext<PropsT, StateT, OutputT>.renderChild(
+    BaseRenderContext<PropsT, StateT, OutputT>.renderChild(
   child: Workflow<Unit, Nothing, ChildRenderingT>,
   key: String = ""
 ): ChildRenderingT = renderChild(child, Unit, key) { noAction() }
@@ -181,7 +181,7 @@ fun <PropsT, StateT, OutputT, ChildRenderingT>
  *
  * @param key An optional string key that is used to distinguish between identical [Worker]s.
  */
-fun <PropsT, StateT, OutputT> RenderContext<PropsT, StateT, OutputT>.runningWorker(
+fun <PropsT, StateT, OutputT> BaseRenderContext<PropsT, StateT, OutputT>.runningWorker(
   worker: Worker<Nothing>,
   key: String = ""
 ) {
@@ -209,7 +209,7 @@ fun <PropsT, StateT, OutputT> RenderContext<PropsT, StateT, OutputT>.runningWork
 @OptIn(ExperimentalStdlibApi::class)
 /* ktlint-disable parameter-list-wrapping */
 inline fun <T, reified W : Worker<T>, PropsT, StateT, OutputT>
-    RenderContext<PropsT, StateT, OutputT>.runningWorker(
+    BaseRenderContext<PropsT, StateT, OutputT>.runningWorker(
   worker: W,
   key: String = "",
   noinline handler: (T) -> WorkflowAction<PropsT, StateT, OutputT>
@@ -230,7 +230,7 @@ inline fun <T, reified W : Worker<T>, PropsT, StateT, OutputT>
 @PublishedApi
 /* ktlint-disable parameter-list-wrapping */
 internal fun <T, PropsT, StateT, OutputT>
-    RenderContext<PropsT, StateT, OutputT>.runningWorker(
+    BaseRenderContext<PropsT, StateT, OutputT>.runningWorker(
   worker: Worker<T>,
   workerType: KType,
   key: String = "",
@@ -245,7 +245,7 @@ internal fun <T, PropsT, StateT, OutputT>
  * Alternative to [RenderContext.actionSink] that allows externally defined
  * event types to be mapped to anonymous [WorkflowAction]s.
  */
-fun <EventT, PropsT, StateT, OutputT> RenderContext<PropsT, StateT, OutputT>.makeEventSink(
+fun <EventT, PropsT, StateT, OutputT> BaseRenderContext<PropsT, StateT, OutputT>.makeEventSink(
   update: Updater<Any?, StateT, OutputT>.(EventT) -> Unit
 ): Sink<EventT> = actionSink.contraMap { event ->
   action({ "eventSink($event)" }) { update(event) }
@@ -262,7 +262,7 @@ fun <EventT, PropsT, StateT, OutputT> RenderContext<PropsT, StateT, OutputT>.mak
     "Use runningWorker",
     ReplaceWith("runningWorker(worker, key, handler)", "com.squareup.workflow1.runningWorker")
 )
-inline fun <PropsT, StateT, OutputT, reified T> RenderContext<PropsT, StateT, OutputT>.onWorkerOutput(
+inline fun <PropsT, StateT, OutputT, reified T> BaseRenderContext<PropsT, StateT, OutputT>.onWorkerOutput(
   worker: Worker<T>,
   key: String = "",
   noinline handler: (T) -> WorkflowAction<PropsT, StateT, OutputT>

--- a/workflow-core/src/main/java/com/squareup/workflow1/WorkerWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/WorkerWorkflow.kt
@@ -66,7 +66,7 @@ internal class WorkerWorkflow<OutputT>(
   override fun render(
     props: Worker<OutputT>,
     state: Int,
-    context: RenderContext<Worker<OutputT>, Int, OutputT>
+    context: RenderContext
   ) {
     // Scope the side effect coroutine to the state value, so the worker will be re-started when
     // it changes (such that doesSameWorkAs returns false above).

--- a/workflow-core/src/main/java/com/squareup/workflow1/Workflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/Workflow.kt
@@ -138,7 +138,7 @@ fun <PropsT, OutputT, FromRenderingT, ToRenderingT>
 
     override fun render(
       props: PropsT,
-      context: RenderContext<PropsT, Nothing, OutputT>
+      context: RenderContext
     ): ToRenderingT {
       val rendering = context.renderChild(this@mapRendering, props) { output ->
         action({ "mapRendering" }) { setOutput(output) }

--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -2,7 +2,7 @@ public final class com/squareup/workflow1/NoopWorkflowInterceptor : com/squareup
 	public static final field INSTANCE Lcom/squareup/workflow1/NoopWorkflowInterceptor;
 	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
-	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/RenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)V
 	public fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/Snapshot;
 }
@@ -32,7 +32,7 @@ public class com/squareup/workflow1/SimpleLoggingWorkflowInterceptor : com/squar
 	protected fun logEnd (Ljava/lang/String;)V
 	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
-	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/RenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)V
 	public fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/Snapshot;
 }
@@ -53,7 +53,7 @@ public final class com/squareup/workflow1/TreeSnapshot$Companion {
 public abstract interface class com/squareup/workflow1/WorkflowInterceptor {
 	public abstract fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public abstract fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
-	public abstract fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/RenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public abstract fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public abstract fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)V
 	public abstract fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/Snapshot;
 }
@@ -61,7 +61,7 @@ public abstract interface class com/squareup/workflow1/WorkflowInterceptor {
 public final class com/squareup/workflow1/WorkflowInterceptor$DefaultImpls {
 	public static fun onInitialState (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public static fun onPropsChanged (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
-	public static fun onRender (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/RenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public static fun onRender (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public static fun onSessionStarted (Lcom/squareup/workflow1/WorkflowInterceptor;Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)V
 	public static fun onSnapshotState (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/Snapshot;
 }

--- a/workflow-runtime/src/jmh/java/com/squareup/workflow1/WorkflowNodeBenchmark.kt
+++ b/workflow-runtime/src/jmh/java/com/squareup/workflow1/WorkflowNodeBenchmark.kt
@@ -164,7 +164,7 @@ private class FractalWorkflow(
   override fun render(
     props: Props,
     state: Unit,
-    context: RenderContext<Props, Unit, Nothing>
+    context: RenderContext
   ) {
     if (childWorkflow != null && (props.renderLeaves || !areChildrenLeaves)) {
       for (i in 0 until childCount) {

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/SimpleLoggingWorkflowInterceptor.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/SimpleLoggingWorkflowInterceptor.kt
@@ -56,8 +56,8 @@ open class SimpleLoggingWorkflowInterceptor : WorkflowInterceptor {
   override fun <P, S, O, R> onRender(
     props: P,
     state: S,
-    context: RenderContext<P, S, O>,
-    proceed: (P, S, RenderContext<P, S, O>) -> R,
+    context: BaseRenderContext<P, S, O>,
+    proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
     session: WorkflowSession
   ): R = logMethod("onRender", props, state, session) {
     proceed(props, state, context)

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/WorkflowInterceptor.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/WorkflowInterceptor.kt
@@ -96,8 +96,8 @@ interface WorkflowInterceptor {
   fun <P, S, O, R> onRender(
     props: P,
     state: S,
-    context: RenderContext<P, S, O>,
-    proceed: (P, S, RenderContext<P, S, O>) -> R,
+    context: BaseRenderContext<P, S, O>,
+    proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
     session: WorkflowSession
   ): R = proceed(props, state, context)
 
@@ -167,8 +167,12 @@ internal fun <P, S, O, R> WorkflowInterceptor.intercept(
     override fun render(
       props: P,
       state: S,
-      context: RenderContext<P, S, O>
-    ): R = onRender(props, state, context, workflow::render, workflowSession)
+      context: RenderContext
+    ): R = onRender(
+        props, state, context,
+        proceed = { p, s, c -> workflow.render(p, s, RenderContext(c, this)) },
+        session = workflowSession
+    )
 
     override fun snapshotState(state: S) =
       onSnapshotState(state, workflow::snapshotState, workflowSession)

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/internal/ChainedWorkflowInterceptor.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/internal/ChainedWorkflowInterceptor.kt
@@ -15,11 +15,11 @@
  */
 package com.squareup.workflow1.internal
 
+import com.squareup.workflow1.BaseRenderContext
 import com.squareup.workflow1.ExperimentalWorkflowApi
-import com.squareup.workflow1.RenderContext
+import com.squareup.workflow1.NoopWorkflowInterceptor
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.WorkflowInterceptor
-import com.squareup.workflow1.NoopWorkflowInterceptor
 import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
 import kotlinx.coroutines.CoroutineScope
 
@@ -75,8 +75,8 @@ internal class ChainedWorkflowInterceptor(
   override fun <P, S, O, R> onRender(
     props: P,
     state: S,
-    context: RenderContext<P, S, O>,
-    proceed: (P, S, RenderContext<P, S, O>) -> R,
+    context: BaseRenderContext<P, S, O>,
+    proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
     session: WorkflowSession
   ): R {
     val chainedProceed = interceptors.foldRight(proceed) { workflowInterceptor, proceedAcc ->

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/internal/RealRenderContext.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/internal/RealRenderContext.kt
@@ -17,7 +17,7 @@
 
 package com.squareup.workflow1.internal
 
-import com.squareup.workflow1.RenderContext
+import com.squareup.workflow1.BaseRenderContext
 import com.squareup.workflow1.Sink
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
@@ -27,7 +27,7 @@ internal class RealRenderContext<out PropsT, StateT, OutputT>(
   private val renderer: Renderer<PropsT, StateT, OutputT>,
   private val sideEffectRunner: SideEffectRunner,
   private val eventActionsChannel: SendChannel<WorkflowAction<PropsT, StateT, OutputT>>
-) : RenderContext<PropsT, StateT, OutputT>, Sink<WorkflowAction<PropsT, StateT, OutputT>> {
+) : BaseRenderContext<PropsT, StateT, OutputT>, Sink<WorkflowAction<PropsT, StateT, OutputT>> {
 
   interface Renderer<PropsT, StateT, OutputT> {
     fun <ChildPropsT, ChildOutputT, ChildRenderingT> render(

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/internal/WorkflowNode.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/internal/WorkflowNode.kt
@@ -17,6 +17,7 @@ package com.squareup.workflow1.internal
 
 import com.squareup.workflow1.ExperimentalWorkflowApi
 import com.squareup.workflow1.NoopWorkflowInterceptor
+import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.TreeSnapshot
 import com.squareup.workflow1.Workflow
@@ -201,7 +202,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
         eventActionsChannel = eventActionsChannel
     )
     val rendering = interceptor.intercept(workflow, this)
-        .render(props, state, context)
+        .render(props, state, RenderContext(context, workflow))
     context.freeze()
 
     // Tear down workflows and workers that are obsolete.

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/WorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/WorkflowInterceptorTest.kt
@@ -57,7 +57,7 @@ class WorkflowInterceptorTest {
   @Test fun `intercept() intercepts calls to render()`() {
     val recorder = RecordingWorkflowInterceptor()
     val intercepted = recorder.intercept(TestWorkflow, TestWorkflow.session)
-    val fakeContext = object : RenderContext<String, String, String> {
+    val fakeContext = object : BaseRenderContext<String, String, String> {
       override val actionSink: Sink<WorkflowAction<String, String, String>> get() = fail()
 
       override fun <ChildPropsT, ChildOutputT, ChildRenderingT> renderChild(
@@ -73,7 +73,7 @@ class WorkflowInterceptorTest {
       ): Unit = fail()
     }
 
-    val rendering = intercepted.render("props", "state", fakeContext)
+    val rendering = intercepted.render("props", "state", RenderContext(fakeContext, TestWorkflow))
 
     assertEquals("props|state", rendering)
     assertEquals(listOf("BEGIN|onRender", "END|onRender"), recorder.consumeEventNames())
@@ -114,7 +114,7 @@ class WorkflowInterceptorTest {
     override fun render(
       props: String,
       state: String,
-      context: RenderContext<String, String, String>
+      context: RenderContext
     ): String = "$props|$state"
 
     override fun snapshotState(state: String): Snapshot = Snapshot.of(state)

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/WorkflowOperatorsTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/WorkflowOperatorsTest.kt
@@ -38,7 +38,7 @@ class WorkflowOperatorsTest {
       override fun toString(): String = "ChildWorkflow"
       override fun render(
         props: Unit,
-        context: RenderContext<Unit, Nothing, Nothing>
+        context: RenderContext
       ): Nothing = fail()
     }
     val mappedWorkflow = workflow.mapRendering { fail() }
@@ -230,7 +230,7 @@ class WorkflowOperatorsTest {
 
     override fun render(
       props: Unit,
-      context: RenderContext<Unit, Nothing, Nothing>
+      context: RenderContext
     ): T {
       // Listen to the flow to trigger a re-render when it updates.
       context.runningWorker(rerenderWorker as Worker<Any?>) { WorkflowAction.noAction() }

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
@@ -17,9 +17,9 @@
 
 package com.squareup.workflow1.internal
 
+import com.squareup.workflow1.BaseRenderContext
 import com.squareup.workflow1.ExperimentalWorkflowApi
 import com.squareup.workflow1.NoopWorkflowInterceptor
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Sink
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.Workflow
@@ -188,35 +188,35 @@ class ChainedWorkflowInterceptorTest {
       override fun <P, S, O, R> onRender(
         props: P,
         state: S,
-        context: RenderContext<P, S, O>,
-        proceed: (P, S, RenderContext<P, S, O>) -> R,
+        context: BaseRenderContext<P, S, O>,
+        proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
         session: WorkflowSession
       ): R = ("r1: " +
           proceed(
               "props1: $props" as P,
               "state1: $state" as S,
-              FakeRenderContext("context1: $context") as RenderContext<P, S, O>
+              FakeRenderContext("context1: $context") as BaseRenderContext<P, S, O>
           )) as R
     }
     val interceptor2 = object : WorkflowInterceptor {
       override fun <P, S, O, R> onRender(
         props: P,
         state: S,
-        context: RenderContext<P, S, O>,
-        proceed: (P, S, RenderContext<P, S, O>) -> R,
+        context: BaseRenderContext<P, S, O>,
+        proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
         session: WorkflowSession
       ): R = ("r2: " +
           proceed(
               "props2: $props" as P,
               "state2: $state" as S,
-              FakeRenderContext("context2: $context") as RenderContext<P, S, O>
+              FakeRenderContext("context2: $context") as BaseRenderContext<P, S, O>
           )) as R
     }
     val chained = listOf(interceptor1, interceptor2).chained()
     fun render(
       props: String,
       state: String,
-      context: RenderContext<String, String, String>
+      context: BaseRenderContext<String, String, String>
     ): String = "($props|$state|$context)"
 
     val finalRendering =
@@ -254,7 +254,9 @@ class ChainedWorkflowInterceptorTest {
 
   private fun Snapshot?.readUtf8() = this?.bytes?.parse { it.readUtf8() }
 
-  private class FakeRenderContext(private val name: String) : RenderContext<String, String, String> {
+  private class FakeRenderContext(
+    private val name: String
+  ) : BaseRenderContext<String, String, String> {
     override fun toString(): String = name
 
     override val actionSink: Sink<WorkflowAction<String, String, String>>

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/RealRenderContextTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/RealRenderContextTest.kt
@@ -88,7 +88,7 @@ class RealRenderContextTest {
     override fun render(
       props: String,
       state: String,
-      context: RenderContext<String, String, String>
+      context: RenderContext
     ): Rendering {
       fail("This shouldn't actually be called.")
     }

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/SubtreeManagerTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/SubtreeManagerTest.kt
@@ -64,7 +64,7 @@ class SubtreeManagerTest {
     override fun render(
       props: String,
       state: String,
-      context: RenderContext<String, String, String>
+      context: RenderContext
     ): Rendering {
       val sink: Sink<String> = context.makeEventSink { setOutput(it) }
       return Rendering(props, state) { sink.send("workflow output:$it") }
@@ -87,7 +87,7 @@ class SubtreeManagerTest {
     override fun render(
       props: Unit,
       state: Unit,
-      context: RenderContext<Unit, Unit, Nothing>
+      context: RenderContext
     ) {
     }
 

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -17,8 +17,8 @@
 
 package com.squareup.workflow1.internal
 
+import com.squareup.workflow1.BaseRenderContext
 import com.squareup.workflow1.ExperimentalWorkflowApi
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Sink
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
@@ -95,7 +95,7 @@ class WorkflowNodeTest {
     override fun render(
       props: String,
       state: String,
-      context: RenderContext<String, String, String>
+      context: RenderContext
     ): String {
       return """
         props:$props
@@ -175,7 +175,7 @@ class WorkflowNodeTest {
       override fun render(
         props: String,
         state: String,
-        context: RenderContext<String, String, String>
+        context: RenderContext
       ): String {
         sink = context.makeEventSink { setOutput(it) }
         return ""
@@ -213,7 +213,7 @@ class WorkflowNodeTest {
       override fun render(
         props: String,
         state: String,
-        context: RenderContext<String, String, String>
+        context: RenderContext
       ): String {
         sink = context.makeEventSink { setOutput(it) }
         return ""
@@ -253,7 +253,7 @@ class WorkflowNodeTest {
       override fun render(
         props: String,
         state: String,
-        context: RenderContext<String, String, String>
+        context: RenderContext
       ): String {
         sink = context.actionSink
         return ""
@@ -883,15 +883,15 @@ class WorkflowNodeTest {
   @Test fun `interceptor handles render()`() {
     lateinit var interceptedProps: String
     lateinit var interceptedState: String
-    lateinit var interceptedContext: RenderContext<*, *, *>
+    lateinit var interceptedContext: BaseRenderContext<*, *, *>
     lateinit var interceptedRendering: String
     lateinit var interceptedSession: WorkflowSession
     val interceptor = object : WorkflowInterceptor {
       override fun <P, S, O, R> onRender(
         props: P,
         state: S,
-        context: RenderContext<P, S, O>,
-        proceed: (P, S, RenderContext<P, S, O>) -> R,
+        context: BaseRenderContext<P, S, O>,
+        proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
         session: WorkflowSession
       ): R {
         interceptedProps = props as String
@@ -1016,8 +1016,8 @@ class WorkflowNodeTest {
       override fun <P, S, O, R> onRender(
         props: P,
         state: S,
-        context: RenderContext<P, S, O>,
-        proceed: (P, S, RenderContext<P, S, O>) -> R,
+        context: BaseRenderContext<P, S, O>,
+        proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
         session: WorkflowSession
       ): R = "[${proceed("[$props]" as P, "[$state]" as S, context)}]" as R
     }

--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -2,7 +2,7 @@ public final class com/squareup/workflow1/testing/RenderIdempotencyChecker : com
 	public static final field INSTANCE Lcom/squareup/workflow1/testing/RenderIdempotencyChecker;
 	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
-	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/RenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)V
 	public fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/Snapshot;
 }

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/RealRenderTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/RealRenderTester.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.workflow1.testing
 
+import com.squareup.workflow1.BaseRenderContext
 import com.squareup.workflow1.ExperimentalWorkflowApi
 import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Sink
@@ -51,7 +52,7 @@ internal class RealRenderTester<PropsT, StateT, OutputT, RenderingT>(
   private var childWillEmitOutput: Boolean = false,
   private var processedAction: WorkflowAction<PropsT, StateT, OutputT>? = null
 ) : RenderTester<PropsT, StateT, OutputT, RenderingT>,
-    RenderContext<PropsT, StateT, OutputT>,
+    BaseRenderContext<PropsT, StateT, OutputT>,
     RenderTestResult<PropsT, StateT, OutputT>,
     Sink<WorkflowAction<PropsT, StateT, OutputT>> {
 
@@ -111,9 +112,9 @@ internal class RealRenderTester<PropsT, StateT, OutputT, RenderingT>(
 
     // Clone the expectations to run a "dry" render pass.
     val noopContext = deepCloneForRender()
-    workflow.render(props, state, noopContext)
+    workflow.render(props, state, RenderContext(noopContext, workflow))
 
-    workflow.render(props, state, this)
+    workflow.render(props, state, RenderContext(this, workflow))
         .also(block)
 
     // Ensure all exact matches were consumed.
@@ -242,7 +243,7 @@ internal class RealRenderTester<PropsT, StateT, OutputT, RenderingT>(
     }
   }
 
-  private fun deepCloneForRender(): RenderContext<PropsT, StateT, OutputT> = RealRenderTester(
+  private fun deepCloneForRender(): BaseRenderContext<PropsT, StateT, OutputT> = RealRenderTester(
       workflow, props, state,
       // Copy the list of expectations since it's mutable.
       expectations = ArrayList(expectations),

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderIdempotencyChecker.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderIdempotencyChecker.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.workflow1.testing
 
+import com.squareup.workflow1.BaseRenderContext
 import com.squareup.workflow1.ExperimentalWorkflowApi
 import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Sink
@@ -36,8 +37,8 @@ object RenderIdempotencyChecker : WorkflowInterceptor {
   override fun <P, S, O, R> onRender(
     props: P,
     state: S,
-    context: RenderContext<P, S, O>,
-    proceed: (P, S, RenderContext<P, S, O>) -> R,
+    context: BaseRenderContext<P, S, O>,
+    proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
     session: WorkflowSession
   ): R {
     val recordingContext = RecordingRenderContext(context)
@@ -59,8 +60,8 @@ object RenderIdempotencyChecker : WorkflowInterceptor {
  * play them back over a second render pass that doesn't actually perform any actions.
  */
 private class RecordingRenderContext<PropsT, StateT, OutputT>(
-  private val delegate: RenderContext<PropsT, StateT, OutputT>
-) : RenderContext<PropsT, StateT, OutputT> {
+  private val delegate: BaseRenderContext<PropsT, StateT, OutputT>
+) : BaseRenderContext<PropsT, StateT, OutputT> {
 
   private var replaying = false
 

--- a/workflow-testing/src/test/java/com/squareup/workflow1/TreeWorkflow.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/TreeWorkflow.kt
@@ -53,7 +53,7 @@ internal class TreeWorkflow(
   override fun render(
     props: String,
     state: String,
-    context: RenderContext<String, String, Nothing>
+    context: RenderContext
   ): Rendering {
     val childRenderings = children
         .mapIndexed { index, child ->

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
@@ -487,7 +487,7 @@ class RealRenderTesterTest {
     class Child : OutputNothingChild, StatelessWorkflow<Unit, Nothing, Unit>() {
       override fun render(
         props: Unit,
-        context: RenderContext<Unit, Nothing, Nothing>
+        context: RenderContext
       ) {
         // Nothing to do.
       }
@@ -684,7 +684,7 @@ class RealRenderTesterTest {
     val child = object : OutputNothingChild, StatelessWorkflow<Unit, Nothing, Unit>() {
       override fun render(
         props: Unit,
-        context: RenderContext<Unit, Nothing, Nothing>
+        context: RenderContext
       ) {
         // Do nothing.
       }
@@ -989,7 +989,7 @@ class RealRenderTesterTest {
       override fun render(
         props: String,
         state: Double,
-        context: RenderContext<String, Double, Int>
+        context: RenderContext
       ) = throw NotImplementedError()
 
       override fun snapshotState(state: Double): Snapshot? = throw NotImplementedError()
@@ -1007,7 +1007,7 @@ class RealRenderTesterTest {
     val workflow = object : StatelessWorkflow<String, Int, Unit>() {
       override fun render(
         props: String,
-        context: RenderContext<String, Nothing, Int>
+        context: RenderContext
       ) = throw NotImplementedError()
     }
     val invocation = createRenderChildInvocation(workflow, "props", "key")
@@ -1029,7 +1029,7 @@ class RealRenderTesterTest {
       override fun render(
         props: String,
         state: Double,
-        context: RenderContext<String, Double, Int>
+        context: RenderContext
       ) = throw NotImplementedError()
 
       override fun snapshotState(state: Double): Snapshot? = throw NotImplementedError()
@@ -1049,7 +1049,7 @@ class RealRenderTesterTest {
     class TestWorkflow : StatelessWorkflow<String, Int, Unit>() {
       override fun render(
         props: String,
-        context: RenderContext<String, Nothing, Int>
+        context: RenderContext
       ) = throw NotImplementedError()
     }
 

--- a/workflow-tracing/api/workflow-tracing.api
+++ b/workflow-tracing/api/workflow-tracing.api
@@ -14,7 +14,7 @@ public final class com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInte
 	public synthetic fun <init> (Lcom/squareup/workflow1/diagnostic/tracing/MemoryStats;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
-	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/RenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)V
 	public fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/Snapshot;
 }

--- a/workflow-tracing/src/main/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptor.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptor.kt
@@ -28,8 +28,8 @@ import com.squareup.tracing.TraceEvent.ObjectCreated
 import com.squareup.tracing.TraceEvent.ObjectDestroyed
 import com.squareup.tracing.TraceEvent.ObjectSnapshot
 import com.squareup.tracing.TraceLogger
+import com.squareup.workflow1.BaseRenderContext
 import com.squareup.workflow1.ExperimentalWorkflowApi
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Sink
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.WorkflowAction
@@ -210,8 +210,8 @@ class TracingWorkflowInterceptor internal constructor(
   override fun <P, S, O, R> onRender(
     props: P,
     state: S,
-    context: RenderContext<P, S, O>,
-    proceed: (P, S, RenderContext<P, S, O>) -> R,
+    context: BaseRenderContext<P, S, O>,
+    proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
     session: WorkflowSession
   ): R {
     if (session.parent == null) {
@@ -476,9 +476,9 @@ class TracingWorkflowInterceptor internal constructor(
   }
 
   private inner class TracingRenderContext<P, S, O>(
-    private val delegate: RenderContext<P, S, O>,
+    private val delegate: BaseRenderContext<P, S, O>,
     private val session: WorkflowSession
-  ) : RenderContext<P, S, O> by delegate, Sink<WorkflowAction<P, S, O>> {
+  ) : BaseRenderContext<P, S, O> by delegate, Sink<WorkflowAction<P, S, O>> {
     override val actionSink: Sink<WorkflowAction<P, S, O>> get() = this
 
     override fun send(value: WorkflowAction<P, S, O>) {

--- a/workflow-tracing/src/test/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptorTest.kt
+++ b/workflow-tracing/src/test/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptorTest.kt
@@ -160,7 +160,7 @@ class TracingWorkflowInterceptorTest {
     override fun render(
       props: Int,
       state: String,
-      context: RenderContext<Int, String, String>
+      context: RenderContext
     ): String {
       if (props == 0) return "initial"
       if (props in 1..6) context.renderChild(this, 0) { bubbleUp(it) }


### PR DESCRIPTION
Renamed `RenderContext` to `BaseRenderContext`, and gave both `StatelessWorkflow`
and `StatefulWorkflow` their own verions of `RenderContext`. These are inner classes,
so they can use the workflow's type parameters. This removes the type parameters from
the `RenderContext` reference in the `render` parameter list. Both types implement
`BaseWorkflowContext` however, so code that doesn't know about a particular workflow
instance can use this base type and convert it to a specific `RenderContext` later,
given a `Stateful/StatelessWorkflow` instance.