### PR TITLE
Introduce helpers for working with EditTexts from LayoutRunners.

### DIFF
--- a/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/inputrows/TextInputRow.kt
+++ b/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/inputrows/TextInputRow.kt
@@ -15,8 +15,6 @@
  */
 package com.squareup.sample.recyclerview.inputrows
 
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -24,7 +22,11 @@ import android.widget.EditText
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.squareup.sample.recyclerview.R
 import com.squareup.sample.recyclerview.inputrows.TextInputRow.TextHolder
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.setTextChangedListener
+import com.squareup.workflow1.ui.updateText
 
+@OptIn(WorkflowUiExperimentalApi::class)
 object TextInputRow : InputRow<String, TextHolder> {
 
   override val description: String get() = "Text Input Row"
@@ -41,10 +43,7 @@ object TextInputRow : InputRow<String, TextHolder> {
     holder: TextHolder,
     value: String
   ) {
-    val currentText = holder.editText.text.toString()
-    if (currentText != value) {
-      holder.editText.editableText.replace(0, currentText.length, value)
-    }
+    holder.editText.updateText(value)
   }
 
   override fun setListener(
@@ -52,36 +51,10 @@ object TextInputRow : InputRow<String, TextHolder> {
     renderedValue: String,
     listener: (String) -> Unit
   ) {
-    holder.textChangedListener = {
-      listener(it)
-    }
+    holder.editText.setTextChangedListener { listener(it.toString()) }
   }
 
   class TextHolder(view: View) : ViewHolder(view) {
-
     val editText: EditText = view.findViewById(R.id.edittext)
-    var textChangedListener: (String) -> Unit = {}
-
-    init {
-      editText.addTextChangedListener(object : TextWatcher {
-        override fun afterTextChanged(s: Editable) {
-          textChangedListener(s.toString())
-        }
-
-        override fun beforeTextChanged(
-          s: CharSequence?,
-          start: Int,
-          count: Int,
-          after: Int
-        ) = Unit
-
-        override fun onTextChanged(
-          s: CharSequence?,
-          start: Int,
-          before: Int,
-          count: Int
-        ) = Unit
-      })
-    }
   }
 }

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -19,6 +19,11 @@ public final class com/squareup/workflow1/ui/DecorativeViewFactory : com/squareu
 	public fun getType ()Lkotlin/reflect/KClass;
 }
 
+public final class com/squareup/workflow1/ui/EditTextsKt {
+	public static final fun setTextChangedListener (Landroid/widget/EditText;Lkotlin/jvm/functions/Function1;)V
+	public static final fun updateText (Landroid/widget/EditText;Ljava/lang/CharSequence;)V
+}
+
 public abstract interface class com/squareup/workflow1/ui/LayoutRunner {
 	public static final field Companion Lcom/squareup/workflow1/ui/LayoutRunner$Companion;
 	public abstract fun showRendering (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;)V

--- a/workflow-ui/core-android/build.gradle.kts
+++ b/workflow-ui/core-android/build.gradle.kts
@@ -25,8 +25,8 @@ java {
 }
 
 apply(from = rootProject.file(".buildscript/configure-maven-publish.gradle"))
-
 apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
+apply(from = rootProject.file(".buildscript/android-ui-tests.gradle"))
 
 dependencies {
   compileOnly(Dependencies.AndroidX.viewbinding)
@@ -51,4 +51,6 @@ dependencies {
   testImplementation(Dependencies.Kotlin.Coroutines.test)
   testImplementation(Dependencies.Kotlin.Test.jdk)
   testImplementation(Dependencies.Kotlin.Test.mockito)
+
+  androidTestImplementation(Dependencies.Test.truth)
 }

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/EditTextsTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/EditTextsTest.kt
@@ -1,0 +1,108 @@
+package com.squareup.workflow1.ui
+
+import android.text.Selection
+import android.text.SpannableStringBuilder
+import android.widget.EditText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(WorkflowUiExperimentalApi::class)
+@RunWith(AndroidJUnit4::class)
+class EditTextsTest {
+
+  private val instrumentation = InstrumentationRegistry.getInstrumentation()
+  private val editText = EditText(instrumentation.context)
+
+  @Test fun updateText_setsTextValue() {
+    assertThat(editText.text.toString()).isEqualTo("")
+
+    editText.updateText("h")
+    assertThat(editText.text.toString()).isEqualTo("h")
+
+    editText.updateText("hello")
+    assertThat(editText.text.toString()).isEqualTo("hello")
+  }
+
+  @Test fun updateText_setsSelectionWhenSpecified() {
+    editText.setText("hello")
+    assertThat(editText.selectionStart).isEqualTo(0)
+    assertThat(editText.selectionEnd).isEqualTo(0)
+
+    val newText = SpannableStringBuilder("hello")
+        .also { Selection.setSelection(it, 1, 3) }
+    editText.updateText(newText)
+    assertThat(editText.text.toString()).isEqualTo("hello")
+    assertThat(editText.selectionStart).isEqualTo(1)
+    assertThat(editText.selectionEnd).isEqualTo(3)
+  }
+
+  @Test fun updateText_preservesSelectionWhenNotSpecified() {
+    editText.setText("hello")
+    editText.setSelection(1, 3)
+
+    editText.updateText("world")
+    assertThat(editText.text.toString()).isEqualTo("world")
+    assertThat(editText.selectionStart).isEqualTo(1)
+    assertThat(editText.selectionEnd).isEqualTo(3)
+  }
+
+  @Test fun setTextChangedListener_doesntFireImmediately() {
+    var fired = false
+
+    editText.setText("hello")
+    editText.setTextChangedListener() { fired = true }
+
+    assertThat(fired).isFalse()
+  }
+
+  @Test fun setTextChangedListener_doesntFireWhenUpdateTextCalledWithInitialValue() {
+    var fired = false
+
+    editText.setTextChangedListener() { fired = true }
+    editText.updateText("")
+
+    assertThat(fired).isFalse()
+  }
+
+  @Test fun setTextChangedListener_doesntFireWhenUpdateTextCalledWithCurrentValue() {
+    var fired = false
+    editText.setText("hello")
+
+    editText.setTextChangedListener() { fired = true }
+    editText.updateText("hello")
+
+    assertThat(fired).isFalse()
+  }
+
+  @Test fun setTextChangedListener_handlesTextChanges() {
+    val changes = mutableListOf<String>()
+    editText.setTextChangedListener() { changes += it.toString() }
+
+    editText.setText("foo")
+    assertThat(changes).containsExactly("foo")
+
+    editText.text!!.append("bar")
+    assertThat(changes).containsExactly("foo", "foobar")
+  }
+
+  @Test fun setTextChangedListener_replacesPreviousListener() {
+    val changes = mutableListOf<String>()
+
+    editText.setTextChangedListener() { fail("Expected original listener not to be called.") }
+    editText.setTextChangedListener() { changes += it.toString() }
+
+    editText.setText("foo")
+    assertThat(changes).containsExactly("foo")
+  }
+
+  @Test fun setTextChangedListener_clearedWhenNull() {
+    editText.setTextChangedListener() { fail("Expected original listener not to be called.") }
+    editText.setTextChangedListener(null)
+
+    editText.setText("foo")
+  }
+}

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/EditTexts.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/EditTexts.kt
@@ -1,0 +1,100 @@
+package com.squareup.workflow1.ui
+
+import android.text.Editable
+import android.text.Selection.getSelectionEnd
+import android.text.Selection.getSelectionStart
+import android.text.TextWatcher
+import android.widget.EditText
+
+/**
+ * Helper for setting the text value of an [EditText] without disrupting the IME connection.
+ * If [text] contains a selection, then the selection of this [EditText] is updated to it.
+ *
+ * Intended to be used by [LayoutRunner]s for updating [EditText]s from workflow renderings.
+ */
+@WorkflowUiExperimentalApi
+fun EditText.updateText(text: CharSequence) {
+  if (text.areTextAndSelectionEqual(this.text)) {
+    return
+  }
+
+  val editable = editableText
+  if (editable == null) {
+    setText(text)
+  } else {
+    editable.replace(0, editable.length, text)
+  }
+
+  val textSelection = text.selection
+  if (textSelection != NO_SELECTION) {
+    setSelection(textSelection.first, textSelection.last)
+  }
+}
+
+/**
+ * Helper for setting a simple function as a callback to be invoked whenever an [EditText] text
+ * value changes. Simpler than manually invoking [EditText.removeTextChangedListener] and
+ * [EditText.addTextChangedListener] and implementing a whole [TextWatcher] manually.
+ *
+ * Intended to be used by [LayoutRunner]s for updating [EditText]s from workflow renderings.
+ */
+@WorkflowUiExperimentalApi
+fun EditText.setTextChangedListener(listener: ((CharSequence) -> Unit)?) {
+  val oldWatcher = getTag(R.id.view_text_changed_listener) as? TextChangedListenerWatcher
+
+  if (listener == null && oldWatcher != null) {
+    removeTextChangedListener(oldWatcher)
+    return
+  }
+
+  if (listener != null) {
+    if (oldWatcher == null) {
+      TextChangedListenerWatcher(listener).also { watcher ->
+        setTag(R.id.view_text_changed_listener, watcher)
+        addTextChangedListener(watcher)
+      }
+    } else {
+      oldWatcher.listener = listener
+    }
+  }
+}
+
+private fun CharSequence.areTextAndSelectionEqual(other: CharSequence): Boolean {
+  if (toString() != other.toString()) return false
+
+  val thisSelection = selection
+  val otherSelection = other.selection
+
+  // Treat "no selection" as equal to any selection.
+  if (thisSelection == NO_SELECTION || otherSelection == NO_SELECTION) return true
+  return thisSelection == otherSelection
+}
+
+private val NO_SELECTION = -1..-1
+
+private val CharSequence.selection: IntRange
+  get() = getSelectionStart(this)..getSelectionEnd(this)
+
+private class TextChangedListenerWatcher(var listener: (CharSequence) -> Unit) : TextWatcher {
+  override fun onTextChanged(
+    s: CharSequence,
+    start: Int,
+    before: Int,
+    count: Int
+  ) {
+    listener(s)
+  }
+
+  override fun beforeTextChanged(
+    s: CharSequence?,
+    start: Int,
+    count: Int,
+    after: Int
+  ) {
+    // Noop
+  }
+
+  override fun afterTextChanged(s: Editable?) {
+    // Noop
+  }
+}

--- a/workflow-ui/core-android/src/main/res/values/ids.xml
+++ b/workflow-ui/core-android/src/main/res/values/ids.xml
@@ -19,6 +19,8 @@
   <item type="id" name="view_show_rendering_function"/>
   <!-- View Tag used for back button handlers. -->
   <item type="id" name="view_back_handler"/>
+  <!-- View Tag used for EditText textChangedListener. -->
+  <item type="id" name="view_text_changed_listener"/>
   <!-- Default id used by WorkflowLayout to opt in to view persistence. -->
   <item type="id" name="workflow_layout"/>
 </resources>


### PR DESCRIPTION
This is similar to what we have internally, but also lets you update selection by passing it in via the incoming `CharSequence`.

Related to https://github.com/square/workflow/issues/1213, although doesn't attempt to solve
any cross-platform issues yet.