### PR TITLE
Make RenderTester throw a more realistic exception if the same workflow/side effect is ran twice.

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -192,7 +192,6 @@ public final class com/squareup/workflow1/WorkflowAction$Updater {
 
 public final class com/squareup/workflow1/WorkflowIdentifier {
 	public static final field Companion Lcom/squareup/workflow1/WorkflowIdentifier$Companion;
-	public final fun describeRealIdentifier ()Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRealIdentifierType ()Lkotlin/reflect/KAnnotatedElement;
 	public fun hashCode ()I

--- a/workflow-core/src/main/java/com/squareup/workflow1/WorkflowIdentifier.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/WorkflowIdentifier.kt
@@ -113,20 +113,15 @@ class WorkflowIdentifier internal constructor(
 
   /**
    * If this identifier identifies an [ImpostorWorkflow], returns the result of that workflow's
-   * [ImpostorWorkflow.describeRealIdentifier] method, otherwise returns null.
+   * [ImpostorWorkflow.describeRealIdentifier] method, otherwise returns a description of this
+   * identifier including the name of its workflow type and any [ImpostorWorkflow.realIdentifier]s.
    *
-   * Use [toString] to get a complete representation of this identifier.
-   */
-  fun describeRealIdentifier(): String? = description?.invoke()
-
-  /**
-   * Returns a description of this identifier including the name of its workflow type and any
-   * [ImpostorWorkflow.realIdentifier]s.
    */
   override fun toString(): String =
-    proxiedIdentifiers
-        .joinToString { it.typeName }
-        .let { "WorkflowIdentifier($it)" }
+    description?.invoke()
+        ?: proxiedIdentifiers
+            .joinToString { it.typeName }
+            .let { "WorkflowIdentifier($it)" }
 
   override fun equals(other: Any?): Boolean = when {
     this === other -> true

--- a/workflow-core/src/test/java/com/squareup/workflow1/WorkflowIdentifierTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow1/WorkflowIdentifierTest.kt
@@ -36,10 +36,33 @@ class WorkflowIdentifierTest {
     )
   }
 
-  @Test fun `impostor identifier toString`() {
-    val id = TestImpostor1(TestWorkflow1).identifier
+  @Test fun `impostor identifier toString uses describeRealIdentifier when non-null`() {
+    class TestImpostor : Workflow<Nothing, Nothing, Nothing>, ImpostorWorkflow {
+      override val realIdentifier: WorkflowIdentifier = TestWorkflow1.identifier
+      override fun describeRealIdentifier(): String? =
+        "TestImpostor(${TestWorkflow1::class.simpleName})"
+
+      override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, Nothing, Nothing> =
+        throw NotImplementedError()
+    }
+
+    val id = TestImpostor().identifier
+    assertEquals("TestImpostor(TestWorkflow1)", id.toString())
+  }
+
+  @Test
+  fun `impostor identifier toString uses full chain when describeRealIdentifier returns null`() {
+    class TestImpostor : Workflow<Nothing, Nothing, Nothing>, ImpostorWorkflow {
+      override val realIdentifier: WorkflowIdentifier = TestWorkflow1.identifier
+      override fun describeRealIdentifier(): String? = null
+
+      override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, Nothing, Nothing> =
+        throw NotImplementedError()
+    }
+
+    val id = TestImpostor().identifier
     assertEquals(
-        "WorkflowIdentifier(com.squareup.workflow1.WorkflowIdentifierTest\$TestImpostor1, " +
+        "WorkflowIdentifier(${TestImpostor::class.java.name}, " +
             "com.squareup.workflow1.WorkflowIdentifierTest\$TestWorkflow1)",
         id.toString()
     )
@@ -47,7 +70,7 @@ class WorkflowIdentifierTest {
 
   @Test fun `impostor identifier description`() {
     val id = TestImpostor1(TestWorkflow1).identifier
-    assertEquals("TestImpostor1(TestWorkflow1)", id.describeRealIdentifier())
+    assertEquals("TestImpostor1(TestWorkflow1)", id.toString())
   }
 
   @Test fun `restored identifier toString`() {

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/internal/SubtreeManager.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/internal/SubtreeManager.kt
@@ -23,6 +23,7 @@ import com.squareup.workflow1.WorkflowAction
 import com.squareup.workflow1.WorkflowInterceptor
 import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
 import com.squareup.workflow1.WorkflowOutput
+import com.squareup.workflow1.identifier
 import kotlinx.coroutines.selects.SelectBuilder
 import kotlin.coroutines.CoroutineContext
 
@@ -140,7 +141,7 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
     // Prevent duplicate workflows with the same key.
     children.forEachStaging {
       require(!(it.matches(child, key))) {
-        "Expected keys to be unique for ${child::class.java.name}: key=$key"
+        "Expected keys to be unique for ${child.identifier}: key=\"$key\""
       }
     }
 

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/internal/WorkflowNode.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/internal/WorkflowNode.kt
@@ -142,7 +142,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   ) {
     // Prevent duplicate side effects with the same key.
     sideEffects.forEachStaging {
-      require(key != it.key) { "Expected side effect keys to be unique: $key" }
+      require(key != it.key) { "Expected side effect keys to be unique: \"$key\"" }
     }
 
     sideEffects.retainOrCreate(

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/SubtreeManagerTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/SubtreeManagerTest.kt
@@ -18,7 +18,6 @@
 package com.squareup.workflow1.internal
 
 import com.squareup.workflow1.ExperimentalWorkflowApi
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Sink
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
@@ -28,6 +27,7 @@ import com.squareup.workflow1.action
 import com.squareup.workflow1.applyTo
 import com.squareup.workflow1.internal.SubtreeManagerTest.TestWorkflow.Rendering
 import com.squareup.workflow1.makeEventSink
+import com.squareup.workflow1.workflowIdentifier
 import kotlinx.coroutines.Dispatchers.Unconfined
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
@@ -146,7 +146,7 @@ class SubtreeManagerTest {
       manager.render(workflow, "props", "foo", handler = { fail() })
     }
     assertEquals(
-        "Expected keys to be unique for ${TestWorkflow::class.java.name}: key=foo",
+        "Expected keys to be unique for ${TestWorkflow::class.workflowIdentifier}: key=\"foo\"",
         error.message
     )
   }

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -449,7 +449,7 @@ class WorkflowNodeTest {
     val error = assertFailsWith<IllegalArgumentException> {
       node.render(workflow.asStatefulWorkflow(), Unit)
     }
-    assertEquals("Expected side effect keys to be unique: same", error.message)
+    assertEquals("Expected side effect keys to be unique: \"same\"", error.message)
   }
 
   @Test fun `staggered sideEffects`() {

--- a/workflow-tracing/src/main/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptor.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptor.kt
@@ -169,7 +169,7 @@ class TracingWorkflowInterceptor internal constructor(
     onWorkflowStarted(
         workflowId = session.sessionId,
         parentId = session.parent?.sessionId,
-        workflowType = session.identifier.let { it.describeRealIdentifier() ?: it.toString() },
+        workflowType = session.identifier.toString(),
         key = session.renderKey,
         initialProps = props,
         initialState = initialState,


### PR DESCRIPTION
It now throws an exception that looks just like the real runtime. This doesn't _fail_ the test,
it _errors_ it, which is also better behavior since this case means the workflow-under-test is
written incorrectly, not that it doesn't match expected test behavior. Fixes #120.

This change also cleans up the way `WorkflowIdentifier`s are described in error and testing strings,
unifies the impostor and non-impostor calls, makes the string consistent between runtime and tests,
and removes a method from the public API.