### PR TITLE
Allow multiple outputs from root workflow

### DIFF
--- a/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragment.kt
+++ b/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragment.kt
@@ -21,6 +21,7 @@ import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowFragment
 import com.squareup.workflow1.ui.WorkflowRunner
+import java.lang.IllegalStateException
 
 @OptIn(WorkflowUiExperimentalApi::class)
 class HelloWorkflowFragment : WorkflowFragment<Unit, Nothing>() {
@@ -30,5 +31,9 @@ class HelloWorkflowFragment : WorkflowFragment<Unit, Nothing>() {
     return WorkflowRunner.Config(
         HelloWorkflow, interceptors = listOf(SimpleLoggingWorkflowInterceptor())
     )
+  }
+
+  override fun onResult(output: Nothing) {
+    throw IllegalStateException("Nothing can never be emitted")
   }
 }

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -143,8 +143,8 @@ public final class com/squareup/workflow1/ui/WorkflowLayout : android/widget/Fra
 
 public abstract interface class com/squareup/workflow1/ui/WorkflowRunner {
 	public static final field Companion Lcom/squareup/workflow1/ui/WorkflowRunner$Companion;
-	public abstract fun awaitResult (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getRenderings ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun receiveOutput (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/squareup/workflow1/ui/WorkflowRunner$Companion {

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -132,6 +132,7 @@ public abstract class com/squareup/workflow1/ui/WorkflowFragment : androidx/frag
 	public synthetic fun onCreateView (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Landroid/os/Bundle;)Landroid/view/View;
 	public final fun onCreateView (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Landroid/os/Bundle;)Lcom/squareup/workflow1/ui/WorkflowLayout;
 	protected abstract fun onCreateWorkflow ()Lcom/squareup/workflow1/ui/WorkflowRunner$Config;
+	protected abstract fun onResult (Ljava/lang/Object;)V
 }
 
 public final class com/squareup/workflow1/ui/WorkflowLayout : android/widget/FrameLayout {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowFragment.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowFragment.kt
@@ -19,8 +19,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.ui.WorkflowRunner.Config
+import kotlinx.coroutines.isActive
 
 /**
  * A [Fragment] that can run a workflow. Subclasses implement [onCreateWorkflow]
@@ -69,6 +71,12 @@ abstract class WorkflowFragment<PropsT, OutputT> : Fragment() {
   protected abstract fun onCreateWorkflow(): Config<PropsT, OutputT>
 
   /**
+   * Called with the output emitted by the root workflow. Called only while
+   * the fragment is active, and always called from the UI thread.
+   */
+  protected abstract fun onResult(output: OutputT)
+
+  /**
    * Provides subclasses with access to the products of the running [Workflow].
    * Safe to call after [onCreateView].
    */
@@ -79,14 +87,20 @@ abstract class WorkflowFragment<PropsT, OutputT> : Fragment() {
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): WorkflowLayout {
+    val workflowLayout = WorkflowLayout(inflater.context)
+    _runner = WorkflowRunner.startWorkflow(this, ::onCreateWorkflow)
+
     // https://github.com/square/workflow-kotlin/issues/14
     // We're careful to start up the workflow runtime before the view is attached,
     // since that's what LayoutRunner promises. When we're sloppy about that, we
     // break things like Jetpack Navigation and nested fragments.
+    workflowLayout.start(runner.renderings, viewEnvironment)
 
-    return WorkflowLayout(inflater.context).also { newView ->
-      _runner = WorkflowRunner.startWorkflow(this, ::onCreateWorkflow)
-      newView.start(runner.renderings, viewEnvironment)
+    lifecycleScope.launchWhenStarted {
+      while (isActive) {
+        onResult(runner.receiveOutput())
+      }
     }
+    return workflowLayout
   }
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowRunner.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowRunner.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
 
 /**
  * Uses a [Workflow] and a [ViewRegistry] to drive a [WorkflowLayout].
@@ -48,15 +49,11 @@ interface WorkflowRunner<out OutputT> {
   val renderings: StateFlow<Any>
 
   /**
-   * Returns the first (and only) [OutputT] value emitted by the workflow. Throws the cancellation
+   * Returns the next [OutputT] value emitted by the workflow. Throws the cancellation
    * exception if the workflow was cancelled before emitting.
    *
-   * The output of the root workflow is treated as a result code, handy for use
-   * as a sign that the host Activity or Fragment should be finished. Thus, once
-   * a value is emitted the workflow is ended and its output value is reported through
-   * this field.
    */
-  suspend fun awaitResult(): OutputT
+  suspend fun receiveOutput(): OutputT
 
   /**
    * @param interceptors An optional list of [WorkflowInterceptor]s that will wrap every workflow
@@ -170,7 +167,9 @@ fun <PropsT, OutputT> FragmentActivity.setContentWorkflow(
   }
 
   lifecycleScope.launchWhenStarted {
-    onResult(runner.awaitResult())
+    while (isActive) {
+      onResult(runner.receiveOutput())
+    }
   }
 
   this.setContentView(layout)

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowRunner.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowRunner.kt
@@ -149,10 +149,9 @@ interface WorkflowRunner<out OutputT> {
  * @param configure function defining the root workflow and its environment. Called only
  * once per [lifecycle][FragmentActivity.getLifecycle], and always called from the UI thread.
  *
- * @param onResult function called with the first (and only) output emitted by the root workflow,
- * handy for passing to [FragmentActivity.setResult]. The workflow is ended once it emits any
- * values, so this is also a good place from which to call [FragmentActivity.finish]. Called
- * only while the activity is active, and always called from the UI thread.
+ * @param onResult function called with the output emitted by the root workflow, handy for
+ * passing to [FragmentActivity.setResult]. Called only while the activity is active, and
+ * always called from the UI thread.
  */
 @WorkflowUiExperimentalApi
 fun <PropsT, OutputT> FragmentActivity.setContentWorkflow(


### PR DESCRIPTION
Addresses https://github.com/square/workflow-kotlin/issues/109

Desired behavior:

- Root workflow can emit multiple outputs, each will be consumed in sequence at most once
- If an output x is emitted during config change, then succeeding outputs are paused until there's a new STARTED host that consumes x
- A worker's result is handled even if it was the worker was enqueued in a different host before a config change

I'm very unfamiliar with coroutines and after skimming some docs it looked like a rendezvous channel is what I'm looking for. I 
