### PR TITLE
Remove unused T param for testFromState.

### DIFF
--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTestRuntime.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTestRuntime.kt
@@ -289,7 +289,7 @@ fun <T, PropsT, StateT, OutputT, RenderingT>
 @TestOnly
 @Suppress("NOTHING_TO_INLINE")
 /* ktlint-disable parameter-list-wrapping */
-inline fun <T, StateT, OutputT, RenderingT>
+inline fun <StateT, OutputT, RenderingT>
     StatefulWorkflow<Unit, StateT, OutputT, RenderingT>.testFromState(
   initialState: StateT,
   context: CoroutineContext = EmptyCoroutineContext,


### PR DESCRIPTION
This method is deprecated, but since the parameter is unused, it can't be inferred,
and causes the compiler to complain that it can't be inferred without being
explicitly specified, which breaks existing code on migration.