### PR TITLE
Disable jetifier.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,6 @@
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.parallel=true
 android.useAndroidX=true
-# Required for ViewBinding.
-android.enableJetifier=true
 # Uncomment this to diagnose "API $s is obsolete" warnings. Commented out b/c it's pretty noisy.
 #android.debug.obsoleteApi=true
 


### PR DESCRIPTION
Jetifier takes a significant amount of time to run, so this reduces our build times a lot.
It was only enabled because it was apparently required by ViewBinding, but that no longer seems
to be the case.