### PR TITLE
Deprecate older Worker helpers that are now easier to do by using side effects directly.

### DIFF
--- a/workflow-core/src/main/java/com/squareup/workflow/LifecycleWorker.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/LifecycleWorker.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
  * A [Worker] is stopped when its parent [Workflow] finishes a render pass without running the
  * worker, or when the parent workflow is itself torn down.
  */
+@Deprecated("Use runningSideEffect instead.")
 abstract class LifecycleWorker : Worker<Nothing> {
 
   /**

--- a/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -222,6 +222,7 @@ interface Worker<out OutputT> {
      * call, or can use the `key` parameter to [RenderContext.runningWorker] to prevent conflicts.
      * ```
      */
+    @Deprecated("Use runningSideEffect instead.")
     fun createSideEffect(
       block: suspend () -> Unit
     ): Worker<Nothing> = TypedWorker(TYPE_OF_NOTHING, flow { block() })


### PR DESCRIPTION
# DON"T MERGE UNTIL #110 DOES

