### PR TITLE
Revert "Emit output before next render pass."

### DIFF
--- a/workflow-runtime/src/main/java/com/squareup/workflow1/RenderWorkflow.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/RenderWorkflow.kt
@@ -151,10 +151,12 @@ fun <PropsT, OutputT, RenderingT> renderWorkflowIn(
       // It might look weird to start by consuming the output before getting the rendering below,
       // but remember the first render pass already occurred above, before this coroutine was even
       // launched.
-      runner.nextOutput()
-          ?.let { onOutput(it.value) }
+      val output = runner.nextOutput()
 
+      // After receiving an output, the next render pass must be done before emitting that output,
+      // so that the workflow states appear consistent to observers of the outputs and renderings.
       renderingsAndSnapshots.value = runner.nextRendering()
+      output?.let { onOutput(it.value) }
     }
   }
 

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/RenderWorkflowInTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/RenderWorkflowInTest.kt
@@ -439,8 +439,8 @@ class RenderWorkflowInTest {
     assertEquals(
         listOf(
             "rendering({no output})",
-            "output(output)",
-            "rendering(output)"
+            "rendering(output)",
+            "output(output)"
         ),
         events
     )


### PR DESCRIPTION
This reverts commit b084b16cf72618702e442e8ceac99cf168debbcd from #68 and closes #147.
The change this reverts was related to issue #54.