### PR TITLE
Enforce distinct id and inflatedId values.

### DIFF
--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -176,6 +176,7 @@ public final class com/squareup/workflow1/ui/WorkflowViewStub : android/view/Vie
 	public final fun getUpdatesVisibility ()Z
 	public fun getVisibility ()I
 	public fun setBackground (Landroid/graphics/drawable/Drawable;)V
+	public fun setId (I)V
 	public final fun setInflatedId (I)V
 	public final fun setReplaceOldViewInParent (Lkotlin/jvm/functions/Function2;)V
 	public final fun setUpdatesVisibility (Z)V

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
@@ -98,7 +98,13 @@ class WorkflowViewStub @JvmOverloads constructor(
    * The id to be assigned to new views created by [update]. If the inflated id is
    * [View.NO_ID] (its default value), new views keep their original ids.
    */
-  @IdRes var inflatedId: Int
+  @IdRes var inflatedId: Int = NO_ID
+    set(value) {
+      require(value == NO_ID || value != id) {
+        "inflatedId and id must be distinct"
+      }
+      field = value
+    }
 
   init {
     val attrs = context.obtainStyledAttributes(
@@ -109,6 +115,13 @@ class WorkflowViewStub @JvmOverloads constructor(
     attrs.recycle()
 
     setWillNotDraw(true)
+  }
+
+  override fun setId(@IdRes id: Int) {
+    require(id == NO_ID || id != inflatedId) {
+      "id and inflatedId must be distinct"
+    }
+    super.setId(id)
   }
 
   /**


### PR DESCRIPTION
Closes #176

Cargo culting had lead to them using the same value throughout our codebase,
but we tend not to find out until it breaks view persistence, if ever.
It's easy enough to fail fast in that situation:

```
Caused by: java.lang.IllegalArgumentException: inflatedId and id must be distinct
at com.squareup.workflow1.ui.WorkflowViewStub.setInflatedId(WorkflowViewStub.kt:86)
at com.squareup.workflow1.ui.WorkflowViewStub.<init>(WorkflowViewStub.kt:96)
at com.squareup.workflow1.ui.WorkflowViewStub.<init>(WorkflowViewStub.kt:71)
at com.squareup.workflow1.ui.WorkflowViewStub.<init>(Unknown Source:8)
... 224 more
```