### PR TITLE
Fix RenderTester workflow class matching for mocked workflow instances.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -76,8 +76,8 @@ object Dependencies {
       const val common = "org.jetbrains.kotlin:kotlin-test-common"
       const val annotations = "org.jetbrains.kotlin:kotlin-test-annotations-common"
       const val jdk = "org.jetbrains.kotlin:kotlin-test-junit"
-
       const val mockito = "com.nhaarman:mockito-kotlin-kt1.1:_"
+      const val mockk = "io.mockk:mockk:_"
     }
   }
 

--- a/versions.properties
+++ b/versions.properties
@@ -29,6 +29,7 @@ version.com.vanniktech..gradle-maven-publish-plugin=0.12.0
 version.cycler=0.1.4
 version.google.android.material=1.1.0
 version.io.gitlab.arturbosch.detekt..detekt-gradle-plugin=1.0.1
+version.io.mockk..mockk=1.10.0
 version.io.reactivex.rxjava2..rxandroid=2.1.1
 version.io.reactivex.rxjava2..rxjava=2.2.19
 version.junit.junit=4.13

--- a/workflow-testing/build.gradle.kts
+++ b/workflow-testing/build.gradle.kts
@@ -56,4 +56,6 @@ dependencies {
   implementation(Dependencies.Kotlin.reflect)
 
   testImplementation(Dependencies.Kotlin.Test.jdk)
+  testImplementation(Dependencies.Kotlin.Test.mockito)
+  testImplementation(Dependencies.Kotlin.Test.mockk)
 }


### PR DESCRIPTION
Turns out that mocks made with at least some mocking libraries (tested
with Mockito and Mockk) aren't seen by Kotlin reflection as subclassing
their mocked types. That is, `Interface::class.isSuperclassOf(mock<Interface>()::class)`
returns false. This change works around that issue by falling back to java reflection
if `KClass.isSuperclassOf` returns false.

Fixes #155.