### PR TITLE
Eliminates caching from our CI setup, moves to Java 11

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -13,10 +13,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
-      - name: set up JDK 1.8
+      - name: set up JDK 11.0.7
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11.0.7
 
       ## Actual task
       - name: Assemble with gradle — make sure everything builds
@@ -51,10 +51,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1
-      - name: set up JDK 1.8
+      - name: set up JDK 11.0.7
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11.0.7
 
       ## Actual task
       - name: Check with Gradle
@@ -74,10 +74,10 @@ jobs:
           - 29
     steps:
       - uses: actions/checkout@v2
-      - name: set up JDK 1.8
+      - name: set up JDK 11.0.7
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11.0.7
 
       ## Actual task
       - name: Instrumentation Tests

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -6,62 +6,32 @@ on:
       - main
   pull_request:
 
-env:
-  GRADLE_HOME: ${{ github.workspace }}/gradle-home
-
 jobs:
-  assemble:
-    name: Assemble
+  dokka:
+    name: Assemble & Dokka
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      # These setup steps should be common across all jobs in this workflow.
       - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
 
-      ## Caching
-      - name: Cache gradle dependencies
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.GRADLE_HOME }}/caches
-          # Include the SHA in the hash so this step always adds a cache entry. If we didn't use the SHA, the artifacts
-          # would only get cached once for each build config hash.
-          # Don't use ${{ runner.os }} in the key so we don't re-assemble for UI tests.
-          key: gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/buildSrc/**') }}-${{ github.sha }}
-          # The first time a SHA is assembled, we still want to load dependencies from the cache.
-          # Note that none of jobs dependent on this one need restore keys, since they'll always have an exact hit.
-          restore-keys: |
-            gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/buildSrc/**') }}-
-
-      # We want to keep the dependencies from the cache, but clear out the build cache which contains the actual
-      # compiled artifacts from this project. This ensures we don't run into any issues with stale cache entries,
-      # and that the resulting cache we upload for the other jobs won't waste any space on stale binaries.
-      # A simpler approach would be simply to delete the build-cache before uploading the cache archive, however
-      # if we did that in this job it would defeat the purpose of sharing that directory with dependent jobs,
-      # and there's no way to modify the cache after the job that created it finishes.
-      - name: Clean gradle build cache to assemble fresh
-        run: |
-          ls -lhrt $GRADLE_HOME/caches || true
-          rm -rf $GRADLE_HOME/caches/build-cache-1
-          ls -lhrt $GRADLE_HOME/caches || true
-
       ## Actual task
-      - name: Assemble with gradle
-        run: ./gradlew assemble --build-cache --no-daemon --stacktrace --gradle-user-home "$GRADLE_HOME"
+      - name: Assemble with gradle — make sure everything builds
+        run: ./gradlew assemble --no-daemon --stacktrace
 
-      # This should ideally be done in the Check job below, but until gradle caching is fixed we
-      # need to do it after assembling. See https://github.com/square/workflow/issues/1152.
+      # This should ideally be done as a Check job below, but it needs to be done as a separate
+      # step after running assemble. Heckin' ridikalus.
+      # Probably fixed in dokka 1.4.10, but we can't move to kotlin 1.4 yet.
+      #  https://github.com/square/workflow/issues/1152.
       - name: Run dokka to validate kdoc
-        run: ./gradlew dokka siteDokka --build-cache --no-daemon --stacktrace --gradle-user-home "$GRADLE_HOME"
+        run: ./gradlew dokka siteDokka --build-cache --no-daemon --stacktrace
 
   # Runs all check tasks in parallel.
   check:
     name: Check
-    needs: assemble
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -80,27 +50,18 @@ jobs:
           - jmhJar
     steps:
       - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
 
-      ## Caching
-      - name: Cache build artifacts
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.GRADLE_HOME }}/caches
-          # Don't set restore-keys so cache is always only valid for the current build config.
-          # Also don't use ${{ runner.os }} in the key so we don't re-assemble for UI tests.
-          key: gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/buildSrc/**') }}-${{ github.sha }}
-
       ## Actual task
       - name: Check with Gradle
-        run: ./gradlew ${{ matrix.gradle-task }} --build-cache --no-daemon --stacktrace --gradle-user-home "$GRADLE_HOME"
+        run: ./gradlew ${{ matrix.gradle-task }} --no-daemon --stacktrace
 
   instrumentation-tests:
     name: Instrumentation tests
-    needs: assemble
     runs-on: macos-latest
     timeout-minutes: 20
     strategy:
@@ -109,8 +70,6 @@ jobs:
       matrix:
         api-level:
           # Tests are failing on APIs <24.
-          #- 21
-          #- 23
           - 24
           - 29
     steps:
@@ -120,22 +79,13 @@ jobs:
         with:
           java-version: 1.8
 
-      ## Caching
-      - name: Cache build artifacts
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.GRADLE_HOME }}/caches
-          # Don't set restore-keys so cache is always only valid for the current build config.
-          # Also don't use ${{ runner.os }} in the key so we don't re-assemble for UI tests.
-          key: gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/buildSrc/**') }}-${{ github.sha }}
-
       ## Actual task
       - name: Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
-          script: ./gradlew connectedCheck --build-cache --no-daemon --stacktrace --gradle-user-home "$GRADLE_HOME"
+          script: ./gradlew connectedCheck --no-daemon --stacktrace
 
       - name: Upload results
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Caused timeouts more often than not.

closes #211

Also a second commit to move to JDK 11.