### PR TITLE
Fixes error message when no view binding is found.

### DIFF
--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
@@ -123,7 +123,7 @@ public fun <RenderingT : Any> ViewRegistry.buildView(
 ): View {
   @Suppress("UNCHECKED_CAST")
   val factory: ViewFactory<RenderingT> = getFactoryFor(initialRendering::class)
-    ?: (initialRendering as? AndroidViewRendering<*>)?.viewFactory as ViewFactory<RenderingT>
+    ?: (initialRendering as? AndroidViewRendering<*>)?.viewFactory as? ViewFactory<RenderingT>
     ?: throw IllegalArgumentException(
       "A ${ViewFactory::class.qualifiedName} should have been registered " +
         "to display ${initialRendering::class.qualifiedName} instances, or that class " +

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ViewRegistryTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ViewRegistryTest.kt
@@ -1,0 +1,27 @@
+package com.squareup.workflow1.ui
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import kotlin.reflect.KClass
+import kotlin.test.assertFailsWith
+
+@OptIn(WorkflowUiExperimentalApi::class)
+class ViewRegistryTest {
+
+  @OptIn(WorkflowUiExperimentalApi::class)
+  @Test fun missingBindingMessage_isUseful() {
+    val emptyReg = object : ViewRegistry {
+      override val keys: Set<KClass<*>> = emptySet()
+      override fun <RenderingT : Any> getFactoryFor(
+        renderingType: KClass<out RenderingT>
+      ): ViewFactory<RenderingT>? = null
+    }
+
+    val error = assertFailsWith<IllegalArgumentException> {
+      emptyReg.buildView("render this, bud")
+    }
+    assertThat(error.message).isEqualTo(
+      "A com.squareup.workflow1.ui.ViewFactory should have been registered to display " +
+        "kotlin.String instances, or that class should implement ViewFactory<String>.")
+  }
+}


### PR DESCRIPTION
And adds explicit visibility to some existing tests to quiet IDE warnings.