### PR TITLE
Revert "Extend ViewGroup in stock Kotlin Container classes"

### DIFF
--- a/workflow-ui/backstack-android/api/backstack-android.api
+++ b/workflow-ui/backstack-android/api/backstack-android.api
@@ -12,15 +12,13 @@ public final class com/squareup/workflow/ui/backstack/BackStackConfig$Companion 
 	public synthetic fun getDefault ()Ljava/lang/Object;
 }
 
-public class com/squareup/workflow/ui/backstack/BackStackContainer : android/view/ViewGroup {
+public class com/squareup/workflow/ui/backstack/BackStackContainer : android/widget/FrameLayout {
 	public static final field Companion Lcom/squareup/workflow/ui/backstack/BackStackContainer$Companion;
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	protected fun onLayout (ZIIII)V
-	protected fun onMeasure (II)V
 	protected fun onRestoreInstanceState (Landroid/os/Parcelable;)V
 	protected fun onSaveInstanceState ()Landroid/os/Parcelable;
 	protected fun performTransition (Landroid/view/View;Landroid/view/View;Z)V

--- a/workflow-ui/backstack-android/src/main/java/com/squareup/workflow/ui/backstack/BackStackContainer.kt
+++ b/workflow-ui/backstack-android/src/main/java/com/squareup/workflow/ui/backstack/BackStackContainer.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.animation.AccelerateDecelerateInterpolator
+import android.widget.FrameLayout
 import androidx.transition.Scene
 import androidx.transition.Slide
 import androidx.transition.TransitionManager
@@ -30,8 +31,8 @@ import androidx.transition.TransitionSet
 import com.squareup.workflow.ui.BuilderBinding
 import com.squareup.workflow.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow.ui.Named
-import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.ViewFactory
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.backstack.BackStackConfig.First
 import com.squareup.workflow.ui.backstack.BackStackConfig.Other
@@ -50,24 +51,12 @@ open class BackStackContainer @JvmOverloads constructor(
   attributeSet: AttributeSet? = null,
   defStyle: Int = 0,
   defStyleRes: Int = 0
-) : ViewGroup(context, attributeSet, defStyle, defStyleRes) {
+) : FrameLayout(context, attributeSet, defStyle, defStyleRes) {
 
   private val viewStateCache = ViewStateCache()
 
   private val currentView: View? get() = if (childCount > 0) getChildAt(0) else null
   private var currentRendering: BackStackScreen<Named<*>>? = null
-
-  override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
-    currentView?.layout(0, 0, measuredWidth, measuredHeight)
-  }
-
-  override fun onMeasure(
-    widthMeasureSpec: Int,
-    heightMeasureSpec: Int
-  ) {
-    currentView?.measure(widthMeasureSpec, heightMeasureSpec)
-    super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-  }
 
   protected fun update(
     newRendering: BackStackScreen<*>,

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -134,7 +134,7 @@ public abstract class com/squareup/workflow/ui/WorkflowFragment : androidx/fragm
 	protected abstract fun onCreateWorkflow ()Lcom/squareup/workflow/ui/WorkflowRunner$Config;
 }
 
-public final class com/squareup/workflow/ui/WorkflowLayout : android/view/ViewGroup {
+public final class com/squareup/workflow/ui/WorkflowLayout : android/widget/FrameLayout {
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun start (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow/ui/ViewEnvironment;)V

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowLayout.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowLayout.kt
@@ -24,6 +24,7 @@ import android.util.SparseArray
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.widget.FrameLayout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -41,9 +42,9 @@ import kotlinx.coroutines.flow.onEach
 class WorkflowLayout(
   context: Context,
   attributeSet: AttributeSet? = null
-) : ViewGroup(context, attributeSet) {
+) : FrameLayout(context, attributeSet) {
   private val showing: WorkflowViewStub = WorkflowViewStub(context).also {
-    addView(it, LayoutParams(MATCH_PARENT, MATCH_PARENT))
+    addView(it, ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
   }
 
   private var restoredChildState: SparseArray<Parcelable>? = null
@@ -101,18 +102,6 @@ class WorkflowLayout(
           super.onRestoreInstanceState(state.superState)
         }
         ?: super.onRestoreInstanceState(state)
-  }
-
-  override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
-    showing.actual.layout(0, 0, measuredWidth, measuredHeight)
-  }
-
-  override fun onMeasure(
-    widthMeasureSpec: Int,
-    heightMeasureSpec: Int
-  ) {
-    showing.actual.measure(widthMeasureSpec, heightMeasureSpec)
-    super.onMeasure(widthMeasureSpec, heightMeasureSpec)
   }
 
   private class SavedState : BaseSavedState {

--- a/workflow-ui/modal-android/api/modal-android.api
+++ b/workflow-ui/modal-android/api/modal-android.api
@@ -26,15 +26,13 @@ public final class com/squareup/workflow/ui/modal/BuildConfig {
 	public fun <init> ()V
 }
 
-public abstract class com/squareup/workflow/ui/modal/ModalContainer : android/view/ViewGroup {
+public abstract class com/squareup/workflow/ui/modal/ModalContainer : android/widget/FrameLayout {
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected abstract fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
-	protected fun onLayout (ZIIII)V
-	protected fun onMeasure (II)V
 	protected fun onRestoreInstanceState (Landroid/os/Parcelable;)V
 	protected fun onSaveInstanceState ()Landroid/os/Parcelable;
 	protected final fun update (Lcom/squareup/workflow/ui/modal/HasModals;Lcom/squareup/workflow/ui/ViewEnvironment;)V

--- a/workflow-ui/modal-android/src/main/java/com/squareup/workflow/ui/modal/ModalContainer.kt
+++ b/workflow-ui/modal-android/src/main/java/com/squareup/workflow/ui/modal/ModalContainer.kt
@@ -25,6 +25,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.widget.FrameLayout
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.Event.ON_DESTROY
 import androidx.lifecycle.LifecycleObserver
@@ -47,10 +48,10 @@ abstract class ModalContainer<ModalRenderingT : Any> @JvmOverloads constructor(
   attributeSet: AttributeSet? = null,
   defStyle: Int = 0,
   defStyleRes: Int = 0
-) : ViewGroup(context, attributeSet, defStyle, defStyleRes) {
+) : FrameLayout(context, attributeSet, defStyle, defStyleRes) {
 
   private val baseView: WorkflowViewStub = WorkflowViewStub(context).also {
-    addView(it, LayoutParams(MATCH_PARENT, MATCH_PARENT))
+    addView(it, ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
   }
 
   private var dialogs: List<DialogRef<ModalRenderingT>> = emptyList()
@@ -107,18 +108,6 @@ abstract class ModalContainer<ModalRenderingT : Any> @JvmOverloads constructor(
           super.onRestoreInstanceState(state.superState)
         }
         ?: super.onRestoreInstanceState(state)
-  }
-
-  override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
-    baseView.actual.layout(0, 0, measuredWidth, measuredHeight)
-  }
-
-  override fun onMeasure(
-    widthMeasureSpec: Int,
-    heightMeasureSpec: Int
-  ) {
-    baseView.actual.measure(widthMeasureSpec, heightMeasureSpec)
-    super.onMeasure(widthMeasureSpec, heightMeasureSpec)
   }
 
   internal data class KeyAndBundle(


### PR DESCRIPTION
Our minimal measure / layout code is too minimal, and broke things.

Closes #105.

This reverts commit e41659bc024631c6793dcbae3aa5c0652c0a8a72.