### PR TITLE
Makes snapshots lazy again.

### DIFF
--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -16,13 +16,8 @@ public final class com/squareup/workflow1/RenderingAndSnapshot {
 	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow1/TreeSnapshot;)V
 	public final fun component1 ()Ljava/lang/Object;
 	public final fun component2 ()Lcom/squareup/workflow1/TreeSnapshot;
-	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow1/TreeSnapshot;)Lcom/squareup/workflow1/RenderingAndSnapshot;
-	public static synthetic fun copy$default (Lcom/squareup/workflow1/RenderingAndSnapshot;Ljava/lang/Object;Lcom/squareup/workflow1/TreeSnapshot;ILjava/lang/Object;)Lcom/squareup/workflow1/RenderingAndSnapshot;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRendering ()Ljava/lang/Object;
 	public final fun getSnapshot ()Lcom/squareup/workflow1/TreeSnapshot;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public class com/squareup/workflow1/SimpleLoggingWorkflowInterceptor : com/squareup/workflow1/WorkflowInterceptor {

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/RenderingAndSnapshot.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/RenderingAndSnapshot.kt
@@ -1,24 +1,16 @@
-/*
- * Copyright 2019 Square Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.squareup.workflow1
 
 /**
  * Tuple of rendering and snapshot used by [renderWorkflowIn].
+ *
+ * Note that this class keeps the default identity equality
+ * implementation it inherits from `Any`, rather than comparing
+ * its [rendering] or [snapshot].
  */
-data class RenderingAndSnapshot<out RenderingT>(
+class RenderingAndSnapshot<out RenderingT>(
   val rendering: RenderingT,
   val snapshot: TreeSnapshot
-)
+) {
+  operator fun component1() = rendering
+  operator fun component2() = snapshot
+}

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/RenderingAndSnapshotTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/RenderingAndSnapshotTest.kt
@@ -1,0 +1,24 @@
+package com.squareup.workflow1
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
+
+class RenderingAndSnapshotTest {
+  @Test fun destructuring() {
+    val snapshot = TreeSnapshot(Snapshot.of(0)) { emptyMap() }
+    val (r, t) = RenderingAndSnapshot("Rendering", snapshot)
+    assertEquals(r, "Rendering")
+    assertSame(t, snapshot)
+  }
+
+  @Test fun `identity equality`() {
+    val snapshot = TreeSnapshot(Snapshot.of(0)) { emptyMap() }
+    val me = RenderingAndSnapshot("Rendering", snapshot)
+    val you = RenderingAndSnapshot("Rendering", snapshot)
+
+    assertEquals(me, me)
+    assertNotEquals(me, you)
+  }
+}


### PR DESCRIPTION
`renderWorkflowIn` uses a `MutableStateFlow` as the source of its
`RenderingAndSnapshot` stream, and that class does an equality check as an
optimization.

Fix is to change `RenderingAndSnapshot` to ignore its `Snapshot` in `equal`,
`hashCode`, and while we're at it `toString`. Danger here is that we'll drop
updates that change only the `Snapshot`, but that seems like a pretty weird
case anyway.

Alternative would be to make `RenderingAndSnapshot` always fail equality, but
that seems like it'd be an even bigger landmine.

closes #223