### PR TITLE
Convert Updater to an inner class.

### DIFF
--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemWorkflow.kt
@@ -106,7 +106,7 @@ object PoemWorkflow : StatefulWorkflow<Poem, Int, ClosePoem, OverviewDetailScree
     sink.writeInt(state)
   }
 
-  private sealed class Action : MutatorWorkflowAction<Poem, Int, ClosePoem> {
+  private sealed class Action : MutatorWorkflowAction<Poem, Int, ClosePoem>() {
     object ClearSelection : Action()
     object SelectPrevious : Action()
     object SelectNext : Action()

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameSessionWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameSessionWorkflow.kt
@@ -28,7 +28,6 @@ import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction
 import com.squareup.workflow1.WorkflowAction.Companion.noAction
-import com.squareup.workflow1.WorkflowAction.Updater
 import com.squareup.workflow1.action
 import com.squareup.workflow1.runningWorker
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
@@ -100,8 +99,8 @@ class GameSessionWorkflow(
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private class StartRunning(val board: Board) : WorkflowAction<Props, State, Nothing> {
-    override fun Updater<Props, State, Nothing>.apply() {
+  private class StartRunning(val board: Board) : WorkflowAction<Props, State, Nothing>() {
+    override fun Updater.apply() {
       state = Running(board)
     }
   }

--- a/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/PlayerWorkflow.kt
+++ b/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/PlayerWorkflow.kt
@@ -35,16 +35,16 @@ class PlayerWorkflow(
   private val cellsPerSecond: Float = 15f
 ) : StatefulWorkflow<ActorProps, Movement, Nothing, Rendering>() {
 
-  sealed class Action : WorkflowAction<ActorProps, Movement, Nothing> {
+  sealed class Action : WorkflowAction<ActorProps, Movement, Nothing>() {
 
     class StartMoving(private val direction: Direction) : Action() {
-      override fun Updater<ActorProps, Movement, Nothing>.apply() {
+      override fun Updater.apply() {
         state += direction
       }
     }
 
     class StopMoving(private val direction: Direction) : Action() {
-      override fun Updater<ActorProps, Movement, Nothing>.apply() {
+      override fun Updater.apply() {
         state -= direction
       }
     }

--- a/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineWorkflow.kt
+++ b/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineWorkflow.kt
@@ -25,7 +25,6 @@ import com.squareup.sample.timemachine.shakeable.ShakeableTimeMachineWorkflow.St
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction
-import com.squareup.workflow1.WorkflowAction.Updater
 import com.squareup.workflow1.action
 import com.squareup.workflow1.runningWorker
 import kotlin.time.Duration
@@ -123,14 +122,14 @@ class ShakeableTimeMachineWorkflow<in P, O : Any, out R : Any>(
 
   private inner class SeekAction(
     private val newPosition: Duration
-  ) : WorkflowAction<PropsFactory<P>, State, O> {
-    override fun Updater<PropsFactory<P>, State, O>.apply() {
+  ) : WorkflowAction<PropsFactory<P>, State, O>() {
+    override fun Updater.apply() {
       state = PlayingBack(newPosition)
     }
   }
 
-  private inner class ResumeRecordingAction : WorkflowAction<PropsFactory<P>, State, O> {
-    override fun Updater<PropsFactory<P>, State, O>.apply() {
+  private inner class ResumeRecordingAction : WorkflowAction<PropsFactory<P>, State, O>() {
+    override fun Updater.apply() {
       state = Recording
     }
   }

--- a/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/AppWorkflow.kt
+++ b/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/AppWorkflow.kt
@@ -31,7 +31,6 @@ import com.squareup.sample.recyclerview.inputrows.TextInputRow
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction
-import com.squareup.workflow1.WorkflowAction.Updater
 import com.squareup.workflow1.renderChild
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.modal.HasModals
@@ -75,11 +74,11 @@ object AppWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
       get() = listOfNotNull(popup)
   }
 
-  private sealed class Action : WorkflowAction<Unit, State, Nothing> {
+  private sealed class Action : WorkflowAction<Unit, State, Nothing>() {
     object ShowAddRowAction : Action()
     data class CommitNewRowAction(val index: Int) : Action()
 
-    override fun Updater<Unit, State, Nothing>.apply() {
+    override fun Updater.apply() {
       state = when (this@Action) {
         ShowAddRowAction -> ChooseNewRow(state.rows)
         is CommitNewRowAction -> ShowList(state.rows + allRowTypes[index])

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
@@ -30,12 +30,10 @@ import com.squareup.sample.authworkflow.AuthState.Authorizing
 import com.squareup.sample.authworkflow.AuthState.AuthorizingSecondFactor
 import com.squareup.sample.authworkflow.AuthState.LoginPrompt
 import com.squareup.sample.authworkflow.AuthState.SecondFactorPrompt
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
-import com.squareup.workflow1.WorkflowAction.Updater
 import com.squareup.workflow1.runningWorker
 import com.squareup.workflow1.rx2.asWorker
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
@@ -72,7 +70,7 @@ sealed class AuthResult {
   object Canceled : AuthResult()
 }
 
-internal sealed class Action : WorkflowAction<Unit, AuthState, AuthResult> {
+internal sealed class Action : WorkflowAction<Unit, AuthState, AuthResult>() {
   class SubmitLogin(
     val email: String,
     val password: String
@@ -94,7 +92,7 @@ internal sealed class Action : WorkflowAction<Unit, AuthState, AuthResult> {
     val response: AuthResponse
   ) : Action()
 
-  final override fun Updater<Unit, AuthState, AuthResult>.apply() {
+  final override fun Updater.apply() {
     when (this@Action) {
       is SubmitLogin -> {
         state = when {

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
@@ -44,7 +44,6 @@ import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
-import com.squareup.workflow1.WorkflowAction.Updater
 import com.squareup.workflow1.runningWorker
 import com.squareup.workflow1.rx2.asWorker
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
@@ -70,7 +69,7 @@ typealias RunGameScreen = AlertContainerScreen<PanelContainerScreen<Any, Any>>
  */
 typealias RunGameWorkflow = Workflow<Unit, RunGameResult, RunGameScreen>
 
-sealed class Action : WorkflowAction<Unit, RunGameState, RunGameResult> {
+sealed class Action : WorkflowAction<Unit, RunGameState, RunGameResult>() {
   object CancelNewGame : Action()
 
   class StartGame(
@@ -101,7 +100,7 @@ sealed class Action : WorkflowAction<Unit, RunGameState, RunGameResult> {
   // signal that this workflow is too big, and should be refactored into something
   // like one workflow per screen.
 
-  override fun Updater<Unit, RunGameState, RunGameResult>.apply() {
+  override fun Updater.apply() {
 
     when (this@Action) {
       CancelNewGame -> setOutput(CanceledStart)

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
@@ -24,7 +24,6 @@ import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
-import com.squareup.workflow1.WorkflowAction.Updater
 
 typealias TakeTurnsWorkflow = Workflow<TakeTurnsProps, CompletedGame, GamePlayScreen>
 
@@ -51,12 +50,12 @@ class TakeTurnsProps private constructor(
 class RealTakeTurnsWorkflow : TakeTurnsWorkflow,
     StatefulWorkflow<TakeTurnsProps, Turn, CompletedGame, GamePlayScreen>() {
 
-  sealed class Action : WorkflowAction<TakeTurnsProps, Turn, CompletedGame> {
+  sealed class Action : WorkflowAction<TakeTurnsProps, Turn, CompletedGame>() {
     class TakeSquare(
       private val row: Int,
       private val col: Int
     ) : Action() {
-      override fun Updater<TakeTurnsProps, Turn, CompletedGame>.apply() {
+      override fun Updater.apply() {
         val newBoard = state.board.takeSquare(row, col, state.playing)
 
         when {
@@ -71,7 +70,7 @@ class RealTakeTurnsWorkflow : TakeTurnsWorkflow,
     }
 
     object Quit : Action() {
-      override fun Updater<TakeTurnsProps, Turn, CompletedGame>.apply() {
+      override fun Updater.apply() {
         setOutput(CompletedGame(Quitted, state))
       }
     }

--- a/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
+++ b/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
@@ -25,7 +25,6 @@ import com.squareup.sample.todo.TodoEditorOutput.ListUpdated
 import com.squareup.workflow1.Sink
 import com.squareup.workflow1.StatelessWorkflow
 import com.squareup.workflow1.WorkflowAction
-import com.squareup.workflow1.WorkflowAction.Updater
 
 data class TodoList(
   val title: String,
@@ -37,7 +36,7 @@ data class TodoRow(
   val done: Boolean = false
 )
 
-sealed class TodoAction : WorkflowAction<TodoList, Nothing, TodoEditorOutput> {
+sealed class TodoAction : WorkflowAction<TodoList, Nothing, TodoEditorOutput>() {
   object GoBackClicked : TodoAction()
 
   sealed class ListAction : TodoAction() {
@@ -65,7 +64,7 @@ sealed class TodoAction : WorkflowAction<TodoList, Nothing, TodoEditorOutput> {
     ) : ListAction()
   }
 
-  override fun Updater<TodoList, Nothing, TodoEditorOutput>.apply() {
+  override fun Updater.apply() {
     when (this@TodoAction) {
       is GoBackClicked -> Done
       is TitleChanged -> ListUpdated(list.copy(title = newTitle))

--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -37,13 +37,10 @@ public abstract class com/squareup/workflow1/LifecycleWorker : com/squareup/work
 	public final fun run ()Lkotlinx/coroutines/flow/Flow;
 }
 
-public abstract interface class com/squareup/workflow1/MutatorWorkflowAction : com/squareup/workflow1/WorkflowAction {
+public abstract class com/squareup/workflow1/MutatorWorkflowAction : com/squareup/workflow1/WorkflowAction {
+	public fun <init> ()V
 	public abstract fun apply (Lcom/squareup/workflow1/MutatorWorkflowAction$Mutator;)Ljava/lang/Object;
-	public abstract fun apply (Lcom/squareup/workflow1/WorkflowAction$Updater;)V
-}
-
-public final class com/squareup/workflow1/MutatorWorkflowAction$DefaultImpls {
-	public static fun apply (Lcom/squareup/workflow1/MutatorWorkflowAction;Lcom/squareup/workflow1/WorkflowAction$Updater;)V
+	public final fun apply (Lcom/squareup/workflow1/WorkflowAction$Updater;)V
 }
 
 public final class com/squareup/workflow1/MutatorWorkflowAction$Mutator {
@@ -158,8 +155,9 @@ public abstract interface class com/squareup/workflow1/Workflow {
 public final class com/squareup/workflow1/Workflow$Companion {
 }
 
-public abstract interface class com/squareup/workflow1/WorkflowAction {
+public abstract class com/squareup/workflow1/WorkflowAction {
 	public static final field Companion Lcom/squareup/workflow1/WorkflowAction$Companion;
+	public fun <init> ()V
 	public abstract fun apply (Lcom/squareup/workflow1/WorkflowAction$Updater;)V
 }
 
@@ -176,7 +174,7 @@ public final class com/squareup/workflow1/WorkflowAction$Companion {
 }
 
 public final class com/squareup/workflow1/WorkflowAction$Updater {
-	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun <init> (Lcom/squareup/workflow1/WorkflowAction;Ljava/lang/Object;Ljava/lang/Object;)V
 	public final fun getNextState ()Ljava/lang/Object;
 	public final fun getProps ()Ljava/lang/Object;
 	public final fun getState ()Ljava/lang/Object;

--- a/workflow-core/src/main/java/com/squareup/workflow1/MutatorWorkflowAction.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/MutatorWorkflowAction.kt
@@ -18,23 +18,21 @@
 
 package com.squareup.workflow1
 
-import com.squareup.workflow1.WorkflowAction.Updater
-
 /**
- * An atomic operation that updates the state of a [Workflow], and also optionally emits an output.
+ * Deprecated, legacy version of [WorkflowAction]. Kept around for migration.
  */
 @Deprecated("Use WorkflowAction")
 @Suppress("DEPRECATION")
-interface MutatorWorkflowAction<in PropsT, StateT, out OutputT> :
-    WorkflowAction<PropsT, StateT, OutputT> {
+abstract class MutatorWorkflowAction<in PropsT, StateT, out OutputT> :
+    WorkflowAction<PropsT, StateT, OutputT>() {
 
   @Deprecated("Use WorkflowAction.Updater")
   class Mutator<S>(var state: S)
 
   @Deprecated("Implement WorkflowAction.apply")
-  fun Mutator<StateT>.apply(): OutputT?
+  abstract fun Mutator<StateT>.apply(): OutputT?
 
-  override fun Updater<PropsT, StateT, OutputT>.apply() {
+  final override fun Updater.apply() {
     val mutator = Mutator(state)
     mutator.apply()
         ?.let { setOutput(it) }

--- a/workflow-core/src/main/java/com/squareup/workflow1/RenderContext.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/RenderContext.kt
@@ -238,7 +238,7 @@ internal fun <T, PropsT, StateT, OutputT>
  * event types to be mapped to anonymous [WorkflowAction]s.
  */
 fun <EventT, PropsT, StateT, OutputT> BaseRenderContext<PropsT, StateT, OutputT>.makeEventSink(
-  update: Updater<Any?, StateT, OutputT>.(EventT) -> Unit
+  update: WorkflowAction<PropsT, StateT, OutputT>.Updater.(EventT) -> Unit
 ): Sink<EventT> = actionSink.contraMap { event ->
   action({ "eventSink($event)" }) { update(event) }
 }

--- a/workflow-core/src/main/java/com/squareup/workflow1/Sink.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/Sink.kt
@@ -105,9 +105,9 @@ internal suspend fun <
       action: WorkflowAction<PropsT, StateT, OutputT>
     ) {
   suspendCancellableCoroutine<Unit> { continuation ->
-    val resumingAction = object : WorkflowAction<PropsT, StateT, OutputT> {
+    val resumingAction = object : WorkflowAction<PropsT, StateT, OutputT>() {
       override fun toString(): String = "sendAndAwaitApplication($action)"
-      override fun Updater<PropsT, StateT, OutputT>.apply() {
+      override fun Updater.apply() {
         // Don't execute anything if the caller was cancelled while we were in the queue.
         if (!continuation.isActive) return
 

--- a/workflow-core/src/main/java/com/squareup/workflow1/StatefulWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/StatefulWorkflow.kt
@@ -276,7 +276,7 @@ inline fun <StateT, OutputT, RenderingT> Workflow.Companion.stateful(
 fun <PropsT, StateT, OutputT, RenderingT>
     StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.action(
       name: String = "",
-      update: Updater<PropsT, StateT, OutputT>.() -> Unit
+      update: WorkflowAction<PropsT, StateT, OutputT>.Updater.() -> Unit
     ) = action({ name }, update)
 
 /**
@@ -292,10 +292,10 @@ fun <PropsT, StateT, OutputT, RenderingT>
 fun <PropsT, StateT, OutputT, RenderingT>
     StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.action(
   name: () -> String,
-  update: Updater<PropsT, StateT, OutputT>.() -> Unit
-): WorkflowAction<PropsT, StateT, OutputT> = object : WorkflowAction<PropsT, StateT, OutputT> {
+  update: WorkflowAction<PropsT, StateT, OutputT>.Updater.() -> Unit
+): WorkflowAction<PropsT, StateT, OutputT> = object : WorkflowAction<PropsT, StateT, OutputT>() {
   /* ktlint-enable parameter-list-wrapping */
-  override fun Updater<PropsT, StateT, OutputT>.apply() = update.invoke(this)
+  override fun Updater.apply() = update.invoke(this)
   override fun toString(): String = "action(${name()})-${this@action}"
 }
 
@@ -329,7 +329,7 @@ fun <PropsT, StateT, OutputT, RenderingT>
   block: Mutator<StateT>.() -> OutputT?
 ): WorkflowAction<PropsT, StateT, OutputT> =
 /* ktlint-enable parameter-list-wrapping */
-  object : MutatorWorkflowAction<PropsT, StateT, OutputT> {
+  object : MutatorWorkflowAction<PropsT, StateT, OutputT>() {
     override fun Mutator<StateT>.apply() = block.invoke(this)
     override fun toString(): String = "workflowAction(${name()})-${this@workflowAction}"
   }

--- a/workflow-core/src/main/java/com/squareup/workflow1/StatelessWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/StatelessWorkflow.kt
@@ -130,7 +130,7 @@ fun <RenderingT> Workflow.Companion.rendering(
 fun <PropsT, OutputT, RenderingT>
     StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
   name: String = "",
-  update: Updater<PropsT, Nothing, OutputT>.() -> Unit
+  update: WorkflowAction<PropsT, *, OutputT>.Updater.() -> Unit
 ) = action({ name }, update)
 
 /**
@@ -145,8 +145,8 @@ fun <PropsT, OutputT, RenderingT>
 fun <PropsT, OutputT, RenderingT>
     StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
   name: () -> String,
-  update: Updater<PropsT, Nothing, OutputT>.() -> Unit
-): WorkflowAction<PropsT, Nothing, OutputT> = object : WorkflowAction<PropsT, Nothing, OutputT> {
-  override fun Updater<PropsT, Nothing, OutputT>.apply() = update.invoke(this)
+  update: WorkflowAction<PropsT, *, OutputT>.Updater.() -> Unit
+): WorkflowAction<PropsT, Nothing, OutputT> = object : WorkflowAction<PropsT, Nothing, OutputT>() {
+  override fun Updater.apply() = update.invoke(this)
   override fun toString(): String = "action(${name()})-${this@action}"
 }

--- a/workflow-core/src/main/java/com/squareup/workflow1/WorkerWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/WorkerWorkflow.kt
@@ -103,11 +103,11 @@ private class EmitWorkerOutputAction<P, S, O>(
   private val worker: Worker<*>,
   private val renderKey: String,
   private val output: O
-) : WorkflowAction<P, S, O> {
+) : WorkflowAction<P, S, O>() {
   override fun toString(): String =
     "${EmitWorkerOutputAction::class.qualifiedName}(worker=$worker, key=\"$renderKey\")"
 
-  override fun Updater<P, S, O>.apply() {
+  override fun Updater.apply() {
     setOutput(output)
   }
 }

--- a/workflow-core/src/test/java/com/squareup/workflow1/WorkflowActionTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow1/WorkflowActionTest.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.workflow1
 
-import com.squareup.workflow1.WorkflowAction.Updater
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -25,8 +24,8 @@ import kotlin.test.assertNull
 class WorkflowActionTest {
 
   @Test fun `applyTo works when no output is set`() {
-    val action = object : WorkflowAction<String, String, String?> {
-      override fun Updater<String, String, String?>.apply() {
+    val action = object : WorkflowAction<String, String, String?>() {
+      override fun Updater.apply() {
         state = "state: $state, props: $props"
       }
     }
@@ -36,8 +35,8 @@ class WorkflowActionTest {
   }
 
   @Test fun `applyTo works when null output is set`() {
-    val action = object : WorkflowAction<String, String, String?> {
-      override fun Updater<String, String, String?>.apply() {
+    val action = object : WorkflowAction<String, String, String?>() {
+      override fun Updater.apply() {
         state = "state: $state, props: $props"
         setOutput(null)
       }
@@ -49,8 +48,8 @@ class WorkflowActionTest {
   }
 
   @Test fun `applyTo works when non-null output is set`() {
-    val action = object : WorkflowAction<String, String, String?> {
-      override fun Updater<String, String, String?>.apply() {
+    val action = object : WorkflowAction<String, String, String?>() {
+      override fun Updater.apply() {
         state = "state: $state, props: $props"
         setOutput("output")
       }

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/RealRenderContextTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/RealRenderContextTest.kt
@@ -18,14 +18,12 @@
 package com.squareup.workflow1.internal
 
 import com.squareup.workflow1.ExperimentalWorkflowApi
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Sink
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
 import com.squareup.workflow1.WorkflowAction.Companion.noAction
-import com.squareup.workflow1.WorkflowAction.Updater
 import com.squareup.workflow1.action
 import com.squareup.workflow1.applyTo
 import com.squareup.workflow1.internal.RealRenderContext.Renderer
@@ -135,8 +133,8 @@ class RealRenderContextTest {
 
   @Test fun `onEvent allows multiple invocations`() {
     val context = createdPoisonedContext()
-    fun expectedUpdate(msg: String) = object : WorkflowAction<String, String, String> {
-      override fun Updater<String, String, String>.apply() = Unit
+    fun expectedUpdate(msg: String) = object : WorkflowAction<String, String, String>() {
+      override fun Updater.apply() = Unit
       override fun toString(): String = "action($msg)"
     }
 
@@ -167,12 +165,12 @@ class RealRenderContextTest {
 
   @Test fun `send allows multiple sends`() {
     val context = createdPoisonedContext()
-    val firstAction = object : WorkflowAction<String, String, String> {
-      override fun Updater<String, String, String>.apply() = Unit
+    val firstAction = object : WorkflowAction<String, String, String>() {
+      override fun Updater.apply() = Unit
       override fun toString(): String = "firstAction"
     }
-    val secondAction = object : WorkflowAction<String, String, String> {
-      override fun Updater<String, String, String>.apply() = Unit
+    val secondAction = object : WorkflowAction<String, String, String>() {
+      override fun Updater.apply() = Unit
       override fun toString(): String = "secondAction"
     }
     // Enable sink sends.
@@ -186,8 +184,8 @@ class RealRenderContextTest {
 
   @Test fun `send throws before render returns`() {
     val context = createdPoisonedContext()
-    val action = object : WorkflowAction<String, String, String> {
-      override fun Updater<String, String, String>.apply() = Unit
+    val action = object : WorkflowAction<String, String, String>() {
+      override fun Updater.apply() = Unit
       override fun toString(): String = "action"
     }
 

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -26,7 +26,6 @@ import com.squareup.workflow1.TreeSnapshot
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
 import com.squareup.workflow1.WorkflowAction.Companion.emitOutput
-import com.squareup.workflow1.WorkflowAction.Updater
 import com.squareup.workflow1.WorkflowIdentifier
 import com.squareup.workflow1.WorkflowInterceptor
 import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
@@ -1071,8 +1070,8 @@ class WorkflowNodeTest {
   }
 
   @Test fun `send fails before render pass completed`() {
-    class TestAction : WorkflowAction<Unit, Nothing, Nothing> {
-      override fun Updater<Unit, Nothing, Nothing>.apply() = fail("Expected sink send to fail.")
+    class TestAction : WorkflowAction<Unit, Nothing, Nothing>() {
+      override fun Updater.apply() = fail("Expected sink send to fail.")
       override fun toString(): String = "TestAction()"
     }
 

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
@@ -25,7 +25,6 @@ import com.squareup.workflow1.Worker
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
 import com.squareup.workflow1.WorkflowAction.Companion.noAction
-import com.squareup.workflow1.WorkflowAction.Updater
 import com.squareup.workflow1.WorkflowIdentifier
 import com.squareup.workflow1.WorkflowOutput
 import com.squareup.workflow1.contraMap
@@ -159,8 +158,8 @@ class RealRenderTesterTest {
   }
 
   @Test fun `sending to sink throws when called multiple times`() {
-    class TestAction(private val name: String) : WorkflowAction<Unit, Unit, Nothing> {
-      override fun Updater<Unit, Unit, Nothing>.apply() {}
+    class TestAction(private val name: String) : WorkflowAction<Unit, Unit, Nothing>() {
+      override fun Updater.apply() {}
       override fun toString(): String = "TestAction($name)"
     }
 
@@ -188,8 +187,8 @@ class RealRenderTesterTest {
   }
 
   @Test fun `sending to sink throws when child output expected`() {
-    class TestAction : WorkflowAction<Unit, Unit, Nothing> {
-      override fun Updater<Unit, Unit, Nothing>.apply() {}
+    class TestAction : WorkflowAction<Unit, Unit, Nothing>() {
+      override fun Updater.apply() {}
       override fun toString(): String = "TestAction"
     }
 
@@ -535,7 +534,7 @@ class RealRenderTesterTest {
     }
 
     val tester = workflow.testRender(Unit)
-        .expectWorkflow<Nothing, Unit>(child.identifier, Unit)
+        .expectWorkflow(child.identifier, Unit)
 
     val error = assertFailsWith<IllegalArgumentException> {
       tester.render()
@@ -854,8 +853,8 @@ class RealRenderTesterTest {
     assertEquals("bad props: wrong props", error.message)
   }
 
-  private class TestAction(val name: String) : WorkflowAction<Unit, Nothing, Nothing> {
-    override fun Updater<Unit, Nothing, Nothing>.apply() {}
+  private class TestAction(val name: String) : WorkflowAction<Unit, Nothing, Nothing>() {
+    override fun Updater.apply() {}
     override fun toString(): String = "TestAction($name)"
   }
 
@@ -953,8 +952,8 @@ class RealRenderTesterTest {
   }
 
   @Test fun `verifyActionResult handles new state and output`() {
-    class TestAction : WorkflowAction<Unit, String, String> {
-      override fun Updater<Unit, String, String>.apply() {
+    class TestAction : WorkflowAction<Unit, String, String>() {
+      override fun Updater.apply() {
         state = "new state"
         setOutput("output")
       }

--- a/workflow-tracing/src/main/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptor.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptor.kt
@@ -491,8 +491,8 @@ class TracingWorkflowInterceptor internal constructor(
   private inner class TracingAction<P, S, O>(
     private val delegate: WorkflowAction<P, S, O>,
     private val session: WorkflowSession
-  ) : WorkflowAction<P, S, O> {
-    override fun Updater<P, S, O>.apply() {
+  ) : WorkflowAction<P, S, O>() {
+    override fun Updater.apply() {
       val oldState = state
       val (newState, output) = delegate.applyTo(props, state)
       state = newState


### PR DESCRIPTION
Follow-up to #128 that does the `interface + class` to `abstract class + inner class` refactor again to get rid of the inner type params. 