### PR TITLE
Don't inherit visibility from WorkflowViewStub

### DIFF
--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardsListLayoutRunner.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardsListLayoutRunner.kt
@@ -16,7 +16,6 @@
 package com.squareup.sample.dungeon
 
 import android.view.View
-import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.widget.TextView
@@ -70,16 +69,7 @@ class BoardsListLayoutRunner(rootView: View) : LayoutRunner<DisplayBoardsListScr
             val boardPreviewView: WorkflowViewStub = view.findViewById(R.id.board_preview_stub)
 
             boardNameView.text = item.board.metadata.name
-            boardPreviewView.update(item.board, item.viewEnvironment)
-
-            // Gratuitous, hacky, inline test of WorkflowViewStub features.
-            check(boardPreviewView.actual.visibility == INVISIBLE) {
-              "Expected swizzled board to be INVISIBLE"
-            }
-            boardPreviewView.visibility = VISIBLE
-            check(view.findViewById<View>(R.id.board_preview).visibility == VISIBLE) {
-              "Expected swizzled board to be VISIBLE"
-            }
+            boardPreviewView.update(item.board, item.viewEnvironment).visibility = VISIBLE
 
             card.setOnClickListener { item.onClicked() }
           }

--- a/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
+++ b/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
@@ -32,6 +32,7 @@ import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.squareup.sample.gameworkflow.GamePlayScreen
@@ -189,7 +190,7 @@ class TicTacToeEspressoTest {
 
     // Rotate and then use the back button to go back and see the login screen again.
     rotate()
-    pressBack()
+    onView(withContentDescription(R.string.back_arrow_description)).perform(click())
     // Make sure edit text was restored from view state cached by the back stack container.
     onView(withId(R.id.login_email)).check(matches(withText("foo@2fa")))
   }

--- a/samples/tictactoe/app/src/main/res/layout/second_factor_layout.xml
+++ b/samples/tictactoe/app/src/main/res/layout/second_factor_layout.xml
@@ -24,6 +24,7 @@
       android:layout_width="match_parent"
       android:layout_height="?attr/actionBarSize"
       app:navigationIcon="?attr/homeAsUpIndicator"
+      app:navigationContentDescription="@string/back_arrow_description"
       app:title="Enter Second Factor"
       />
 

--- a/samples/tictactoe/app/src/main/res/values/strings.xml
+++ b/samples/tictactoe/app/src/main/res/values/strings.xml
@@ -28,4 +28,5 @@
   <string name="player_o">Player O</string>
   <string name="player_x">Player X</string>
   <string name="second_factor_hint">one time token</string>
+  <string name="back_arrow_description">Navigate up</string>
 </resources>

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
@@ -94,6 +94,7 @@ class WorkflowViewStub @JvmOverloads constructor(
     inflatedId = attrs.getResourceId(R.styleable.WorkflowViewStub_inflatedId, NO_ID)
     attrs.recycle()
 
+    visibility = GONE
     setWillNotDraw(true)
   }
 
@@ -114,8 +115,8 @@ class WorkflowViewStub @JvmOverloads constructor(
   }
 
   /**
-   * Sets the visibility of this stub as usual, and also that of [actual].
-   * Any new views created by [update] will be assigned this visibility.
+   * Sets the visibility of this stub as usual, and also that of [actual] if it exists.
+   * Any new views created by [update] will NOT be assigned this visibility.
    */
   override fun setVisibility(visibility: Int) {
     super.setVisibility(visibility)
@@ -166,6 +167,7 @@ class WorkflowViewStub @JvmOverloads constructor(
     actual.takeIf { it.canShowRendering(rendering) }
         ?.let {
           it.showRendering(rendering, viewEnvironment)
+          super.setVisibility(it.visibility)
           return it
         }
 
@@ -177,10 +179,10 @@ class WorkflowViewStub @JvmOverloads constructor(
     return viewEnvironment[ViewRegistry].buildView(rendering, viewEnvironment, parent)
         .also { newView ->
           if (inflatedId != NO_ID) newView.id = inflatedId
-          newView.visibility = visibility
           background?.let { newView.background = it }
           replaceOldViewInParent(parent, newView)
           actual = newView
+          super.setVisibility(actual.visibility)
         }
   }
 }


### PR DESCRIPTION
Setting the default visibility to GONE mimics android's `ViewStub` and addresses the scenario specified in #170.
This then causes the next view to be also GONE though, since visibilities are inherited.

Not sure how/when Square is setting visibilities on WorkflowViewStubs, and whether this would break things or not.
Perhaps letting users override visibility when calling update() is another solution?

This change allows LayoutRunners to set their own visibility to GONE if required.