### PR TITLE
Hello RenderContext.eventHandler

### DIFF
--- a/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemListWorkflow.kt
+++ b/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemListWorkflow.kt
@@ -1,23 +1,7 @@
-/*
- * Copyright 2019 Square Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.squareup.sample.poetryapp
 
 import com.squareup.sample.poetry.model.Poem
 import com.squareup.workflow1.StatelessWorkflow
-import com.squareup.workflow1.makeEventSink
 
 /**
  * Renders a given ordered list of [Poem]s. Reports the index of any that are clicked.
@@ -28,12 +12,9 @@ object PoemListWorkflow : StatelessWorkflow<List<Poem>, Int, PoemListRendering>(
     props: List<Poem>,
     context: RenderContext
   ): PoemListRendering {
-    // A sink that emits the given index as the result of this workflow.
-    val sink = context.makeEventSink { index: Int -> setOutput(index) }
-
     return PoemListRendering(
         poems = props,
-        onPoemSelected = sink::send
+        onPoemSelected = context.eventHandler { index -> setOutput(index) }
     )
   }
 }

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright 2020 Square Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.squareup.sample.hellobackbutton
 
 import android.os.Parcelable
@@ -23,7 +8,6 @@ import com.squareup.sample.hellobackbutton.HelloBackButtonWorkflow.State.Baker
 import com.squareup.sample.hellobackbutton.HelloBackButtonWorkflow.State.Charlie
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
-import com.squareup.workflow1.action
 import com.squareup.workflow1.ui.toParcelable
 import com.squareup.workflow1.ui.toSnapshot
 import kotlinx.android.parcel.Parcelize
@@ -54,26 +38,22 @@ object HelloBackButtonWorkflow : StatefulWorkflow<Unit, State, Nothing, Renderin
   ): Rendering {
     return Rendering(
         message = "$state",
-        onClick = { context.actionSink.send(advance) },
-        onBackPressed = { context.actionSink.send(retreat) }.takeIf { state != Able }
+        onClick = context.eventHandler {
+          this.state = when (this.state) {
+            Able -> Baker
+            Baker -> Charlie
+            Charlie -> Able
+          }
+        },
+        onBackPressed = if (state == Able) null else context.eventHandler {
+          this.state = when (this.state) {
+            Able -> throw IllegalStateException()
+            Baker -> Able
+            Charlie -> Baker
+          }
+        }
     )
   }
 
   override fun snapshotState(state: State): Snapshot = state.toSnapshot()
-
-  private val advance = action {
-    state = when (state) {
-      Able -> Baker
-      Baker -> Charlie
-      Charlie -> Able
-    }
-  }
-
-  private val retreat = action {
-    state = when (state) {
-      Able -> throw IllegalStateException()
-      Baker -> Able
-      Charlie -> Baker
-    }
-  }
 }

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
@@ -1,24 +1,7 @@
-/*
- * Copyright 2019 Square Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.squareup.sample.poetry
 
 import com.squareup.sample.poetry.model.Poem
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.StatelessWorkflow
-import com.squareup.workflow1.makeEventSink
 
 /**
  * Given a [Poem], renders a list of its [initialStanzas][Poem.initialStanzas].
@@ -31,15 +14,12 @@ object StanzaListWorkflow : StatelessWorkflow<Poem, Int, StanzaListRendering>() 
     props: Poem,
     context: RenderContext
   ): StanzaListRendering {
-    // A sink that emits the given index as the result of this workflow.
-    val sink = context.makeEventSink { index: Int -> setOutput(index) }
-
     return StanzaListRendering(
         title = props.title,
         subtitle = props.poet.fullName,
         firstLines = props.initialStanzas,
-        onStanzaSelected = sink::send,
-        onExit = { sink.send(-1) }
+        onStanzaSelected = context.eventHandler { index -> setOutput(index) },
+        onExit = context.eventHandler { setOutput(-1) }
     )
   }
 }

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright 2019 Square Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.squareup.sample.poetry
 
 import com.squareup.sample.poetry.StanzaWorkflow.Output
@@ -21,10 +6,7 @@ import com.squareup.sample.poetry.StanzaWorkflow.Output.ShowNextStanza
 import com.squareup.sample.poetry.StanzaWorkflow.Output.ShowPreviousStanza
 import com.squareup.sample.poetry.StanzaWorkflow.Props
 import com.squareup.sample.poetry.model.Poem
-import com.squareup.workflow1.RenderContext
-import com.squareup.workflow1.Sink
 import com.squareup.workflow1.StatelessWorkflow
-import com.squareup.workflow1.makeEventSink
 import com.squareup.workflow1.ui.Compatible
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
@@ -45,24 +27,22 @@ object StanzaWorkflow : StatelessWorkflow<Props, Output, StanzaRendering>() {
     context: RenderContext
   ): StanzaRendering {
     with(props) {
-      val sink: Sink<Output> = context.makeEventSink { setOutput(it) }
-
       val onGoBack: (() -> Unit)? = when (index) {
         0 -> null
         else -> {
-          { sink.send(ShowPreviousStanza) }
+          context.eventHandler { setOutput(ShowPreviousStanza) }
         }
       }
 
       val onGoForth: (() -> Unit)? = when (index) {
         poem.stanzas.size - 1 -> null
         else -> {
-          { sink.send(ShowNextStanza) }
+          context.eventHandler { setOutput(ShowNextStanza) }
         }
       }
 
       return StanzaRendering(
-          onGoUp = { sink.send(CloseStanzas) },
+          onGoUp = context.eventHandler { setOutput(CloseStanzas) },
           title = poem.title,
           stanzaNumber = index + 1,
           lines = poem.stanzas[index],

--- a/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
+++ b/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
@@ -19,9 +19,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.sample.timemachine.TimeMachineWorkflow.TimeMachineProps
 import com.squareup.sample.timemachine.TimeMachineWorkflow.TimeMachineProps.PlayingBackAt
 import com.squareup.sample.timemachine.TimeMachineWorkflow.TimeMachineProps.Recording
-import com.squareup.workflow1.Sink
 import com.squareup.workflow1.Workflow
-import com.squareup.workflow1.makeEventSink
 import com.squareup.workflow1.stateful
 import com.squareup.workflow1.testing.launchForTestingFromStartWith
 import org.junit.Test
@@ -42,8 +40,7 @@ class TimeMachineWorkflowTest {
     val delegateWorkflow = Workflow.stateful<String, Nothing, DelegateRendering>(
         initialState = "initial",
         render = { state ->
-          val sink: Sink<String> = makeEventSink { this.state = it }
-          DelegateRendering(state, setState = { sink.send(it) })
+          DelegateRendering(state, setState = eventHandler { s -> this.state = s })
         }
     )
     val clock = TestTimeSource()

--- a/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
+++ b/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
@@ -1,32 +1,15 @@
-/*
- * Copyright 2019 Square Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.squareup.sample.todo
 
-import com.squareup.workflow1.Sink
 import com.squareup.workflow1.StatelessWorkflow
-import com.squareup.workflow1.makeEventSink
 
 class TodoListsWorkflow : StatelessWorkflow<List<TodoList>, Int, TodoListsScreen>() {
   override fun render(
     props: List<TodoList>,
     context: RenderContext
   ): TodoListsScreen {
-    // A sink that emits the given index as the output of this workflow.
-    val sink: Sink<Int> = context.makeEventSink { index: Int -> setOutput(index) }
-
-    return TodoListsScreen(lists = props, onRowClicked = sink::send)
+    return TodoListsScreen(
+        lists = props,
+        onRowClicked = context.eventHandler { index -> setOutput(index) }
+    )
   }
 }

--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -1,10 +1,43 @@
 public abstract interface class com/squareup/workflow1/BaseRenderContext {
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public abstract fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public abstract fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/squareup/workflow1/BaseRenderContext$DefaultImpls {
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;ILjava/lang/Object;)Lkotlin/jvm/functions/Function9;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;ILjava/lang/Object;)Lkotlin/jvm/functions/Function10;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/jvm/functions/Function0;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlin/jvm/functions/Function1;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lkotlin/jvm/functions/Function2;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;ILjava/lang/Object;)Lkotlin/jvm/functions/Function3;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function5;ILjava/lang/Object;)Lkotlin/jvm/functions/Function4;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function6;ILjava/lang/Object;)Lkotlin/jvm/functions/Function5;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;ILjava/lang/Object;)Lkotlin/jvm/functions/Function6;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;ILjava/lang/Object;)Lkotlin/jvm/functions/Function7;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;ILjava/lang/Object;)Lkotlin/jvm/functions/Function8;
 	public static synthetic fun renderChild$default (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -106,6 +139,17 @@ public abstract class com/squareup/workflow1/StatefulWorkflow : com/squareup/wor
 }
 
 public final class com/squareup/workflow1/StatefulWorkflow$RenderContext : com/squareup/workflow1/BaseRenderContext {
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
@@ -118,6 +162,17 @@ public abstract class com/squareup/workflow1/StatelessWorkflow : com/squareup/wo
 }
 
 public final class com/squareup/workflow1/StatelessWorkflow$RenderContext : com/squareup/workflow1/BaseRenderContext {
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
+	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V

--- a/workflow-core/src/main/java/com/squareup/workflow1/BaseRenderContext.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/BaseRenderContext.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright 2019 Square Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 @file:Suppress("EXPERIMENTAL_API_USAGE")
 @file:JvmMultifileClass
 @file:JvmName("Workflows")
@@ -115,9 +100,122 @@ interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     key: String,
     sideEffect: suspend () -> Unit
   )
+
+  // TODO(218): We'd prefer the eventHandler methods to be extensions, but the
+  // compiler disagrees. https://youtrack.jetbrains.com/issue/KT-42741
+
+  /**
+   * Creates a function which builds a [WorkflowAction] from the
+   * given [update] function, and immediately passes it to [actionSink]. Handy for
+   * attaching event handlers to renderings.
+   *
+   * @param name A string describing the update, included in the action's [toString]
+   * as a debugging aid
+   * @param update Function that defines the workflow update.
+   */
+  fun eventHandler(
+    name: () -> String = { "eventHandler" },
+    update: WorkflowAction<PropsT, StateT, OutputT>.Updater.() -> Unit
+  ): () -> Unit {
+    return {
+      actionSink.send(action(name, update))
+    }
+  }
+
+  fun <EventT> eventHandler(
+    name: () -> String = { "eventHandler" },
+    update: WorkflowAction<PropsT, StateT, OutputT>.Updater.(EventT) -> Unit
+  ): (EventT) -> Unit {
+    return { event ->
+      actionSink.send(action(name) { update(event) })
+    }
+  }
+
+  fun <E1, E2> eventHandler(
+    name: () -> String = { "eventHandler" },
+    update: WorkflowAction<PropsT, StateT, OutputT>.Updater.(E1, E2) -> Unit
+  ): (E1, E2) -> Unit {
+    return { e1, e2 ->
+      actionSink.send(action(name) { update(e1, e2) })
+    }
+  }
+
+  fun <E1, E2, E3> eventHandler(
+    name: () -> String = { "eventHandler" },
+    update: WorkflowAction<PropsT, StateT, OutputT>.Updater.(E1, E2, E3) -> Unit
+  ): (E1, E2, E3) -> Unit {
+    return { e1, e2, e3 ->
+      actionSink.send(action(name) { update(e1, e2, e3) })
+    }
+  }
+
+  fun <E1, E2, E3, E4> eventHandler(
+    name: () -> String = { "eventHandler" },
+    update: WorkflowAction<PropsT, StateT, OutputT>.Updater.(E1, E2, E3, E4) -> Unit
+  ): (E1, E2, E3, E4) -> Unit {
+    return { e1, e2, e3, e4 ->
+      actionSink.send(action(name) { update(e1, e2, e3, e4) })
+    }
+  }
+
+  fun <E1, E2, E3, E4, E5> eventHandler(
+    name: () -> String = { "eventHandler" },
+    update: WorkflowAction<PropsT, StateT, OutputT>.Updater.(E1, E2, E3, E4, E5) -> Unit
+  ): (E1, E2, E3, E4, E5) -> Unit {
+    return { e1, e2, e3, e4, e5 ->
+      actionSink.send(action(name) { update(e1, e2, e3, e4, e5) })
+    }
+  }
+
+  fun <E1, E2, E3, E4, E5, E6> eventHandler(
+    name: () -> String = { "eventHandler" },
+    update: WorkflowAction<PropsT, StateT, OutputT>.Updater.(E1, E2, E3, E4, E5, E6) -> Unit
+  ): (E1, E2, E3, E4, E5, E6) -> Unit {
+    return { e1, e2, e3, e4, e5, e6 ->
+      actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6) })
+    }
+  }
+
+  fun <E1, E2, E3, E4, E5, E6, E7> eventHandler(
+    name: () -> String = { "eventHandler" },
+    update: WorkflowAction<PropsT, StateT, OutputT>.Updater.(E1, E2, E3, E4, E5, E6, E7) -> Unit
+  ): (E1, E2, E3, E4, E5, E6, E7) -> Unit {
+    return { e1, e2, e3, e4, e5, e6, e7 ->
+      actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6, e7) })
+    }
+  }
+
+  fun <E1, E2, E3, E4, E5, E6, E7, E8> eventHandler(
+    name: () -> String = { "eventHandler" },
+    update: WorkflowAction<PropsT, StateT, OutputT>.Updater.(E1, E2, E3, E4, E5, E6, E7, E8) -> Unit
+  ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit {
+    return { e1, e2, e3, e4, e5, e6, e7, e8 ->
+      actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6, e7, e8) })
+    }
+  }
+
+  fun <E1, E2, E3, E4, E5, E6, E7, E8, E9> eventHandler(
+    name: () -> String = { "eventHandler" },
+    update: WorkflowAction<PropsT, StateT, OutputT>
+    .Updater.(E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit
+  ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit {
+    return { e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
+      actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6, e7, e8, e9) })
+    }
+  }
+
+  fun <E1, E2, E3, E4, E5, E6, E7, E8, E9, E10> eventHandler(
+    name: () -> String = { "eventHandler" },
+    update: WorkflowAction<PropsT, StateT, OutputT>
+    .Updater.(E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit
+  ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit {
+    return { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
+      actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10) })
+    }
+  }
 }
 
-@Deprecated("Use RenderContext.actionSink.")
+@Deprecated("Use eventHandler.")
 @Suppress("DEPRECATION")
 fun <EventT : Any, PropsT, StateT, OutputT> BaseRenderContext<PropsT, StateT, OutputT>.onEvent(
   handler: (EventT) -> WorkflowAction<PropsT, StateT, OutputT>
@@ -239,6 +337,7 @@ internal fun <T, PropsT, StateT, OutputT>
  * Alternative to [RenderContext.actionSink] that allows externally defined
  * event types to be mapped to anonymous [WorkflowAction]s.
  */
+@Deprecated("Use BaseRenderContext.eventHandler")
 fun <EventT, PropsT, StateT, OutputT> BaseRenderContext<PropsT, StateT, OutputT>.makeEventSink(
   update: WorkflowAction<PropsT, StateT, OutputT>.Updater.(EventT) -> Unit
 ): Sink<EventT> = actionSink.contraMap { event ->

--- a/workflow-core/src/main/java/com/squareup/workflow1/StatefulWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/StatefulWorkflow.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright 2019 Square Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 @file:Suppress("DEPRECATION")
 @file:JvmMultifileClass
 @file:JvmName("Workflows")
@@ -22,7 +7,6 @@ package com.squareup.workflow1
 import com.squareup.workflow1.MutatorWorkflowAction.Mutator
 import com.squareup.workflow1.StatefulWorkflow.RenderContext
 import com.squareup.workflow1.WorkflowAction.Companion.toString
-import com.squareup.workflow1.WorkflowAction.Updater
 
 /**
  * A composable, stateful object that can [handle events][RenderContext.actionSink],

--- a/workflow-core/src/main/java/com/squareup/workflow1/StatelessWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/StatelessWorkflow.kt
@@ -1,24 +1,7 @@
-/*
- * Copyright 2019 Square Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 @file:JvmMultifileClass
 @file:JvmName("Workflows")
 
 package com.squareup.workflow1
-
-import com.squareup.workflow1.WorkflowAction.Updater
 
 /**
  * Minimal implementation of [Workflow] that maintains no state of its own.

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/RealRenderContextTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/RealRenderContextTest.kt
@@ -113,7 +113,8 @@ class RealRenderContextTest {
     }
   }
 
-  private val eventActionsChannel = Channel<WorkflowAction<String, String, String>>(capacity = UNLIMITED)
+  private val eventActionsChannel =
+    Channel<WorkflowAction<String, String, String>>(capacity = UNLIMITED)
 
   @Test fun `onEvent completes update`() {
     val context = createdPoisonedContext()
@@ -200,6 +201,7 @@ class RealRenderContextTest {
 
   @Test fun `makeEventSink gets event`() {
     val context = createdPoisonedContext()
+    @Suppress("DEPRECATION")
     val sink: Sink<String> = context.makeEventSink { setOutput(it) }
     // Enable sink sends.
     context.freeze()
@@ -210,6 +212,181 @@ class RealRenderContextTest {
     val (state, output) = update.applyTo("props", "state")
     assertEquals("state", state)
     assertEquals("foo", output?.value)
+  }
+
+  @Test fun `eventHandler0 gets event`() {
+    val context = createdPoisonedContext()
+    val sink: () -> Unit = context.eventHandler { setOutput("yay") }
+    // Enable sink sends.
+    context.freeze()
+
+    sink()
+
+    val update = eventActionsChannel.poll()!!
+    val (state, output) = update.applyTo("props", "state")
+    assertEquals("state", state)
+    assertEquals("yay", output?.value)
+  }
+
+  @Test fun `eventHandler1 gets event`() {
+    val context = createdPoisonedContext()
+    val sink = context.eventHandler { it: String -> setOutput(it) }
+    // Enable sink sends.
+    context.freeze()
+
+    sink("foo")
+
+    val update = eventActionsChannel.poll()!!
+    val (state, output) = update.applyTo("props", "state")
+    assertEquals("state", state)
+    assertEquals("foo", output?.value)
+  }
+
+  @Test fun `eventHandler2 gets event`() {
+    val context = createdPoisonedContext()
+    val sink = context.eventHandler { a: String, b: String -> setOutput(a + b) }
+    // Enable sink sends.
+    context.freeze()
+
+    sink("foo", "bar")
+
+    val update = eventActionsChannel.poll()!!
+    val (state, output) = update.applyTo("props", "state")
+    assertEquals("state", state)
+    assertEquals("foobar", output?.value)
+  }
+
+  @Test fun `eventHandler3 gets event`() {
+    val context = createdPoisonedContext()
+    val sink = context.eventHandler { a: String, b: String, c: String, d: String ->
+      setOutput(a + b + c + d)
+    }
+    // Enable sink sends.
+    context.freeze()
+
+    sink("foo", "bar", "baz", "bang")
+
+    val update = eventActionsChannel.poll()!!
+    val (state, output) = update.applyTo("props", "state")
+    assertEquals("state", state)
+    assertEquals("foobarbazbang", output?.value)
+  }
+
+  @Test fun `eventHandler4 gets event`() {
+    val context = createdPoisonedContext()
+    val sink = context.eventHandler { a: String, b: String, c: String, d: String ->
+      setOutput(a + b + c + d)
+    }
+    // Enable sink sends.
+    context.freeze()
+
+    sink("foo", "bar", "baz", "bang")
+
+    val update = eventActionsChannel.poll()!!
+    val (state, output) = update.applyTo("props", "state")
+    assertEquals("state", state)
+    assertEquals("foobarbazbang", output?.value)
+  }
+
+  @Test fun `eventHandler5 gets event`() {
+    val context = createdPoisonedContext()
+    val sink = context.eventHandler { a: String, b: String, c: String, d: String, e: String ->
+      setOutput(a + b + c + d + e)
+    }
+    // Enable sink sends.
+    context.freeze()
+
+    sink("foo", "bar", "baz", "bang", "buzz")
+
+    val update = eventActionsChannel.poll()!!
+    val (state, output) = update.applyTo("props", "state")
+    assertEquals("state", state)
+    assertEquals("foobarbazbangbuzz", output?.value)
+  }
+
+  @Test fun `eventHandler6 gets event`() {
+    val context = createdPoisonedContext()
+    val sink =
+      context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String ->
+        setOutput(a + b + c + d + e + f)
+      }
+    // Enable sink sends.
+    context.freeze()
+
+    sink("foo", "bar", "baz", "bang", "buzz", "qux")
+
+    val update = eventActionsChannel.poll()!!
+    val (state, output) = update.applyTo("props", "state")
+    assertEquals("state", state)
+    assertEquals("foobarbazbangbuzzqux", output?.value)
+  }
+
+  @Test fun `eventHandler7 gets event`() {
+    val context = createdPoisonedContext()
+    val sink =
+      context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String, g: String ->
+        setOutput(a + b + c + d + e + f + g)
+      }
+    // Enable sink sends.
+    context.freeze()
+
+    sink("foo", "bar", "baz", "bang", "buzz", "qux", "corge")
+
+    val update = eventActionsChannel.poll()!!
+    val (state, output) = update.applyTo("props", "state")
+    assertEquals("state", state)
+    assertEquals("foobarbazbangbuzzquxcorge", output?.value)
+  }
+
+  @Test fun `eventHandler8 gets event`() {
+    val context = createdPoisonedContext()
+    val sink =
+      context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String ->
+        setOutput(a + b + c + d + e + f + g + h)
+      }
+    // Enable sink sends.
+    context.freeze()
+
+    sink("foo", "bar", "baz", "bang", "buzz", "qux", "corge", "fred")
+
+    val update = eventActionsChannel.poll()!!
+    val (state, output) = update.applyTo("props", "state")
+    assertEquals("state", state)
+    assertEquals("foobarbazbangbuzzquxcorgefred", output?.value)
+  }
+
+  @Test fun `eventHandler9 gets event`() {
+    val context = createdPoisonedContext()
+    val sink =
+      context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String, i: String ->
+        setOutput(a + b + c + d + e + f + g + h + i)
+      }
+    // Enable sink sends.
+    context.freeze()
+
+    sink("foo", "bar", "baz", "bang", "buzz", "qux", "corge", "fred", "xyzzy")
+
+    val update = eventActionsChannel.poll()!!
+    val (state, output) = update.applyTo("props", "state")
+    assertEquals("state", state)
+    assertEquals("foobarbazbangbuzzquxcorgefredxyzzy", output?.value)
+  }
+
+  @Test fun `eventHandler10 gets event`() {
+    val context = createdPoisonedContext()
+    val sink =
+      context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String, i: String, j: String ->
+        setOutput(a + b + c + d + e + f + g + h + i + j)
+      }
+    // Enable sink sends.
+    context.freeze()
+
+    sink("foo", "bar", "baz", "bang", "buzz", "qux", "corge", "fred", "xyzzy", "plugh")
+
+    val update = eventActionsChannel.poll()!!
+    val (state, output) = update.applyTo("props", "state")
+    assertEquals("state", state)
+    assertEquals("foobarbazbangbuzzquxcorgefredxyzzyplugh", output?.value)
   }
 
   @Test fun `renderChild works`() {

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/SubtreeManagerTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/SubtreeManagerTest.kt
@@ -18,7 +18,6 @@
 package com.squareup.workflow1.internal
 
 import com.squareup.workflow1.ExperimentalWorkflowApi
-import com.squareup.workflow1.Sink
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction
@@ -26,7 +25,6 @@ import com.squareup.workflow1.WorkflowOutput
 import com.squareup.workflow1.action
 import com.squareup.workflow1.applyTo
 import com.squareup.workflow1.internal.SubtreeManagerTest.TestWorkflow.Rendering
-import com.squareup.workflow1.makeEventSink
 import com.squareup.workflow1.workflowIdentifier
 import kotlinx.coroutines.Dispatchers.Unconfined
 import kotlinx.coroutines.async
@@ -66,8 +64,10 @@ class SubtreeManagerTest {
       state: String,
       context: RenderContext
     ): Rendering {
-      val sink: Sink<String> = context.makeEventSink { setOutput(it) }
-      return Rendering(props, state) { sink.send("workflow output:$it") }
+      return Rendering(
+          props,
+          state,
+          eventHandler = context.eventHandler { out -> setOutput("workflow output:$out") })
     }
 
     override fun snapshotState(state: String) = fail()


### PR DESCRIPTION
Introduces `BaseRenderContext.eventHandler` to replace the deprecated
`BaseRenderContext.onEvent`. Also deprecates
`BaseRenderContext.makeEventSink`.

Tried to make these extension methods rather than building them into the
interace, but that caused the IDE to complain that it couldn't choose the
correct overload.

closes #207, closes #208
