### PR TITLE
Introduces WorkflowViewStub.updatesVisibility

### DIFF
--- a/samples/stub-visibility/build.gradle.kts
+++ b/samples/stub-visibility/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+  id("com.android.application")
+  kotlin("android")
+}
+
+apply(from = rootProject.file(".buildscript/android-sample-app.gradle"))
+apply(from = rootProject.file(".buildscript/android-ui-tests.gradle"))
+
+android {
+  defaultConfig {
+    applicationId = "com.squareup.sample.stubvisibility"
+  }
+}
+
+dependencies {
+  implementation(project(":workflow-ui:core-android"))
+
+  implementation(Dependencies.AndroidX.viewbinding)
+}

--- a/samples/stub-visibility/src/androidTest/java/com/squareup/sample/stubvisibility/StubVisibilityAppTest.kt
+++ b/samples/stub-visibility/src/androidTest/java/com/squareup/sample/stubvisibility/StubVisibilityAppTest.kt
@@ -1,0 +1,37 @@
+package com.squareup.sample.stubvisibility
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.not
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StubVisibilityAppTest {
+
+  @Rule @JvmField val scenarioRule = ActivityScenarioRule(StubVisibilityActivity::class.java)
+
+  @Test fun togglesFooter() {
+    onView(withId(R.id.should_be_wrapped))
+        .check(matches(not(isDisplayed())))
+
+    onView(withText("Click to show footer"))
+        .perform(click())
+
+    onView(withId(R.id.should_be_wrapped))
+        .check(matches(isDisplayed()))
+
+    onView(withText("Click to hide footer"))
+        .perform(click())
+
+    onView(withId(R.id.should_be_wrapped))
+        .check(matches(not(isDisplayed())))
+  }
+}

--- a/samples/stub-visibility/src/main/AndroidManifest.xml
+++ b/samples/stub-visibility/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.squareup.sample.stubvisibility"
+    >
+
+  <application
+      android:allowBackup="false"
+      android:label="@string/app_name"
+      android:theme="@style/AppTheme"
+      tools:ignore="GoogleAppIndexingWarning,MissingApplicationIcon"
+      >
+
+    <activity android:name=".StubVisibilityActivity">
+
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+
+    </activity>
+
+  </application>
+</manifest>

--- a/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityActivity.kt
+++ b/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityActivity.kt
@@ -1,0 +1,25 @@
+package com.squareup.sample.stubvisibility
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.squareup.workflow1.SimpleLoggingWorkflowInterceptor
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.ViewRegistry
+import com.squareup.workflow1.ui.WorkflowRunner
+import com.squareup.workflow1.ui.setContentWorkflow
+
+@OptIn(WorkflowUiExperimentalApi::class)
+private val viewRegistry = ViewRegistry(StubVisibilityViewFactory, ClickyTextViewFactory)
+
+@OptIn(WorkflowUiExperimentalApi::class)
+class StubVisibilityActivity : AppCompatActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentWorkflow(viewRegistry) {
+      WorkflowRunner.Config(
+          StubVisibilityWorkflow,
+          interceptors = listOf(SimpleLoggingWorkflowInterceptor())
+      )
+    }
+  }
+}

--- a/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityViewFactory.kt
+++ b/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityViewFactory.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.stubvisibility
+
+import android.view.Gravity.CENTER
+import android.view.View
+import android.view.View.GONE
+import android.view.View.OnClickListener
+import android.view.View.VISIBLE
+import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.widget.TextView
+import com.squareup.sample.stubvisibility.StubVisibilityWorkflow.ClickyText
+import com.squareup.sample.stubvisibility.StubVisibilityWorkflow.Outer
+import com.squareup.sample.stubvisibility.databinding.StubVisibilityLayoutBinding
+import com.squareup.workflow1.ui.BuilderBinding
+import com.squareup.workflow1.ui.LayoutRunner
+import com.squareup.workflow1.ui.ViewFactory
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.bindShowRendering
+
+@OptIn(WorkflowUiExperimentalApi::class)
+val StubVisibilityViewFactory: ViewFactory<Outer> =
+  LayoutRunner.bind(StubVisibilityLayoutBinding::inflate) { rendering, env ->
+    shouldBeFilledStub.update(rendering.top, env)
+    shouldBeWrappedStub.update(rendering.bottom, env)
+  }
+
+@OptIn(WorkflowUiExperimentalApi::class)
+val ClickyTextViewFactory: ViewFactory<ClickyText> = BuilderBinding(
+    type = ClickyText::class,
+    viewConstructor = { initialRendering, initialEnv, context, _ ->
+      TextView(context).also { textView ->
+        textView.layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+        textView.gravity = CENTER
+
+        textView.bindShowRendering(initialRendering, initialEnv) { clickyText, _ ->
+          textView.text = clickyText.message
+          textView.isVisible = clickyText.visible
+          textView.setOnClickListener(
+              clickyText.onClick?.let { oc -> OnClickListener { oc() } }
+          )
+        }
+      }
+    }
+)
+
+private var View.isVisible: Boolean
+  get() = visibility == VISIBLE
+  set(value) {
+    visibility = if (value) VISIBLE else GONE
+  }

--- a/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityWorkflow.kt
+++ b/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityWorkflow.kt
@@ -1,0 +1,62 @@
+package com.squareup.sample.stubvisibility
+
+import com.squareup.sample.stubvisibility.StubVisibilityWorkflow.Outer
+import com.squareup.sample.stubvisibility.StubVisibilityWorkflow.State
+import com.squareup.sample.stubvisibility.StubVisibilityWorkflow.State.HideBottom
+import com.squareup.sample.stubvisibility.StubVisibilityWorkflow.State.ShowBottom
+import com.squareup.workflow1.Snapshot
+import com.squareup.workflow1.StatefulWorkflow
+import com.squareup.workflow1.action
+import com.squareup.workflow1.parse
+
+object StubVisibilityWorkflow : StatefulWorkflow<Unit, State, Nothing, Outer>() {
+  enum class State {
+    HideBottom,
+    ShowBottom
+  }
+
+  data class Outer(
+    val top: ClickyText,
+    val bottom: ClickyText
+  )
+
+  data class ClickyText(
+    val message: String,
+    val visible: Boolean = true,
+    val onClick: (() -> Unit)? = null
+  )
+
+  override fun initialState(
+    props: Unit,
+    snapshot: Snapshot?
+  ): State = snapshot
+      ?.bytes
+      ?.parse { source -> if (source.readInt() == 1) HideBottom else ShowBottom }
+      ?: HideBottom
+
+  override fun render(
+    props: Unit,
+    state: State,
+    context: RenderContext
+  ): Outer = when (state) {
+    HideBottom -> Outer(
+        top = ClickyText(message = "Click to show footer") {
+          context.actionSink.send(action {
+            this@action.state = ShowBottom
+          })
+        },
+        bottom = ClickyText(message = "Should not be seen", visible = false)
+    )
+    ShowBottom -> Outer(
+        top = ClickyText(message = "Click to hide footer") {
+          context.actionSink.send(action {
+            this@action.state = HideBottom
+          })
+        },
+        bottom = ClickyText(message = "Footer", visible = true)
+    )
+  }
+
+  override fun snapshotState(state: State): Snapshot =
+    Snapshot.of(if (state == HideBottom) 1 else 0)
+}

--- a/samples/stub-visibility/src/main/res/layout/stub_visibility_layout.xml
+++ b/samples/stub-visibility/src/main/res/layout/stub_visibility_layout.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+  <com.squareup.workflow1.ui.WorkflowViewStub
+      android:id="@+id/should_be_filled_stub"
+      android:background="@android:color/holo_red_dark"
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1"
+      app:inflatedId="@+id/should_be_filled"
+      />
+
+  <TextView
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1"
+      android:gravity="center"
+      android:text="This is static text"
+    />
+
+  <com.squareup.workflow1.ui.WorkflowViewStub
+      android:background="@android:color/holo_green_dark"
+      android:id="@+id/should_be_wrapped_stub"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:visibility="gone"
+      app:updatesVisibility="false"
+      app:inflatedId="@+id/should_be_wrapped"
+      />
+
+</LinearLayout>

--- a/samples/stub-visibility/src/main/res/values/strings.xml
+++ b/samples/stub-visibility/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="app_name">Stub Visibility</string>
+</resources>

--- a/samples/stub-visibility/src/main/res/values/styles.xml
+++ b/samples/stub-visibility/src/main/res/values/styles.xml
@@ -1,0 +1,8 @@
+<resources>
+
+  <!-- Base application theme. -->
+  <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <!-- Customize your theme here. -->
+  </style>
+
+</resources>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,7 @@ include(
     ":samples:hello-workflow",
     ":samples:hello-workflow-fragment",
     ":samples:recyclerview",
+    ":samples:stub-visibility",
     ":samples:tictactoe:app",
     ":samples:tictactoe:common",
     ":samples:todo-android:app",

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -173,9 +173,12 @@ public final class com/squareup/workflow1/ui/WorkflowViewStub : android/view/Vie
 	public final fun getActual ()Landroid/view/View;
 	public final fun getInflatedId ()I
 	public final fun getReplaceOldViewInParent ()Lkotlin/jvm/functions/Function2;
+	public final fun getUpdatesVisibility ()Z
+	public fun getVisibility ()I
 	public fun setBackground (Landroid/graphics/drawable/Drawable;)V
 	public final fun setInflatedId (I)V
 	public final fun setReplaceOldViewInParent (Lkotlin/jvm/functions/Function2;)V
+	public final fun setUpdatesVisibility (Z)V
 	public fun setVisibility (I)V
 	public final fun update (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;)Landroid/view/View;
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
@@ -43,8 +43,9 @@ class WorkflowLayout(
   context: Context,
   attributeSet: AttributeSet? = null
 ) : FrameLayout(context, attributeSet) {
-  private val showing: WorkflowViewStub = WorkflowViewStub(context).also {
-    addView(it, ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
+  private val showing: WorkflowViewStub = WorkflowViewStub(context).also { rootStub ->
+    rootStub.updatesVisibility = false
+    addView(rootStub, ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
   }
 
   private var restoredChildState: SparseArray<Parcelable>? = null

--- a/workflow-ui/core-android/src/main/res/values/attrs.xml
+++ b/workflow-ui/core-android/src/main/res/values/attrs.xml
@@ -18,5 +18,11 @@
   <declare-styleable name="WorkflowViewStub">
     <!-- Used as the id of views created via a WorkflowViewStub -->
     <attr name="inflatedId" format="reference"/>
+
+    <!--
+    Indicates that calls to update will also update the visibility of
+    the proxied view. Defaults to true.
+    -->
+    <attr name="updatesVisibility" format="boolean"/>
   </declare-styleable>
 </resources>


### PR DESCRIPTION
Closes #170 by giving explicit control over whether or not a stub sets the
visibility of the views it creates, or allows them to manage that themselves.
Also changes `getVisibility` to be a passthrough from `actual`.

![ezgif com-resize](https://user-images.githubusercontent.com/1884445/91770089-67105700-eb95-11ea-98a0-438fc92b60de.gif)
