### PR TITLE
Pulled the deprecated Mutator and associated method into a sub-interface of WorkflowAction

### DIFF
--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemWorkflow.kt
@@ -28,12 +28,11 @@ import com.squareup.sample.poetry.StanzaWorkflow.Output.ShowNextStanza
 import com.squareup.sample.poetry.StanzaWorkflow.Output.ShowPreviousStanza
 import com.squareup.sample.poetry.StanzaWorkflow.Props
 import com.squareup.sample.poetry.model.Poem
-import com.squareup.workflow1.RenderContext
+import com.squareup.workflow1.MutatorWorkflowAction
+import com.squareup.workflow1.MutatorWorkflowAction.Mutator
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
-import com.squareup.workflow1.WorkflowAction
 import com.squareup.workflow1.WorkflowAction.Companion.noAction
-import com.squareup.workflow1.WorkflowAction.Mutator
 import com.squareup.workflow1.parse
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.backstack.BackStackScreen
@@ -107,7 +106,7 @@ object PoemWorkflow : StatefulWorkflow<Poem, Int, ClosePoem, OverviewDetailScree
     sink.writeInt(state)
   }
 
-  private sealed class Action : WorkflowAction<Poem, Int, ClosePoem> {
+  private sealed class Action : MutatorWorkflowAction<Poem, Int, ClosePoem> {
     object ClearSelection : Action()
     object SelectPrevious : Action()
     object SelectNext : Action()

--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -41,6 +41,21 @@ public abstract class com/squareup/workflow1/LifecycleWorker : com/squareup/work
 	public final fun run ()Lkotlinx/coroutines/flow/Flow;
 }
 
+public abstract interface class com/squareup/workflow1/MutatorWorkflowAction : com/squareup/workflow1/WorkflowAction {
+	public abstract fun apply (Lcom/squareup/workflow1/MutatorWorkflowAction$Mutator;)Ljava/lang/Object;
+	public abstract fun apply (Lcom/squareup/workflow1/WorkflowAction$Updater;)V
+}
+
+public final class com/squareup/workflow1/MutatorWorkflowAction$DefaultImpls {
+	public static fun apply (Lcom/squareup/workflow1/MutatorWorkflowAction;Lcom/squareup/workflow1/WorkflowAction$Updater;)V
+}
+
+public final class com/squareup/workflow1/MutatorWorkflowAction$Mutator {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun getState ()Ljava/lang/Object;
+	public final fun setState (Ljava/lang/Object;)V
+}
+
 public abstract interface class com/squareup/workflow1/Sink {
 	public abstract fun send (Ljava/lang/Object;)V
 }
@@ -153,7 +168,6 @@ public final class com/squareup/workflow1/Workflow$Companion {
 
 public abstract interface class com/squareup/workflow1/WorkflowAction {
 	public static final field Companion Lcom/squareup/workflow1/WorkflowAction$Companion;
-	public abstract fun apply (Lcom/squareup/workflow1/WorkflowAction$Mutator;)Ljava/lang/Object;
 	public abstract fun apply (Lcom/squareup/workflow1/WorkflowAction$Updater;)V
 }
 
@@ -167,17 +181,6 @@ public final class com/squareup/workflow1/WorkflowAction$Companion {
 	public final fun modifyState (Lkotlin/jvm/functions/Function0;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static synthetic fun modifyState$default (Lcom/squareup/workflow1/WorkflowAction$Companion;Lkotlin/jvm/functions/Function0;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/WorkflowAction;
 	public final fun noAction ()Lcom/squareup/workflow1/WorkflowAction;
-}
-
-public final class com/squareup/workflow1/WorkflowAction$DefaultImpls {
-	public static fun apply (Lcom/squareup/workflow1/WorkflowAction;Lcom/squareup/workflow1/WorkflowAction$Mutator;)Ljava/lang/Object;
-	public static fun apply (Lcom/squareup/workflow1/WorkflowAction;Lcom/squareup/workflow1/WorkflowAction$Updater;)V
-}
-
-public final class com/squareup/workflow1/WorkflowAction$Mutator {
-	public fun <init> (Ljava/lang/Object;)V
-	public final fun getState ()Ljava/lang/Object;
-	public final fun setState (Ljava/lang/Object;)V
 }
 
 public final class com/squareup/workflow1/WorkflowAction$Updater {

--- a/workflow-core/src/main/java/com/squareup/workflow1/MutatorWorkflowAction.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/MutatorWorkflowAction.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmMultifileClass
+@file:JvmName("Workflows")
+
+package com.squareup.workflow1
+
+import com.squareup.workflow1.WorkflowAction.Updater
+
+/**
+ * An atomic operation that updates the state of a [Workflow], and also optionally emits an output.
+ */
+@Deprecated("Use WorkflowAction")
+@Suppress("DEPRECATION")
+interface MutatorWorkflowAction<in PropsT, StateT, out OutputT> :
+    WorkflowAction<PropsT, StateT, OutputT> {
+
+  @Deprecated("Use WorkflowAction.Updater")
+  class Mutator<S>(var state: S)
+
+  @Deprecated("Implement WorkflowAction.apply")
+  fun Mutator<StateT>.apply(): OutputT?
+
+  override fun Updater<PropsT, StateT, OutputT>.apply() {
+    val mutator = Mutator(state)
+    mutator.apply()
+        ?.let { setOutput(it) }
+    state = mutator.state
+  }
+}

--- a/workflow-core/src/main/java/com/squareup/workflow1/StatefulWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/StatefulWorkflow.kt
@@ -19,8 +19,9 @@
 
 package com.squareup.workflow1
 
+import com.squareup.workflow1.MutatorWorkflowAction.Mutator
+import com.squareup.workflow1.StatefulWorkflow.RenderContext
 import com.squareup.workflow1.WorkflowAction.Companion.toString
-import com.squareup.workflow1.WorkflowAction.Mutator
 import com.squareup.workflow1.WorkflowAction.Updater
 
 /**
@@ -287,11 +288,13 @@ fun <PropsT, StateT, OutputT, RenderingT>
  * in [toString].
  * @param update Function that defines the workflow update.
  */
+/* ktlint-disable parameter-list-wrapping */
 fun <PropsT, StateT, OutputT, RenderingT>
     StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.action(
-      name: () -> String,
-      update: Updater<PropsT, StateT, OutputT>.() -> Unit
-    ): WorkflowAction<PropsT, StateT, OutputT> = object : WorkflowAction<PropsT, StateT, OutputT> {
+  name: () -> String,
+  update: Updater<PropsT, StateT, OutputT>.() -> Unit
+): WorkflowAction<PropsT, StateT, OutputT> = object : WorkflowAction<PropsT, StateT, OutputT> {
+  /* ktlint-enable parameter-list-wrapping */
   override fun Updater<PropsT, StateT, OutputT>.apply() = update.invoke(this)
   override fun toString(): String = "action(${name()})-${this@action}"
 }
@@ -303,11 +306,13 @@ fun <PropsT, StateT, OutputT, RenderingT>
         imports = arrayOf("com.squareup.workflow1.action")
     )
 )
+/* ktlint-disable parameter-list-wrapping */
 fun <PropsT, StateT, OutputT, RenderingT>
     StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.workflowAction(
-      name: String = "",
-      block: Mutator<StateT>.() -> OutputT?
-    ) = workflowAction({ name }, block)
+  name: String = "",
+  block: Mutator<StateT>.() -> OutputT?
+) = workflowAction({ name }, block)
+/* ktlint-enable parameter-list-wrapping */
 
 @Suppress("OverridingDeprecatedMember")
 @Deprecated(
@@ -317,11 +322,14 @@ fun <PropsT, StateT, OutputT, RenderingT>
         imports = arrayOf("com.squareup.workflow1.action")
     )
 )
+/* ktlint-disable parameter-list-wrapping */
 fun <PropsT, StateT, OutputT, RenderingT>
     StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.workflowAction(
-      name: () -> String,
-      block: Mutator<StateT>.() -> OutputT?
-    ): WorkflowAction<PropsT, StateT, OutputT> = object : WorkflowAction<PropsT, StateT, OutputT> {
-  override fun Mutator<StateT>.apply() = block.invoke(this)
-  override fun toString(): String = "workflowAction(${name()})-${this@workflowAction}"
-}
+  name: () -> String,
+  block: Mutator<StateT>.() -> OutputT?
+): WorkflowAction<PropsT, StateT, OutputT> =
+/* ktlint-enable parameter-list-wrapping */
+  object : MutatorWorkflowAction<PropsT, StateT, OutputT> {
+    override fun Mutator<StateT>.apply() = block.invoke(this)
+    override fun toString(): String = "workflowAction(${name()})-${this@workflowAction}"
+  }

--- a/workflow-core/src/main/java/com/squareup/workflow1/WorkflowAction.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/WorkflowAction.kt
@@ -25,8 +25,6 @@ import com.squareup.workflow1.WorkflowAction.Updater
  * An atomic operation that updates the state of a [Workflow], and also optionally emits an output.
  */
 interface WorkflowAction<in PropsT, StateT, out OutputT> {
-  @Deprecated("Use Updater")
-  class Mutator<S>(var state: S)
 
   /**
    * The context for calls to [WorkflowAction.apply]. Allows the action to set the
@@ -61,19 +59,7 @@ interface WorkflowAction<in PropsT, StateT, out OutputT> {
    * Executes the logic for this action, including any side effects, updating [state][StateT], and
    * setting the [OutputT] to emit.
    */
-  @Suppress("DEPRECATION")
-  fun Updater<PropsT, StateT, OutputT>.apply() {
-    val mutator = Mutator(state)
-    mutator.apply()
-        ?.let { setOutput(it) }
-    state = mutator.state
-  }
-
-  @Suppress("DEPRECATION")
-  @Deprecated("Implement Updater.apply")
-  fun Mutator<StateT>.apply(): OutputT? {
-    throw UnsupportedOperationException()
-  }
+  fun Updater<PropsT, StateT, OutputT>.apply()
 
   companion object {
     /**


### PR DESCRIPTION
This should be a find-and-replace migration, and allows `WorkflowAction` to require
implementors to override `apply()`. The new sub-interface is completely deprecated.