### PR TITLE
Fix up some names, introduce DecorativeViewFactory

### DIFF
--- a/samples/containers/android/src/main/java/com/squareup/sample/container/BackButtonScreen.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/BackButtonScreen.kt
@@ -15,14 +15,7 @@
  */
 package com.squareup.sample.container
 
-import com.squareup.workflow1.ui.BuilderViewFactory
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.ViewFactory
-import com.squareup.workflow1.ui.ViewRegistry
-import com.squareup.workflow1.ui.backPressedHandler
-import com.squareup.workflow1.ui.bindShowRendering
-import com.squareup.workflow1.ui.buildView
-import com.squareup.workflow1.ui.getShowRendering
 
 /**
  * Adds optional back button handling to a [wrapped] rendering, possibly overriding that
@@ -42,39 +35,4 @@ data class BackButtonScreen<W : Any>(
   val wrapped: W,
   val override: Boolean = false,
   val onBackPressed: (() -> Unit)? = null
-) {
-  companion object : ViewFactory<BackButtonScreen<*>>
-  by BuilderViewFactory(
-      type = BackButtonScreen::class,
-      viewConstructor = { initialRendering, initialEnv, contextForNewView, container ->
-        // Have the ViewRegistry build the view for wrapped.
-        initialEnv[ViewRegistry]
-            .buildView(
-                initialRendering.wrapped,
-                initialEnv,
-                contextForNewView,
-                container
-            )
-            .also { view ->
-              val wrappedUpdater = view.getShowRendering<Any>()!!
-
-              view.bindShowRendering(initialRendering, initialEnv) { rendering, environment ->
-                if (!rendering.override) {
-                  // Place our handler before invoking the wrapped updater, so that
-                  // its later calls to view.backPressedHandler will take precedence
-                  // over ours.
-                  view.backPressedHandler = rendering.onBackPressed
-                }
-
-                wrappedUpdater.invoke(rendering.wrapped, environment)
-
-                if (rendering.override) {
-                  // Place our handler after invoking the wrapped updater, so that ours
-                  // wins.
-                  view.backPressedHandler = rendering.onBackPressed
-                }
-              }
-            }
-      }
-  )
-}
+)

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/BackButtonScreen.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/BackButtonScreen.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.sample.container
 
-import com.squareup.workflow1.ui.BuilderBinding
+import com.squareup.workflow1.ui.BuilderViewFactory
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewRegistry
@@ -43,22 +43,22 @@ data class BackButtonScreen<W : Any>(
   val override: Boolean = false,
   val onBackPressed: (() -> Unit)? = null
 ) {
-  companion object Binding : ViewFactory<BackButtonScreen<*>>
-  by BuilderBinding(
+  companion object : ViewFactory<BackButtonScreen<*>>
+  by BuilderViewFactory(
       type = BackButtonScreen::class,
-      viewConstructor = { initialRendering, initialHints, contextForNewView, container ->
+      viewConstructor = { initialRendering, initialEnv, contextForNewView, container ->
         // Have the ViewRegistry build the view for wrapped.
-        initialHints[ViewRegistry]
+        initialEnv[ViewRegistry]
             .buildView(
                 initialRendering.wrapped,
-                initialHints,
+                initialEnv,
                 contextForNewView,
                 container
             )
             .also { view ->
               val wrappedUpdater = view.getShowRendering<Any>()!!
 
-              view.bindShowRendering(initialRendering, initialHints) { rendering, environment ->
+              view.bindShowRendering(initialRendering, initialEnv) { rendering, environment ->
                 if (!rendering.override) {
                   // Place our handler before invoking the wrapped updater, so that
                   // its later calls to view.backPressedHandler will take precedence

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/BackButtonViewFactory.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/BackButtonViewFactory.kt
@@ -1,0 +1,30 @@
+package com.squareup.sample.container
+
+import com.squareup.workflow1.ui.DecorativeViewFactory
+import com.squareup.workflow1.ui.ViewFactory
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.backPressedHandler
+
+/**
+ * [ViewFactory] that performs the work required by [BackButtonScreen].
+ */
+@WorkflowUiExperimentalApi
+object BackButtonViewFactory : ViewFactory<BackButtonScreen<*>>
+by DecorativeViewFactory(
+    type = BackButtonScreen::class,
+    map = { outer -> outer.wrapped },
+    doShowRendering = { view, innerShowRendering, outerRendering, viewEnvironment ->
+      if (!outerRendering.override) {
+        // Place our handler before invoking innerShowRendering, so that
+        // its later calls to view.backPressedHandler will take precedence
+        // over ours.
+        view.backPressedHandler = outerRendering.onBackPressed
+      }
+
+      innerShowRendering.invoke(outerRendering.wrapped, viewEnvironment)
+
+      if (outerRendering.override) {
+        // Place our handler after invoking innerShowRendering, so that ours wins.
+        view.backPressedHandler = outerRendering.onBackPressed
+      }
+    })

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/SampleContainers.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/SampleContainers.kt
@@ -23,5 +23,5 @@ import com.squareup.workflow1.ui.ViewRegistry
 
 @OptIn(WorkflowUiExperimentalApi::class)
 val SampleContainers = ViewRegistry(
-    BackButtonScreen.Binding, OverviewDetailContainer, PanelContainer, ScrimContainer
+    BackButtonScreen, OverviewDetailContainer, PanelContainer, ScrimContainer
 )

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/SampleContainers.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/SampleContainers.kt
@@ -23,5 +23,5 @@ import com.squareup.workflow1.ui.ViewRegistry
 
 @OptIn(WorkflowUiExperimentalApi::class)
 val SampleContainers = ViewRegistry(
-    BackButtonScreen, OverviewDetailContainer, PanelContainer, ScrimContainer
+    BackButtonViewFactory, OverviewDetailContainer, PanelContainer, ScrimContainer
 )

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailContainer.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailContainer.kt
@@ -19,7 +19,6 @@ import android.view.View
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import com.squareup.sample.container.R
-import com.squareup.sample.container.R.layout
 import com.squareup.sample.container.overviewdetail.OverviewDetailConfig.Detail
 import com.squareup.sample.container.overviewdetail.OverviewDetailConfig.Overview
 import com.squareup.sample.container.overviewdetail.OverviewDetailConfig.Single
@@ -101,7 +100,7 @@ class OverviewDetailContainer(view: View) : LayoutRunner<OverviewDetailScreen> {
 
   companion object : ViewFactory<OverviewDetailScreen> by LayoutRunnerViewFactory(
       type = OverviewDetailScreen::class,
-      layoutId = layout.overview_detail,
+      layoutId = R.layout.overview_detail,
       runnerConstructor = ::OverviewDetailContainer
   )
 }

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailContainer.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailContainer.kt
@@ -19,11 +19,13 @@ import android.view.View
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import com.squareup.sample.container.R
+import com.squareup.sample.container.R.layout
 import com.squareup.sample.container.overviewdetail.OverviewDetailConfig.Detail
 import com.squareup.sample.container.overviewdetail.OverviewDetailConfig.Overview
 import com.squareup.sample.container.overviewdetail.OverviewDetailConfig.Single
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.LayoutRunner
+import com.squareup.workflow1.ui.LayoutRunnerViewFactory
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowViewStub
@@ -97,9 +99,9 @@ class OverviewDetailContainer(view: View) : LayoutRunner<OverviewDetailScreen> {
     stub.update(combined, viewEnvironment + (OverviewDetailConfig to Single))
   }
 
-  companion object : ViewFactory<OverviewDetailScreen> by LayoutRunner.Binding(
+  companion object : ViewFactory<OverviewDetailScreen> by LayoutRunnerViewFactory(
       type = OverviewDetailScreen::class,
-      layoutId = R.layout.overview_detail,
+      layoutId = layout.overview_detail,
       runnerConstructor = ::OverviewDetailContainer
   )
 }

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/panel/PanelContainer.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/panel/PanelContainer.kt
@@ -25,9 +25,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import com.squareup.sample.container.R
-import com.squareup.workflow1.ui.BuilderBinding
-import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.BuilderViewFactory
 import com.squareup.workflow1.ui.ViewFactory
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.bindShowRendering
 import com.squareup.workflow1.ui.modal.ModalViewContainer
 
@@ -73,13 +73,13 @@ class PanelContainer @JvmOverloads constructor(
     }
   }
 
-  companion object : ViewFactory<PanelContainerScreen<*, *>> by BuilderBinding(
+  companion object : ViewFactory<PanelContainerScreen<*, *>> by BuilderViewFactory(
       type = PanelContainerScreen::class,
-      viewConstructor = { initialRendering, initialHints, contextForNewView, _ ->
+      viewConstructor = { initialRendering, initialEnv, contextForNewView, _ ->
         PanelContainer(contextForNewView).apply {
           id = R.id.panel_container
           layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
-          bindShowRendering(initialRendering, initialHints, ::update)
+          bindShowRendering(initialRendering, initialEnv, ::update)
         }
       }
   )

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/panel/ScrimContainer.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/panel/ScrimContainer.kt
@@ -21,7 +21,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
 import com.squareup.sample.container.R
-import com.squareup.workflow1.ui.BuilderBinding
+import com.squareup.workflow1.ui.BuilderViewFactory
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.WorkflowViewStub
@@ -106,7 +106,7 @@ class ScrimContainer @JvmOverloads constructor(
   }
 
   @OptIn(WorkflowUiExperimentalApi::class)
-  companion object : ViewFactory<ScrimContainerScreen<*>> by BuilderBinding(
+  companion object : ViewFactory<ScrimContainerScreen<*>> by BuilderViewFactory(
       type = ScrimContainerScreen::class,
       viewConstructor = { initialRendering, initialViewEnvironment, contextForNewView, _ ->
         val stub = WorkflowViewStub(contextForNewView)

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardView.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardView.kt
@@ -23,7 +23,7 @@ import android.graphics.Rect
 import android.view.View
 import androidx.core.content.ContextCompat
 import com.squareup.sample.dungeon.board.Board
-import com.squareup.workflow1.ui.BuilderBinding
+import com.squareup.workflow1.ui.BuilderViewFactory
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.bindShowRendering
@@ -99,10 +99,10 @@ class BoardView(context: Context) : View(context) {
   }
 
   @OptIn(WorkflowUiExperimentalApi::class)
-  companion object : ViewFactory<Board> by BuilderBinding(
+  companion object : ViewFactory<Board> by BuilderViewFactory(
       type = Board::class,
-      viewConstructor = { initialRendering, initialHints, contextForNewView, _ ->
+      viewConstructor = { initialRendering, initialEnv, contextForNewView, _ ->
         BoardView(contextForNewView)
-            .apply { bindShowRendering(initialRendering, initialHints) { r, _ -> update(r) } }
+            .apply { bindShowRendering(initialRendering, initialEnv) { r, _ -> update(r) } }
       })
 }

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardsListLayoutRunner.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardsListLayoutRunner.kt
@@ -91,7 +91,7 @@ class BoardsListLayoutRunner(rootView: View) : LayoutRunner<DisplayBoardsListScr
     rendering: DisplayBoardsListScreen,
     viewEnvironment: ViewEnvironment
   ) {
-    // Associate the containerHints and event handler to each item because it needs to be used when
+    // Associate the viewEnvironment and event handler to each item because it needs to be used when
     // binding the RecyclerView item above.
     // Recycler is configured with a DataSource, which effectively (and often in practice) a simple
     // wrapper around a List.

--- a/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/BaseScreenViewFactory.kt
+++ b/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/BaseScreenViewFactory.kt
@@ -32,11 +32,11 @@ import com.squareup.workflow1.ui.ViewFactory
  */
 @OptIn(WorkflowUiExperimentalApi::class)
 val BaseScreenViewFactory: ViewFactory<BaseScreen> =
-  LayoutRunner.bind(BaseScreenLayoutBinding::inflate) { rendering, containerHints ->
-    val syncHints = containerHints + (ListDiffMode to Synchronous)
-    val asyncHints = containerHints + (ListDiffMode to Asynchronous)
-    listStub.update(rendering.listRendering, containerHints)
-    syncListStub.update(rendering.listRendering, syncHints)
-    asyncListStub.update(rendering.listRendering, asyncHints)
+  LayoutRunner.bind(BaseScreenLayoutBinding::inflate) { rendering, viewEnvironment ->
+    val syncEnv = viewEnvironment + (ListDiffMode to Synchronous)
+    val asyncEnv = viewEnvironment + (ListDiffMode to Asynchronous)
+    listStub.update(rendering.listRendering, viewEnvironment)
+    syncListStub.update(rendering.listRendering, syncEnv)
+    asyncListStub.update(rendering.listRendering, asyncEnv)
     addNewRowButton.setOnClickListener { rendering.onAddRowTapped() }
   }

--- a/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityViewFactory.kt
+++ b/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityViewFactory.kt
@@ -26,7 +26,7 @@ import android.widget.TextView
 import com.squareup.sample.stubvisibility.StubVisibilityWorkflow.ClickyText
 import com.squareup.sample.stubvisibility.StubVisibilityWorkflow.Outer
 import com.squareup.sample.stubvisibility.databinding.StubVisibilityLayoutBinding
-import com.squareup.workflow1.ui.BuilderBinding
+import com.squareup.workflow1.ui.BuilderViewFactory
 import com.squareup.workflow1.ui.LayoutRunner
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
@@ -40,7 +40,7 @@ val StubVisibilityViewFactory: ViewFactory<Outer> =
   }
 
 @OptIn(WorkflowUiExperimentalApi::class)
-val ClickyTextViewFactory: ViewFactory<ClickyText> = BuilderBinding(
+val ClickyTextViewFactory: ViewFactory<ClickyText> = BuilderViewFactory(
     type = ClickyText::class,
     viewConstructor = { initialRendering, initialEnv, context, _ ->
       TextView(context).also { textView ->

--- a/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
+++ b/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
@@ -94,9 +94,9 @@ class TicTacToeEspressoTest {
       val parent = button.parent as View
       val rendering = parent.getRendering<GamePlayScreen>()!!
       assertThat(rendering.gameState.playing).isSameInstanceAs(Player.X)
-      val firstHints = parent.environment
-      assertThat(firstHints).isNotNull()
-      environment.set(firstHints)
+      val firstEnv = parent.environment
+      assertThat(firstEnv).isNotNull()
+      environment.set(firstEnv)
 
       // Make a move.
       rendering.onClick(0, 0)

--- a/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/TodoListsViewFactory.kt
+++ b/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/TodoListsViewFactory.kt
@@ -29,13 +29,14 @@ import com.squareup.workflow1.ui.ViewFactory
 
 @OptIn(WorkflowUiExperimentalApi::class)
 internal val TodoListsViewFactory: ViewFactory<TodoListsScreen> =
-  LayoutRunner.bind(TodoListsLayoutBinding::inflate) { rendering, containerHints ->
+  LayoutRunner.bind(TodoListsLayoutBinding::inflate) { rendering, viewEnvironment ->
     for ((index, list) in rendering.lists.withIndex()) {
       addRow(
           index,
           list,
-          selectable = containerHints[OverviewDetailConfig] == Overview,
-          selected = index == rendering.selection && containerHints[OverviewDetailConfig] == Overview
+          selectable = viewEnvironment[OverviewDetailConfig] == Overview,
+          selected = index == rendering.selection &&
+              viewEnvironment[OverviewDetailConfig] == Overview
       ) { rendering.onRowClicked(index) }
     }
     pruneDeadRowsFrom(rendering.lists.size)

--- a/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
+++ b/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
@@ -28,7 +28,7 @@ import androidx.transition.Scene
 import androidx.transition.Slide
 import androidx.transition.TransitionManager
 import androidx.transition.TransitionSet
-import com.squareup.workflow1.ui.BuilderBinding
+import com.squareup.workflow1.ui.BuilderViewFactory
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.Named
 import com.squareup.workflow1.ui.ViewFactory
@@ -154,14 +154,14 @@ open class BackStackContainer @JvmOverloads constructor(
   }
 
   companion object : ViewFactory<BackStackScreen<*>>
-  by BuilderBinding(
+  by BuilderViewFactory(
       type = BackStackScreen::class,
-      viewConstructor = { initialRendering, initialHints, context, _ ->
+      viewConstructor = { initialRendering, initialEnv, context, _ ->
         BackStackContainer(context)
             .apply {
               id = R.id.workflow_back_stack_container
               layoutParams = (ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
-              bindShowRendering(initialRendering, initialHints, ::update)
+              bindShowRendering(initialRendering, initialEnv, ::update)
             }
       }
   )

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -4,8 +4,17 @@ public final class com/squareup/workflow1/ui/BackPressHandlerKt {
 	public static final fun setBackPressedHandler (Landroid/view/View;Lkotlin/jvm/functions/Function0;)V
 }
 
-public final class com/squareup/workflow1/ui/BuilderBinding : com/squareup/workflow1/ui/ViewFactory {
+public final class com/squareup/workflow1/ui/BuilderViewFactory : com/squareup/workflow1/ui/ViewFactory {
 	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function4;)V
+	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun getType ()Lkotlin/reflect/KClass;
+}
+
+public final class com/squareup/workflow1/ui/DecorativeViewFactory : com/squareup/workflow1/ui/ViewFactory {
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function4;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function4;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public fun getType ()Lkotlin/reflect/KClass;
 }
@@ -15,17 +24,24 @@ public abstract interface class com/squareup/workflow1/ui/LayoutRunner {
 	public abstract fun showRendering (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
 }
 
-public final class com/squareup/workflow1/ui/LayoutRunner$Binding : com/squareup/workflow1/ui/ViewFactory {
+public final class com/squareup/workflow1/ui/LayoutRunner$Companion {
+}
+
+public final class com/squareup/workflow1/ui/LayoutRunnerViewFactory : com/squareup/workflow1/ui/ViewFactory {
 	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/jvm/functions/Function1;)V
 	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public fun getType ()Lkotlin/reflect/KClass;
 }
 
-public final class com/squareup/workflow1/ui/LayoutRunner$Companion {
-}
-
 public final class com/squareup/workflow1/ui/LifecyclesKt {
 	public static final fun lifecycleOrNull (Landroid/content/Context;)Landroidx/lifecycle/Lifecycle;
+}
+
+public final class com/squareup/workflow1/ui/NamedViewFactory : com/squareup/workflow1/ui/ViewFactory {
+	public static final field INSTANCE Lcom/squareup/workflow1/ui/NamedViewFactory;
+	public fun buildView (Lcom/squareup/workflow1/ui/Named;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun getType ()Lkotlin/reflect/KClass;
 }
 
 public final class com/squareup/workflow1/ui/ShowRenderingTag {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BuilderViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BuilderViewFactory.kt
@@ -25,7 +25,7 @@ import kotlin.reflect.KClass
  * to be generated from code. (Use [LayoutRunner] to work with XML layout resources.)
  *
  * Typical usage is to have a custom builder or view's `companion object` implement
- * [ViewFactory] by delegating to a [BuilderBinding], like this:
+ * [ViewFactory] by delegating to a [BuilderViewFactory], like this:
  *
  *    class MyView(
  *      context: Context
@@ -51,7 +51,7 @@ import kotlin.reflect.KClass
  *    )
  */
 @WorkflowUiExperimentalApi
-class BuilderBinding<RenderingT : Any>(
+class BuilderViewFactory<RenderingT : Any>(
   override val type: KClass<RenderingT>,
   private val viewConstructor: (
     initialRendering: RenderingT,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/DecorativeViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/DecorativeViewFactory.kt
@@ -1,0 +1,157 @@
+package com.squareup.workflow1.ui
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import kotlin.reflect.KClass
+
+/**
+ * A [ViewFactory] for [OuterT] that delegates view construction responsibilities
+ * to the factory registered for [InnerT]. Makes it convenient for [OuterT] to wrap
+ * instances of [InnerT] to add information or behavior, without requiring wasteful wrapping
+ * in the view system.
+ *
+ * ## Examples
+ *
+ * To make one rendering type an "alias" for another -- that is, to use the same [ViewFactory]
+ * to display it -- provide nothing but a single-arg mapping function:
+ *
+ *    class OriginalRendering(val data: String)
+ *    class AliasRendering(val similarData: String)
+ *
+ *    object DecorativeViewFactory : ViewFactory<AliasRendering>
+ *    by DecorativeViewFactory(
+ *      type = AliasRendering::class, map = { alias -> OriginalRendering(alias.similarData) }
+ *    )
+ *
+ * To make a decorator type that adds information to the [ViewEnvironment]:
+ *
+ *    class NeutronFlowPolarity(val reversed) {
+ *      companion object : ViewEnvironmentKey<NeutronFlowPolarity>(NeutronFlowPolarity::class) {
+ *        override val default: NeutronFlowPolarity = NeutronFlowPolarity(reversed = false)
+ *      }
+ *    }
+ *
+ *    class NeutronFlowPolarityOverride<W>(
+ *      val wrapped: W,
+ *      val polarity: NeutronFlowPolarity
+ *    )
+ *
+ *    object NeutronFlowPolarityViewFactory : ViewFactory<NeutronFlowPolarityOverride<*>>
+ *    by DecorativeViewFactory(
+ *        type = NeutronFlowPolarityOverride::class,
+ *        map = { override, env ->
+ *          Pair(override.wrapped, env + (NeutronFlowPolarity to override.polarity))
+ *        }
+ *    )
+ *
+ * To make a decorator type that customizes [View] initialization:
+ *
+ *    class WithTutorialTips<W>(val wrapped: W)
+ *
+ *    object WithTutorialTipsViewFactory : ViewFactory<WithTutorialTips<*>>
+ *    by DecorativeViewFactory(
+ *        type = WithTutorialTips::class,
+ *        map = { withTips -> withTips.wrapped },
+ *        initView = { _, view -> TutorialTipRunner.run(view) }
+ *    )
+ *
+ * To make a decorator type that adds pre- or post-processing to [View] updates:
+ *
+ *    class BackButtonScreen<W : Any>(
+ *       val wrapped: W,
+ *       val override: Boolean = false,
+ *       val onBackPressed: (() -> Unit)? = null
+ *    )
+ *
+ *    object BackButtonViewFactory : ViewFactory<BackButtonScreen<*>>
+ *    by DecorativeViewFactory(
+ *        type = BackButtonScreen::class,
+ *        map = { outer -> outer.wrapped },
+ *        doShowRendering = { view, innerShowRendering, outerRendering, viewEnvironment ->
+ *          if (!outerRendering.override) {
+ *            // Place our handler before invoking innerShowRendering, so that
+ *            // its later calls to view.backPressedHandler will take precedence
+ *            // over ours.
+ *            view.backPressedHandler = outerRendering.onBackPressed
+ *          }
+ *
+ *          innerShowRendering.invoke(outerRendering.wrapped, viewEnvironment)
+ *
+ *          if (outerRendering.override) {
+ *            // Place our handler after invoking innerShowRendering, so that ours wins.
+ *            view.backPressedHandler = outerRendering.onBackPressed
+ *          }
+ *        })
+ *
+ * @param map called to convert instances of [OuterT] to [InnerT], and to
+ * allow [ViewEnvironment] to be transformed.
+ *
+ * @param initView called after the [ViewFactory] for [InnerT] has created a [View].
+ * Defaults to a no-op. Note that the [ViewEnvironment] is accessible via [View.environment].
+ *
+ * @param doShowRendering called to apply the [ViewShowRendering] function for
+ * [InnerT], allowing pre- and post-processing. Default implementation simply
+ * applies [map] and makes the function call.
+ */
+@WorkflowUiExperimentalApi
+class DecorativeViewFactory<OuterT : Any, InnerT : Any>(
+  override val type: KClass<OuterT>,
+  private val map: (OuterT, ViewEnvironment) -> Pair<InnerT, ViewEnvironment>,
+  private val initView: (OuterT, View) -> Unit = { _, _ -> },
+  private val doShowRendering: (
+    view: View,
+    innerShowRendering: ViewShowRendering<InnerT>,
+    outerRendering: OuterT,
+    env: ViewEnvironment
+  ) -> Unit = { _, innerShowRendering, outerRendering, viewEnvironment ->
+    val (innerRendering, processedEnv) = map(outerRendering, viewEnvironment)
+    innerShowRendering(innerRendering, processedEnv)
+  }
+) : ViewFactory<OuterT> {
+  /**
+   * Convenience constructor for cases requiring no changes to the [ViewEnvironment].
+   */
+  constructor(
+    type: KClass<OuterT>,
+    map: (OuterT) -> InnerT,
+    initView: (OuterT, View) -> Unit = { _, _ -> },
+    doShowRendering: (
+      view: View,
+      innerShowRendering: ViewShowRendering<InnerT>,
+      outerRendering: OuterT,
+      env: ViewEnvironment
+    ) -> Unit = { _, innerShowRendering, outerRendering, viewEnvironment ->
+      innerShowRendering(map(outerRendering), viewEnvironment)
+    }
+  ) : this(
+      type,
+      map = { outer, viewEnvironment -> Pair(map(outer), viewEnvironment) },
+      initView = initView,
+      doShowRendering = doShowRendering
+  )
+
+  override fun buildView(
+    initialRendering: OuterT,
+    initialViewEnvironment: ViewEnvironment,
+    contextForNewView: Context,
+    container: ViewGroup?
+  ): View {
+    val (innerInitialRendering, processedInitialEnv) = map(initialRendering, initialViewEnvironment)
+
+    return processedInitialEnv[ViewRegistry]
+        .buildView(
+            innerInitialRendering,
+            processedInitialEnv,
+            contextForNewView,
+            container
+        )
+        .also { view ->
+          val innerShowRendering: ViewShowRendering<InnerT> = view.getShowRendering()!!
+          initView(initialRendering, view)
+          view.bindShowRendering(initialRendering, processedInitialEnv) { rendering, env ->
+            doShowRendering(view, innerShowRendering, rendering, env)
+          }
+        }
+  }
+}

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunnerViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunnerViewFactory.kt
@@ -1,0 +1,36 @@
+package com.squareup.workflow1.ui
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import kotlin.reflect.KClass
+
+/**
+ * A [ViewFactory] that ties a [layout resource][layoutId] to a
+ * [LayoutRunner factory][runnerConstructor] function. See [LayoutRunner] for
+ * details.
+ */
+@WorkflowUiExperimentalApi
+class LayoutRunnerViewFactory<RenderingT : Any>(
+  override val type: KClass<RenderingT>,
+  @LayoutRes private val layoutId: Int,
+  private val runnerConstructor: (View) -> LayoutRunner<RenderingT>
+) : ViewFactory<RenderingT> {
+  override fun buildView(
+    initialRendering: RenderingT,
+    initialViewEnvironment: ViewEnvironment,
+    contextForNewView: Context,
+    container: ViewGroup?
+  ): View {
+    return contextForNewView.viewBindingLayoutInflater(container)
+        .inflate(layoutId, container, false)
+        .apply {
+          bindShowRendering(
+              initialRendering,
+              initialViewEnvironment,
+              runnerConstructor.invoke(this)::showRendering
+          )
+        }
+  }
+}

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/NamedViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/NamedViewFactory.kt
@@ -21,28 +21,4 @@ package com.squareup.workflow1.ui
  */
 @WorkflowUiExperimentalApi
 object NamedViewFactory : ViewFactory<Named<*>>
-by BuilderViewFactory(
-    type = Named::class,
-    viewConstructor = { initialRendering, initialEnv, contextForNewView, container ->
-      // Have the ViewRegistry build the view for wrapped.
-      initialEnv[ViewRegistry]
-          .buildView(
-              initialRendering.wrapped,
-              initialEnv,
-              contextForNewView,
-              container
-          )
-          .also { view ->
-            // Rendering updates will be instances of Named, but the view
-            // was built to accept updates matching the type of wrapped.
-            // So replace the view's update function with one of our
-            // own, which calls through to the original.
-
-            val wrappedUpdater = view.getShowRendering<Any>()!!
-
-            view.bindShowRendering(initialRendering, initialEnv) { rendering, environment ->
-              wrappedUpdater.invoke(rendering.wrapped, environment)
-            }
-          }
-    }
-)
+by DecorativeViewFactory(Named::class, { named -> named.wrapped })

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/NamedViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/NamedViewFactory.kt
@@ -15,16 +15,20 @@
  */
 package com.squareup.workflow1.ui
 
+/**
+ * [ViewFactory] that allows views to display instances of [Named]. Delegates
+ * to the factory for [Named.wrapped].
+ */
 @WorkflowUiExperimentalApi
-internal object NamedBinding : ViewFactory<Named<*>>
-by BuilderBinding(
+object NamedViewFactory : ViewFactory<Named<*>>
+by BuilderViewFactory(
     type = Named::class,
-    viewConstructor = { initialRendering, initialHints, contextForNewView, container ->
+    viewConstructor = { initialRendering, initialEnv, contextForNewView, container ->
       // Have the ViewRegistry build the view for wrapped.
-      initialHints[ViewRegistry]
+      initialEnv[ViewRegistry]
           .buildView(
               initialRendering.wrapped,
-              initialHints,
+              initialEnv,
               contextForNewView,
               container
           )
@@ -36,7 +40,7 @@ by BuilderBinding(
 
             val wrappedUpdater = view.getShowRendering<Any>()!!
 
-            view.bindShowRendering(initialRendering, initialHints) { rendering, environment ->
+            view.bindShowRendering(initialRendering, initialEnv) { rendering, environment ->
               wrappedUpdater.invoke(rendering.wrapped, environment)
             }
           }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/TypedViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/TypedViewRegistry.kt
@@ -22,7 +22,7 @@ import kotlin.reflect.KClass
  * rendering types.
  */
 @WorkflowUiExperimentalApi
-internal class BindingViewRegistry private constructor(
+internal class TypedViewRegistry private constructor(
   private val bindings: Map<KClass<*>, ViewFactory<*>>
 ) : ViewRegistry {
 

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewFactory.kt
@@ -23,7 +23,7 @@ import kotlin.reflect.KClass
 /**
  * Factory for [View] instances that can show renderings of type[RenderingT].
  * Use [LayoutRunner.bind] to work with XML layout resources, or
- * [BuilderBinding] to create views from code.
+ * [BuilderViewFactory] to create views from code.
  *
  * Sets of bindings are gathered in [ViewRegistry] instances.
  */

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
@@ -26,7 +26,7 @@ import kotlin.reflect.KClass
  * [ViewFactory]s that are always available.
  */
 @WorkflowUiExperimentalApi
-internal val defaultViewFactories = ViewRegistry(NamedBinding)
+internal val defaultViewFactories = ViewRegistry(NamedViewFactory)
 
 /**
  * A collection of [ViewFactory]s that can be used to display the stream of renderings
@@ -37,7 +37,7 @@ internal val defaultViewFactories = ViewRegistry(NamedBinding)
  *  - [LayoutRunner.Binding], allowing the easy pairing of Android XML layout resources with
  *    [LayoutRunner]s to drive them.
  *
- *  - [BuilderBinding], which can build views from code.
+ *  - [BuilderViewFactory], which can build views from code.
  *
  *  Registries can be assembled via concatenation, making it easy to snap together screen sets.
  *  For example:
@@ -94,7 +94,7 @@ interface ViewRegistry {
 }
 
 @WorkflowUiExperimentalApi
-fun ViewRegistry(vararg bindings: ViewFactory<*>): ViewRegistry = BindingViewRegistry(*bindings)
+fun ViewRegistry(vararg bindings: ViewFactory<*>): ViewRegistry = TypedViewRegistry(*bindings)
 
 /**
  * Returns a [ViewRegistry] that merges all the given [registries].
@@ -108,7 +108,7 @@ fun ViewRegistry(vararg registries: ViewRegistry): ViewRegistry = CompositeViewR
  * Exists as a separate overload from the other two functions to disambiguate between them.
  */
 @WorkflowUiExperimentalApi
-fun ViewRegistry(): ViewRegistry = BindingViewRegistry()
+fun ViewRegistry(): ViewRegistry = TypedViewRegistry()
 
 /**
  * It is usually more convenient to use [WorkflowViewStub] than to call this method directly.

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
@@ -71,8 +71,8 @@ class WorkflowLayout(
     renderings: Flow<Any>,
     environment: ViewEnvironment
   ) {
-    val hintsWithDefaults = environment.withDefaultViewFactories()
-    takeWhileAttached(renderings) { show(it, hintsWithDefaults) }
+    val envWithDefaults = environment.withDefaultViewFactories()
+    takeWhileAttached(renderings) { show(it, envWithDefaults) }
   }
 
   private fun ViewEnvironment.withDefaultViewFactories(): ViewEnvironment =

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/BindingViewRegistryTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/BindingViewRegistryTest.kt
@@ -26,7 +26,7 @@ class BindingViewRegistryTest {
   @Test fun `keys from bindings`() {
     val factory1 = TestViewFactory(FooRendering::class)
     val factory2 = TestViewFactory(BarRendering::class)
-    val registry = BindingViewRegistry(factory1, factory2)
+    val registry = TypedViewRegistry(factory1, factory2)
 
     assertThat(registry.keys).containsExactly(factory1.type, factory2.type)
   }
@@ -36,7 +36,7 @@ class BindingViewRegistryTest {
     val factory2 = TestViewFactory(FooRendering::class)
 
     val error = assertFailsWith<IllegalStateException> {
-      BindingViewRegistry(factory1, factory2)
+      TypedViewRegistry(factory1, factory2)
     }
     assertThat(error).hasMessageThat()
         .endsWith("must not have duplicate entries.")
@@ -46,7 +46,7 @@ class BindingViewRegistryTest {
 
   @Test fun `getFactoryFor works`() {
     val fooFactory = TestViewFactory(FooRendering::class)
-    val registry = BindingViewRegistry(fooFactory)
+    val registry = TypedViewRegistry(fooFactory)
 
     val factory = registry.getFactoryFor(FooRendering::class)
     assertThat(factory).isSameInstanceAs(fooFactory)
@@ -54,7 +54,7 @@ class BindingViewRegistryTest {
 
   @Test fun `getFactoryFor throws on missing binding`() {
     val fooFactory = TestViewFactory(FooRendering::class)
-    val registry = BindingViewRegistry(fooFactory)
+    val registry = TypedViewRegistry(fooFactory)
 
     val error = assertFailsWith<IllegalArgumentException> {
       registry.getFactoryFor(BarRendering::class)

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ViewEnvironmentTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ViewEnvironmentTest.kt
@@ -37,14 +37,14 @@ class ViewEnvironmentTest {
     }
   }
 
-  private val emptyHints = ViewEnvironment(ViewRegistry())
+  private val emptyEnv = ViewEnvironment(ViewRegistry())
 
   @Test fun defaults() {
-    assertThat(emptyHints[DataHint]).isEqualTo(DataHint())
+    assertThat(emptyEnv[DataHint]).isEqualTo(DataHint())
   }
 
   @Test fun put() {
-    val environment = emptyHints +
+    val environment = emptyEnv +
         (StringHint to "fnord") +
         (DataHint to DataHint(42, "foo"))
 
@@ -53,27 +53,27 @@ class ViewEnvironmentTest {
   }
 
   @Test fun `map equality`() {
-    val hints1 = emptyHints +
+    val env1 = emptyEnv +
         (StringHint to "fnord") +
         (DataHint to DataHint(42, "foo"))
 
-    val hints2 = emptyHints +
+    val env2 = emptyEnv +
         (StringHint to "fnord") +
         (DataHint to DataHint(42, "foo"))
 
-    assertThat(hints1).isEqualTo(hints2)
+    assertThat(env1).isEqualTo(env2)
   }
 
   @Test fun `map inequality`() {
-    val hints1 = emptyHints +
+    val env1 = emptyEnv +
         (StringHint to "fnord") +
         (DataHint to DataHint(42, "foo"))
 
-    val hints2 = emptyHints +
+    val env2 = emptyEnv +
         (StringHint to "fnord") +
         (DataHint to DataHint(43, "foo"))
 
-    assertThat(hints1).isNotEqualTo(hints2)
+    assertThat(env1).isNotEqualTo(env2)
   }
 
   @Test fun `key equality`() {
@@ -85,7 +85,7 @@ class ViewEnvironmentTest {
   }
 
   @Test fun override() {
-    val environment = emptyHints +
+    val environment = emptyEnv +
         (StringHint to "able") +
         (StringHint to "baker")
 
@@ -93,7 +93,7 @@ class ViewEnvironmentTest {
   }
 
   @Test fun `keys of the same type`() {
-    val environment = emptyHints +
+    val environment = emptyEnv +
         (StringHint to "able") +
         (OtherStringHint to "baker")
 

--- a/workflow-ui/modal-android/api/modal-android.api
+++ b/workflow-ui/modal-android/api/modal-android.api
@@ -60,13 +60,13 @@ public class com/squareup/workflow1/ui/modal/ModalViewContainer : com/squareup/w
 	protected fun updateDialog (Lcom/squareup/workflow1/ui/modal/ModalContainer$DialogRef;)V
 }
 
-public final class com/squareup/workflow1/ui/modal/ModalViewContainer$Binding : com/squareup/workflow1/ui/ViewFactory {
+public final class com/squareup/workflow1/ui/modal/ModalViewContainer$Companion {
+}
+
+public final class com/squareup/workflow1/ui/modal/ModalViewContainer$ModalViewFactory : com/squareup/workflow1/ui/ViewFactory {
 	public fun <init> (ILkotlin/reflect/KClass;)V
 	public fun buildView (Lcom/squareup/workflow1/ui/modal/HasModals;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public fun getType ()Lkotlin/reflect/KClass;
-}
-
-public final class com/squareup/workflow1/ui/modal/ModalViewContainer$Companion {
 }
 

--- a/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/AlertContainer.kt
+++ b/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/AlertContainer.kt
@@ -23,7 +23,7 @@ import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.annotation.StyleRes
 import androidx.appcompat.app.AlertDialog
-import com.squareup.workflow1.ui.BuilderBinding
+import com.squareup.workflow1.ui.BuilderViewFactory
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewEnvironment
@@ -92,21 +92,21 @@ class AlertContainer @JvmOverloads constructor(
     NEUTRAL -> DialogInterface.BUTTON_NEUTRAL
   }
 
-  private class AlertContainerBinding(
+  private class AlertContainerViewFactory(
     @StyleRes private val dialogThemeResId: Int = 0
-  ) : ViewFactory<AlertContainerScreen<*>> by BuilderBinding(
+  ) : ViewFactory<AlertContainerScreen<*>> by BuilderViewFactory(
       type = AlertContainerScreen::class,
-      viewConstructor = { initialRendering, initialHints, context, _ ->
+      viewConstructor = { initialRendering, initialEnv, context, _ ->
         AlertContainer(context, dialogThemeResId = dialogThemeResId)
             .apply {
               id = R.id.workflow_alert_container
               layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
-              bindShowRendering(initialRendering, initialHints, ::update)
+              bindShowRendering(initialRendering, initialEnv, ::update)
             }
       }
   )
 
-  companion object : ViewFactory<AlertContainerScreen<*>> by AlertContainerBinding() {
+  companion object : ViewFactory<AlertContainerScreen<*>> by AlertContainerViewFactory() {
     /**
      * Creates a [ViewFactory] to show the [AlertScreen]s of an [AlertContainerScreen]
      * as Android `AlertDialog`s.
@@ -116,6 +116,6 @@ class AlertContainer @JvmOverloads constructor(
      */
     fun customThemeBinding(
       @StyleRes dialogThemeResId: Int = 0
-    ): ViewFactory<AlertContainerScreen<*>> = AlertContainerBinding(dialogThemeResId)
+    ): ViewFactory<AlertContainerScreen<*>> = AlertContainerViewFactory(dialogThemeResId)
   }
 }

--- a/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/ModalViewContainer.kt
+++ b/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/ModalViewContainer.kt
@@ -25,9 +25,8 @@ import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import androidx.annotation.IdRes
-import com.squareup.workflow1.ui.BuilderBinding
+import com.squareup.workflow1.ui.BuilderViewFactory
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.backPressedHandler
@@ -119,24 +118,25 @@ open class ModalViewContainer @JvmOverloads constructor(
   }
 
   @PublishedApi
-  internal class Binding<H : HasModals<*, *>>(
+  internal class ModalViewFactory<H : HasModals<*, *>>(
     @IdRes id: Int,
     type: KClass<H>
-  ) : ViewFactory<H>
-  by BuilderBinding(
+  ) : com.squareup.workflow1.ui.ViewFactory<H>
+  by BuilderViewFactory(
       type = type,
-      viewConstructor = { initialRendering, initialHints, context, _ ->
+      viewConstructor = { initialRendering, initialEnv, context, _ ->
         ModalViewContainer(context).apply {
           this.id = id
           layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
-          bindShowRendering(initialRendering, initialHints, ::update)
+          bindShowRendering(initialRendering, initialEnv, ::update)
         }
       }
   )
 
   companion object {
     /**
-     * Creates a [ViewFactory] for modal container screens of type [H].
+     * Creates a [ViewFactory][com.squareup.workflow1.ui.ViewFactory] for
+     * modal container screens of type [H].
      *
      * Each view created for [HasModals.modals] will be shown in a [Dialog]
      * whose window is set to size itself to `WRAP_CONTENT` (see [android.view.Window.setLayout]).
@@ -146,6 +146,7 @@ open class ModalViewContainer @JvmOverloads constructor(
      */
     inline fun <reified H : HasModals<*, *>> binding(
       @IdRes id: Int = View.NO_ID
-    ): ViewFactory<H> = Binding(id, H::class)
+    ): com.squareup.workflow1.ui.ViewFactory<H> =
+      ModalViewFactory(id, H::class)
   }
 }


### PR DESCRIPTION
Two commits:

### Follow-up on ViewFactory, ViewEnvironment namings.
    
There were still anumber of things with a `Binding` suffix that now have a
`ViewFactory` suffix, as nature intended. Same for a lot of `hints` that are
now `env`.

### Introduces `AdditiveViewFactory`.
    
Simplifies creating `ViewFactory` implementations for wrapper renderings like
`Named` and `BackButtonScreen`.
