### PR TITLE
Make core RenderTester.expectWorkflow method internal.

### DIFF
--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -12,10 +12,12 @@ public abstract interface class com/squareup/workflow1/testing/RenderTestResult 
 	public abstract fun verifyActionResult (Lkotlin/jvm/functions/Function2;)V
 }
 
-public abstract interface class com/squareup/workflow1/testing/RenderTester {
+public abstract class com/squareup/workflow1/testing/RenderTester {
+	public fun <init> ()V
 	public abstract fun expectSideEffect (Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/testing/RenderTester;
-	public abstract fun expectWorkflow (Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/testing/RenderTester;
+	public static synthetic fun expectSideEffect$default (Lcom/squareup/workflow1/testing/RenderTester;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTester;
 	public abstract fun render (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/testing/RenderTestResult;
+	public static synthetic fun render$default (Lcom/squareup/workflow1/testing/RenderTester;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTestResult;
 }
 
 public abstract class com/squareup/workflow1/testing/RenderTester$ChildWorkflowMatch {
@@ -30,12 +32,6 @@ public final class com/squareup/workflow1/testing/RenderTester$ChildWorkflowMatc
 
 public final class com/squareup/workflow1/testing/RenderTester$ChildWorkflowMatch$NotMatched : com/squareup/workflow1/testing/RenderTester$ChildWorkflowMatch {
 	public static final field INSTANCE Lcom/squareup/workflow1/testing/RenderTester$ChildWorkflowMatch$NotMatched;
-}
-
-public final class com/squareup/workflow1/testing/RenderTester$DefaultImpls {
-	public static synthetic fun expectSideEffect$default (Lcom/squareup/workflow1/testing/RenderTester;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTester;
-	public static synthetic fun expectWorkflow$default (Lcom/squareup/workflow1/testing/RenderTester;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTester;
-	public static synthetic fun render$default (Lcom/squareup/workflow1/testing/RenderTester;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTestResult;
 }
 
 public final class com/squareup/workflow1/testing/RenderTester$RenderChildInvocation {

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/RealRenderTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/RealRenderTester.kt
@@ -78,7 +78,7 @@ internal class RealRenderTester<PropsT, StateT, OutputT, RenderingT>(
    * runtime and throw if a side effects is ran twice in the same pass.
    */
   private val ranSideEffects: MutableList<String> = mutableListOf()
-) : RenderTester<PropsT, StateT, OutputT, RenderingT>,
+) : RenderTester<PropsT, StateT, OutputT, RenderingT>(),
     BaseRenderContext<PropsT, StateT, OutputT>,
     RenderTestResult<PropsT, StateT, OutputT>,
     Sink<WorkflowAction<PropsT, StateT, OutputT>> {

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderTester.kt
@@ -221,7 +221,7 @@ fun <PropsT, StateT, OutputT, RenderingT>
  *     rendering.onCancelClicked()
  * ```
  */
-interface RenderTester<PropsT, StateT, OutputT, RenderingT> {
+abstract class RenderTester<PropsT, StateT, OutputT, RenderingT> {
 
   /**
    * Specifies that this render pass is expected to render a particular child workflow.
@@ -237,7 +237,7 @@ interface RenderTester<PropsT, StateT, OutputT, RenderingT> {
    * expectation by returning a [ChildWorkflowMatch]. If the expectation matches, the function
    * must include the rendering and optional output for the child workflow.
    */
-  fun expectWorkflow(
+  internal abstract fun expectWorkflow(
     description: String,
     exactMatch: Boolean = true,
     matcher: (RenderChildInvocation) -> ChildWorkflowMatch
@@ -258,7 +258,7 @@ interface RenderTester<PropsT, StateT, OutputT, RenderingT> {
    * [runningSideEffect][com.squareup.workflow1.RenderContext.runningSideEffect] and return true if
    * this key is expected.
    */
-  fun expectSideEffect(
+  abstract fun expectSideEffect(
     description: String,
     exactMatch: Boolean = true,
     matcher: (key: String) -> Boolean
@@ -278,7 +278,9 @@ interface RenderTester<PropsT, StateT, OutputT, RenderingT> {
    * @return A [RenderTestResult] that can be used to verify the [WorkflowAction] that was used to
    * handle a workflow or worker output or a rendering event.
    */
-  fun render(block: (rendering: RenderingT) -> Unit = {}): RenderTestResult<PropsT, StateT, OutputT>
+  abstract fun render(
+    block: (rendering: RenderingT) -> Unit = {}
+  ): RenderTestResult<PropsT, StateT, OutputT>
 
   /**
    * Describes a call to


### PR DESCRIPTION
To do this, RenderTester has been turned into an abstract class, with all abstract methods.

This solves the issue of AS/IJ autocomplete giving priority to the least-used method, and then once you've made that mistake, not offering to import the extensions, because now everything is an extension.

cc @steve-the-edwards 