### PR TITLE
Make TreeSnapshot nullable throughout the runtime API and internally.

### DIFF
--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -46,7 +46,6 @@ public final class com/squareup/workflow1/TreeSnapshot {
 
 public final class com/squareup/workflow1/TreeSnapshot$Companion {
 	public final fun forRootOnly (Lcom/squareup/workflow1/Snapshot;)Lcom/squareup/workflow1/TreeSnapshot;
-	public final fun getNONE ()Lcom/squareup/workflow1/TreeSnapshot;
 	public final fun parse (Lokio/ByteString;)Lcom/squareup/workflow1/TreeSnapshot;
 }
 

--- a/workflow-runtime/src/jmh/java/com/squareup/workflow1/WorkflowNodeBenchmark.kt
+++ b/workflow-runtime/src/jmh/java/com/squareup/workflow1/WorkflowNodeBenchmark.kt
@@ -123,7 +123,7 @@ open class WorkflowNodeBenchmark {
       id = this.id(),
       workflow = this,
       initialProps = RENDER_LEAVES,
-      snapshot = TreeSnapshot.NONE,
+      snapshot = null,
       baseContext = context
   )
 }

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/RenderWorkflow.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/RenderWorkflow.kt
@@ -119,7 +119,7 @@ fun <PropsT, OutputT, RenderingT> renderWorkflowIn(
   workflow: Workflow<PropsT, OutputT, RenderingT>,
   scope: CoroutineScope,
   props: StateFlow<PropsT>,
-  initialSnapshot: TreeSnapshot = TreeSnapshot.NONE,
+  initialSnapshot: TreeSnapshot? = null,
   interceptors: List<WorkflowInterceptor> = emptyList(),
   onOutput: suspend (OutputT) -> Unit
 ): StateFlow<RenderingAndSnapshot<RenderingT>> {

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/TreeSnapshot.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/TreeSnapshot.kt
@@ -20,6 +20,7 @@ import com.squareup.workflow1.TreeSnapshot.Companion.parse
 import com.squareup.workflow1.internal.WorkflowNodeId
 import okio.Buffer
 import okio.ByteString
+import kotlin.LazyThreadSafetyMode.NONE
 
 /**
  * Aggregate of all the snapshots of a tree of workflows.
@@ -91,11 +92,6 @@ class TreeSnapshot internal constructor(
   }
 
   companion object {
-    /**
-     * A [TreeSnapshot] that has a null [workflowSnapshot] and no [childTreeSnapshots].
-     */
-    val NONE = TreeSnapshot(null, ::emptyMap)
-
     /**
      * Returns a [TreeSnapshot] that only contains a [Snapshot] for the root workflow, and no child
      * snapshots.

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/internal/SubtreeManager.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/internal/SubtreeManager.kt
@@ -97,7 +97,7 @@ import kotlin.coroutines.CoroutineContext
  */
 @OptIn(ExperimentalWorkflowApi::class)
 internal class SubtreeManager<PropsT, StateT, OutputT>(
-  snapshotCache: Map<WorkflowNodeId, TreeSnapshot>,
+  snapshotCache: Map<WorkflowNodeId, TreeSnapshot>?,
   private val contextForChildren: CoroutineContext,
   private val emitActionToParent: (WorkflowAction<PropsT, StateT, OutputT>) -> Any?,
   private val workflowSession: WorkflowSession? = null,
@@ -110,7 +110,7 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
    * this cache. Then, when those children are started for the first time, they are also restored
    * from their snapshots.
    */
-  private val snapshotCache = snapshotCache.toMutableMap()
+  private val snapshotCache = snapshotCache?.toMutableMap() ?: mutableMapOf()
 
   private var children = ActiveStagingList<WorkflowChildNode<*, *, *, *, *>>()
 
@@ -187,7 +187,7 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
       return emitActionToParent(action)
     }
 
-    val childTreeSnapshots = snapshotCache[id] ?: TreeSnapshot.NONE
+    val childTreeSnapshots = snapshotCache[id]
 
     val workflowNode = WorkflowNode(
         id,

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/internal/WorkflowNode.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/internal/WorkflowNode.kt
@@ -57,7 +57,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   val id: WorkflowNodeId,
   workflow: StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>,
   initialProps: PropsT,
-  snapshot: TreeSnapshot,
+  snapshot: TreeSnapshot?,
   baseContext: CoroutineContext,
   private val emitOutputToParent: (OutputT) -> Any? = { WorkflowOutput(it) },
   override val parent: WorkflowSession? = null,
@@ -77,7 +77,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   override val sessionId: Long = idCounter.createId()
 
   private val subtreeManager = SubtreeManager<PropsT, StateT, OutputT>(
-      snapshotCache = snapshot.childTreeSnapshots,
+      snapshotCache = snapshot?.childTreeSnapshots,
       contextForChildren = coroutineContext,
       emitActionToParent = ::applyAction,
       workflowSession = this,
@@ -94,7 +94,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
     interceptor.onSessionStarted(this, this)
 
     state = interceptor.intercept(workflow, this)
-        .initialState(initialProps, snapshot.workflowSnapshot)
+        .initialState(initialProps, snapshot?.workflowSnapshot)
   }
 
   override fun toString(): String {

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/internal/WorkflowRunner.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/internal/WorkflowRunner.kt
@@ -35,7 +35,7 @@ internal class WorkflowRunner<PropsT, OutputT, RenderingT>(
   scope: CoroutineScope,
   protoWorkflow: Workflow<PropsT, OutputT, RenderingT>,
   props: StateFlow<PropsT>,
-  snapshot: TreeSnapshot,
+  snapshot: TreeSnapshot?,
   interceptor: WorkflowInterceptor
 ) {
   private val workflow = protoWorkflow.asStatefulWorkflow()

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -115,7 +115,7 @@ class WorkflowNodeTest {
       oldAndNewProps += old to new
       return@PropsRenderingWorkflow state
     }
-    val node = WorkflowNode(workflow.id(), workflow, "old", TreeSnapshot.NONE, context)
+    val node = WorkflowNode(workflow.id(), workflow, "old", null, context)
 
     node.render(workflow, "new")
 
@@ -128,7 +128,7 @@ class WorkflowNodeTest {
       oldAndNewProps += old to new
       return@PropsRenderingWorkflow state
     }
-    val node = WorkflowNode(workflow.id(), workflow, "old", TreeSnapshot.NONE, context)
+    val node = WorkflowNode(workflow.id(), workflow, "old", null, context)
 
     node.render(workflow, "old")
 
@@ -139,7 +139,7 @@ class WorkflowNodeTest {
     val workflow = PropsRenderingWorkflow { old, new, _ ->
       "$old->$new"
     }
-    val node = WorkflowNode(workflow.id(), workflow, "foo", TreeSnapshot.NONE, context)
+    val node = WorkflowNode(workflow.id(), workflow, "foo", null, context)
 
     val rendering = node.render(workflow, "foo2")
 
@@ -181,7 +181,7 @@ class WorkflowNodeTest {
       }
     }
     val node = WorkflowNode(
-        workflow.id(), workflow, "", TreeSnapshot.NONE, context,
+        workflow.id(), workflow, "", null, context,
         emitOutputToParent = { WorkflowOutput("tick:$it") }
     )
     node.render(workflow, "")
@@ -218,7 +218,7 @@ class WorkflowNodeTest {
         return ""
       }
     }
-    val node = WorkflowNode(workflow.id(), workflow, "", TreeSnapshot.NONE, context,
+    val node = WorkflowNode(workflow.id(), workflow, "", null, context,
         emitOutputToParent = { WorkflowOutput("tick:$it") }
     )
     node.render(workflow, "")
@@ -258,7 +258,7 @@ class WorkflowNodeTest {
         return ""
       }
     }
-    val node = WorkflowNode(workflow.id(), workflow, "", TreeSnapshot.NONE, context)
+    val node = WorkflowNode(workflow.id(), workflow, "", null, context)
 
     node.render(workflow, "")
     sink.send(emitOutput("event"))
@@ -277,7 +277,7 @@ class WorkflowNodeTest {
     }
     val node = WorkflowNode(
         workflow.id(), workflow.asStatefulWorkflow(), initialProps = Unit,
-        snapshot = TreeSnapshot.NONE, baseContext = context
+        snapshot = null, baseContext = context
     )
 
     runBlocking {
@@ -295,7 +295,7 @@ class WorkflowNodeTest {
     }
     val node = WorkflowNode(
         workflow.id(), workflow.asStatefulWorkflow(), initialProps = Unit,
-        snapshot = TreeSnapshot.NONE, baseContext = context
+        snapshot = null, baseContext = context
     )
 
     node.render(workflow.asStatefulWorkflow(), Unit)
@@ -314,7 +314,7 @@ class WorkflowNodeTest {
     }
     val node = WorkflowNode(
         workflow.id(), workflow.asStatefulWorkflow(), initialProps = Unit,
-        snapshot = TreeSnapshot.NONE, baseContext = context
+        snapshot = null, baseContext = context
     )
     node.render(workflow.asStatefulWorkflow(), Unit)
 
@@ -344,7 +344,7 @@ class WorkflowNodeTest {
     }
     val node = WorkflowNode(
         workflow.id(), workflow.asStatefulWorkflow(), initialProps = true,
-        snapshot = TreeSnapshot.NONE, baseContext = context
+        snapshot = null, baseContext = context
     )
 
     runBlocking {
@@ -370,7 +370,7 @@ class WorkflowNodeTest {
     }
     val node = WorkflowNode(
         workflow.id(), workflow.asStatefulWorkflow(), initialProps = Unit,
-        snapshot = TreeSnapshot.NONE, baseContext = context
+        snapshot = null, baseContext = context
     )
 
     runBlocking {
@@ -396,7 +396,7 @@ class WorkflowNodeTest {
     }
     val node = WorkflowNode(
         workflow.id(), workflow.asStatefulWorkflow(), initialProps = 0,
-        snapshot = TreeSnapshot.NONE, baseContext = context
+        snapshot = null, baseContext = context
     )
 
     runBlocking {
@@ -421,7 +421,7 @@ class WorkflowNodeTest {
     }
     val node = WorkflowNode(
         workflow.id(), workflow.asStatefulWorkflow(), initialProps = 0,
-        snapshot = TreeSnapshot.NONE, baseContext = context
+        snapshot = null, baseContext = context
     )
 
     runBlocking {
@@ -442,7 +442,7 @@ class WorkflowNodeTest {
     }
     val node = WorkflowNode(
         workflow.id(), workflow.asStatefulWorkflow(), initialProps = Unit,
-        snapshot = TreeSnapshot.NONE, baseContext = context
+        snapshot = null, baseContext = context
     )
 
     val error = assertFailsWith<IllegalArgumentException> {
@@ -469,7 +469,7 @@ class WorkflowNodeTest {
     }
         .asStatefulWorkflow()
     val node = WorkflowNode(
-        workflow.id(), workflow, initialProps = 0, snapshot = TreeSnapshot.NONE,
+        workflow.id(), workflow, initialProps = 0, snapshot = null,
         baseContext = context
     )
 
@@ -503,7 +503,7 @@ class WorkflowNodeTest {
     }
     val node = WorkflowNode(
         workflow.id(), workflow.asStatefulWorkflow(), initialProps = Unit,
-        snapshot = TreeSnapshot.NONE, baseContext = context
+        snapshot = null, baseContext = context
     )
 
     assertFalse(started1)
@@ -532,7 +532,7 @@ class WorkflowNodeTest {
         workflow.id(),
         workflow,
         initialProps = "initial props",
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined
     )
 
@@ -561,7 +561,7 @@ class WorkflowNodeTest {
         workflow.id(),
         workflow,
         initialProps = "initial props",
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined
     )
 
@@ -618,7 +618,7 @@ class WorkflowNodeTest {
         parentWorkflow.id(),
         parentWorkflow,
         initialProps = "initial props",
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined
     )
 
@@ -657,7 +657,7 @@ class WorkflowNodeTest {
           }
         }
     )
-    val node = WorkflowNode(workflow.id(), workflow, Unit, TreeSnapshot.NONE, Unconfined)
+    val node = WorkflowNode(workflow.id(), workflow, Unit, null, Unconfined)
 
     assertEquals(0, snapshotCalls)
     assertEquals(0, snapshotWrites)
@@ -698,7 +698,7 @@ class WorkflowNodeTest {
         workflow.id(),
         workflow,
         initialProps = "initial props",
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined
     )
 
@@ -722,7 +722,7 @@ class WorkflowNodeTest {
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = Unit,
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined,
         parent = null
     )
@@ -739,7 +739,7 @@ class WorkflowNodeTest {
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = Unit,
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined,
         parent = TestSession(42)
     )
@@ -771,7 +771,7 @@ class WorkflowNodeTest {
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = Unit,
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         interceptor = interceptor,
         baseContext = Unconfined,
         parent = TestSession(42)
@@ -861,7 +861,7 @@ class WorkflowNodeTest {
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = "old",
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         interceptor = interceptor,
         baseContext = Unconfined,
         parent = TestSession(42)
@@ -909,7 +909,7 @@ class WorkflowNodeTest {
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = "props",
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         interceptor = interceptor,
         baseContext = Unconfined,
         parent = TestSession(42)
@@ -952,7 +952,7 @@ class WorkflowNodeTest {
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = "old",
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         interceptor = interceptor,
         baseContext = Unconfined,
         parent = TestSession(42)
@@ -993,7 +993,7 @@ class WorkflowNodeTest {
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = "old",
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         interceptor = interceptor,
         baseContext = Unconfined,
         parent = TestSession(42)
@@ -1034,7 +1034,7 @@ class WorkflowNodeTest {
         id = rootWorkflow.id(key = "foo"),
         workflow = rootWorkflow.asStatefulWorkflow(),
         initialProps = "props",
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         interceptor = interceptor,
         baseContext = Unconfined,
         parent = TestSession(42),
@@ -1054,7 +1054,7 @@ class WorkflowNodeTest {
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined
     )
 
@@ -1082,7 +1082,7 @@ class WorkflowNodeTest {
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined
     )
 
@@ -1109,7 +1109,7 @@ class WorkflowNodeTest {
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined
     )
     val (_, sink) = node.render(workflow.asStatefulWorkflow(), Unit)
@@ -1134,7 +1134,7 @@ class WorkflowNodeTest {
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined,
         emitOutputToParent = { WorkflowOutput("output:$it") }
     )
@@ -1159,7 +1159,7 @@ class WorkflowNodeTest {
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined,
         emitOutputToParent = { WorkflowOutput(it) }
     )
@@ -1190,7 +1190,7 @@ class WorkflowNodeTest {
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined
     )
     node.render(workflow.asStatefulWorkflow(), Unit)
@@ -1215,7 +1215,7 @@ class WorkflowNodeTest {
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined,
         emitOutputToParent = { WorkflowOutput("output:$it") }
     )
@@ -1240,7 +1240,7 @@ class WorkflowNodeTest {
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
-        snapshot = TreeSnapshot.NONE,
+        snapshot = null,
         baseContext = Unconfined,
         emitOutputToParent = { WorkflowOutput(it) }
     )

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowRunnerTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowRunnerTest.kt
@@ -17,7 +17,6 @@ package com.squareup.workflow1.internal
 
 import com.squareup.workflow1.ExperimentalWorkflowApi
 import com.squareup.workflow1.NoopWorkflowInterceptor
-import com.squareup.workflow1.TreeSnapshot
 import com.squareup.workflow1.Worker
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.action
@@ -256,6 +255,6 @@ class WorkflowRunnerTest {
     workflow: Workflow<P, O, R>,
     props: StateFlow<P>
   ): WorkflowRunner<P, O, R> = WorkflowRunner(
-      scope, workflow, props, snapshot = TreeSnapshot.NONE, interceptor = NoopWorkflowInterceptor
+      scope, workflow, props, snapshot = null, interceptor = NoopWorkflowInterceptor
   )
 }

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTestRuntime.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTestRuntime.kt
@@ -361,10 +361,10 @@ fun <T, PropsT, StateT, OutputT, RenderingT>
   }
 
   val snapshot = when (val startFrom = testParams.startFrom) {
-    StartFresh -> TreeSnapshot.NONE
+    StartFresh -> null
     is StartFromWorkflowSnapshot -> TreeSnapshot.forRootOnly(startFrom.snapshot)
     is StartFromCompleteSnapshot -> startFrom.snapshot
-    is StartFromState -> TreeSnapshot.NONE
+    is StartFromState -> null
   }
 
   val workflowScope = CoroutineScope(Unconfined + context + uncaughtExceptionHandler)

--- a/workflow-testing/src/test/java/com/squareup/workflow1/SnapshottingIntegrationTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/SnapshottingIntegrationTest.kt
@@ -27,7 +27,7 @@ class SnapshottingIntegrationTest {
 
   @Test fun `snapshots and restores single workflow`() {
     val root = TreeWorkflow("root")
-    var snapshot = TreeSnapshot.NONE
+    var snapshot: TreeSnapshot? = null
 
     // Setup initial state and change the state the workflow in the tree.
     root.launchForTestingFromStartWith("initial props") {
@@ -44,27 +44,15 @@ class SnapshottingIntegrationTest {
 
     root.launchForTestingFromStartWith(
         props = "unused props",
-        testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot))
+        testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot!!))
     ) {
       assertEquals("root:new data", awaitNextRendering().data)
     }
   }
 
-  @Test fun `empty snapshot is ignored`() {
-    val root = TreeWorkflow("root")
-    val snapshot = TreeSnapshot.NONE
-
-    root.launchForTestingFromStartWith(
-        props = "initial props",
-        testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot))
-    ) {
-      // Success!
-    }
-  }
-
   @Test fun `snapshots and restores parent child workflows`() {
     val root = TreeWorkflow("root", TreeWorkflow("leaf"))
-    var snapshot = TreeSnapshot.NONE
+    var snapshot: TreeSnapshot? = null
 
     // Setup initial state and change the state the workflow in the tree.
     root.launchForTestingFromStartWith("initial props") {
@@ -87,7 +75,7 @@ class SnapshottingIntegrationTest {
 
     root.launchForTestingFromStartWith(
         props = "unused props",
-        testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot))
+        testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot!!))
     ) {
       awaitNextRendering()
           .let {
@@ -110,7 +98,7 @@ class SnapshottingIntegrationTest {
             TreeWorkflow("leaf3")
         )
     )
-    var snapshot = TreeSnapshot.NONE
+    var snapshot: TreeSnapshot? = null
 
     // Setup initial state and change the state of two workflows in the tree.
     root.launchForTestingFromStartWith("initial props") {
@@ -143,7 +131,7 @@ class SnapshottingIntegrationTest {
 
     root.launchForTestingFromStartWith(
         props = "unused props",
-        testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot))
+        testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot!!))
     ) {
       awaitNextRendering()
           .let {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowRunnerViewModel.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowRunnerViewModel.kt
@@ -45,17 +45,16 @@ internal class WorkflowRunnerViewModel<OutputT>(
 ) : ViewModel(), WorkflowRunner<OutputT>, SavedStateProvider {
 
   internal interface SnapshotSaver {
-    fun consumeSnapshot(): TreeSnapshot
+    fun consumeSnapshot(): TreeSnapshot?
     fun registerProvider(provider: SavedStateProvider)
 
     companion object {
       fun fromSavedStateRegistry(savedStateRegistry: SavedStateRegistry) = object : SnapshotSaver {
-        override fun consumeSnapshot(): TreeSnapshot {
+        override fun consumeSnapshot(): TreeSnapshot? {
           return savedStateRegistry
               .consumeRestoredStateForKey(BUNDLE_KEY)
               ?.getParcelable<PickledWorkflow>(BUNDLE_KEY)
               ?.snapshot
-              ?: TreeSnapshot.NONE
         }
 
         override fun registerProvider(provider: SavedStateProvider) {

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/WorkflowRunnerViewModelTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/WorkflowRunnerViewModelTest.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
+import okio.ByteString
 import org.junit.After
 import org.junit.Test
 
@@ -47,11 +48,12 @@ class WorkflowRunnerViewModelTest {
     val snapshot1 = TreeSnapshot.forRootOnly(Snapshot.of("one"))
     val snapshot2 = TreeSnapshot.forRootOnly(Snapshot.of("two"))
     val outputDeferred = CompletableDeferred<String>()
-    val renderingsAndSnapshots = MutableStateFlow(RenderingAndSnapshot(Any(), TreeSnapshot.NONE))
+    val treeSnapshot = TreeSnapshot.forRootOnly(Snapshot.of("snapshot"))
+    val renderingsAndSnapshots = MutableStateFlow(RenderingAndSnapshot(Any(), treeSnapshot))
 
     val runner = WorkflowRunnerViewModel(runnerScope, outputDeferred, renderingsAndSnapshots)
 
-    assertThat(runner.getLastSnapshotForTest()).isEqualTo(TreeSnapshot.NONE)
+    assertThat(runner.getLastSnapshotForTest()).isEqualTo(treeSnapshot)
 
     renderingsAndSnapshots.value = RenderingAndSnapshot(Unit, snapshot1)
     assertThat(runner.getLastSnapshotForTest()).isEqualTo(snapshot1)
@@ -112,7 +114,8 @@ class WorkflowRunnerViewModelTest {
       )
     }
     val outputDeferred = CompletableDeferred<String>()
-    val renderingsAndSnapshots = MutableStateFlow(RenderingAndSnapshot(Any(), TreeSnapshot.NONE))
+    val treeSnapshot = TreeSnapshot.forRootOnly(Snapshot.of(ByteString.EMPTY))
+    val renderingsAndSnapshots = MutableStateFlow(RenderingAndSnapshot(Any(), treeSnapshot))
     val runner = WorkflowRunnerViewModel(runnerScope, outputDeferred, renderingsAndSnapshots)
 
     assertThat(cancellationException).isNull()
@@ -172,7 +175,7 @@ class WorkflowRunnerViewModelTest {
         .firstOrNull { it !is CancellationException }
 
   object NoopSnapshotSaver : SnapshotSaver {
-    override fun consumeSnapshot(): TreeSnapshot = TreeSnapshot.NONE
+    override fun consumeSnapshot(): TreeSnapshot? = null
     override fun registerProvider(provider: SavedStateProvider) = Unit
   }
 }


### PR DESCRIPTION
Closes #134.