### PR TITLE
Tweaks kdoc on snapshotState.

### DIFF
--- a/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
@@ -150,7 +150,7 @@ abstract class StatefulWorkflow<
    * rarely.
    *
    * If the workflow does not have any state, or should always be started from scratch, return
-   * [Snapshot.EMPTY] from this method.
+   * `null` from this method.
    *
    * @see initialState
    */


### PR DESCRIPTION
Should we also deprecate `Snapshot.EMPTY`?