### PR TITLE
A couple of Worker<Nothing> fixes.

### DIFF
--- a/workflow-core/src/main/java/com/squareup/workflow1/LifecycleWorker.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/LifecycleWorker.kt
@@ -73,5 +73,7 @@ abstract class LifecycleWorker : Worker<Nothing> {
   /**
    * Equates [LifecycleWorker]s that have the same concrete class.
    */
-  override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = true
+  override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean {
+    return otherWorker::class == this::class
+  }
 }

--- a/workflow-testing/src/test/java/com/squareup/workflow1/LifecycleWorkerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/LifecycleWorkerTest.kt
@@ -62,4 +62,12 @@ class LifecycleWorkerTest {
       assertTrue(onCancelledCalled)
     }
   }
+
+  @Test fun `doesSameWorkAs compares concrete types`() {
+    class LwA : LifecycleWorker()
+    class LwB : LifecycleWorker()
+
+    assertFalse(LwA().doesSameWorkAs(LwB()))
+    assertTrue(LwA().doesSameWorkAs(LwA()))
+  }
 }


### PR DESCRIPTION
 * `LifecycleWorker.doesSameWorkAs` now actually does compare concrete types,
   like its kdoc claims.
 * Fixes a problem where `RenderTester` thought `Worker<Nothing>` matched
   all types registered with `expectWorker`