### PR TITLE
Make runningSideEffect's function accept a CoroutineScope receiver.

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -12,7 +12,7 @@ public abstract interface class com/squareup/workflow1/BaseRenderContext {
 	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public abstract fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public abstract fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public abstract fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class com/squareup/workflow1/BaseRenderContext$DefaultImpls {
@@ -152,7 +152,7 @@ public final class com/squareup/workflow1/StatefulWorkflow$RenderContext : com/s
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
 public abstract class com/squareup/workflow1/StatelessWorkflow : com/squareup/workflow1/Workflow {
@@ -175,7 +175,7 @@ public final class com/squareup/workflow1/StatelessWorkflow$RenderContext : com/
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class com/squareup/workflow1/TypedWorker : com/squareup/workflow1/Worker {

--- a/workflow-core/src/main/java/com/squareup/workflow1/BaseRenderContext.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/BaseRenderContext.kt
@@ -6,6 +6,7 @@ package com.squareup.workflow1
 
 import com.squareup.workflow1.StatefulWorkflow.RenderContext
 import com.squareup.workflow1.WorkflowAction.Companion.noAction
+import kotlinx.coroutines.CoroutineScope
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
@@ -98,7 +99,7 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
    */
   public fun runningSideEffect(
     key: String,
-    sideEffect: suspend () -> Unit
+    sideEffect: suspend CoroutineScope.() -> Unit
   )
 
   // TODO(218): We'd prefer the eventHandler methods to be extensions, but the

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/internal/RealRenderContext.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/internal/RealRenderContext.kt
@@ -6,6 +6,7 @@ import com.squareup.workflow1.BaseRenderContext
 import com.squareup.workflow1.Sink
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.SendChannel
 
 internal class RealRenderContext<out PropsT, StateT, OutputT>(
@@ -26,7 +27,7 @@ internal class RealRenderContext<out PropsT, StateT, OutputT>(
   interface SideEffectRunner {
     fun runningSideEffect(
       key: String,
-      sideEffect: suspend () -> Unit
+      sideEffect: suspend CoroutineScope.() -> Unit
     )
   }
 
@@ -62,7 +63,7 @@ internal class RealRenderContext<out PropsT, StateT, OutputT>(
 
   override fun runningSideEffect(
     key: String,
-    sideEffect: suspend () -> Unit
+    sideEffect: suspend CoroutineScope.() -> Unit
   ) {
     checkNotFrozen()
     sideEffectRunner.runningSideEffect(key, sideEffect)

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/internal/WorkflowNode.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/internal/WorkflowNode.kt
@@ -123,7 +123,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
 
   override fun runningSideEffect(
     key: String,
-    sideEffect: suspend () -> Unit
+    sideEffect: suspend CoroutineScope.() -> Unit
   ) {
     // Prevent duplicate side effects with the same key.
     sideEffects.forEachStaging {
@@ -225,10 +225,10 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
 
   private fun createSideEffectNode(
     key: String,
-    sideEffect: suspend () -> Unit
+    sideEffect: suspend CoroutineScope.() -> Unit
   ): SideEffectNode {
     val scope = this + CoroutineName("sideEffect[$key] for $id")
-    val job = scope.launch(start = LAZY) { sideEffect() }
+    val job = scope.launch(start = LAZY, block = sideEffect)
     return SideEffectNode(key, job)
   }
 }

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/SimpleLoggingWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/SimpleLoggingWorkflowInterceptorTest.kt
@@ -49,7 +49,7 @@ class SimpleLoggingWorkflowInterceptorTest {
 
       override fun runningSideEffect(
         key: String,
-        sideEffect: suspend () -> Unit
+        sideEffect: suspend CoroutineScope.() -> Unit
       ) = fail()
     }
     interceptor.onRender(Unit, Unit, context, { _, _, _ -> }, TestWorkflowSession)

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/WorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/WorkflowInterceptorTest.kt
@@ -3,6 +3,7 @@
 package com.squareup.workflow1
 
 import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
+import kotlinx.coroutines.CoroutineScope
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
@@ -54,8 +55,8 @@ class WorkflowInterceptorTest {
 
       override fun runningSideEffect(
         key: String,
-        sideEffect: suspend () -> Unit
-      ): Unit = fail()
+        sideEffect: suspend CoroutineScope.() -> Unit
+      ) = fail()
     }
 
     val rendering = intercepted.render("props", "state", RenderContext(fakeContext, TestWorkflow))

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
@@ -258,7 +258,7 @@ class ChainedWorkflowInterceptorTest {
 
     override fun runningSideEffect(
       key: String,
-      sideEffect: suspend () -> Unit
+      sideEffect: suspend CoroutineScope.() -> Unit
     ) {
       fail()
     }

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/RealRenderContextTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/RealRenderContextTest.kt
@@ -18,6 +18,7 @@ import com.squareup.workflow1.makeEventSink
 import com.squareup.workflow1.onEvent
 import com.squareup.workflow1.renderChild
 import com.squareup.workflow1.stateless
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlin.test.Test
@@ -57,7 +58,7 @@ class RealRenderContextTest {
   private class TestRunner : SideEffectRunner {
     override fun runningSideEffect(
       key: String,
-      sideEffect: suspend () -> Unit
+      sideEffect: suspend CoroutineScope.() -> Unit
     ) {
       // No-op
     }
@@ -92,7 +93,7 @@ class RealRenderContextTest {
   private class PoisonRunner : SideEffectRunner {
     override fun runningSideEffect(
       key: String,
-      sideEffect: suspend () -> Unit
+      sideEffect: suspend CoroutineScope.() -> Unit
     ) {
       fail()
     }

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.coroutineContext
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -438,7 +437,7 @@ class WorkflowNodeTest {
     val events1 = mutableListOf<String>()
     val events2 = mutableListOf<String>()
     val events3 = mutableListOf<String>()
-    fun recordingSideEffect(events: MutableList<String>) = suspend {
+    fun recordingSideEffect(events: MutableList<String>): suspend CoroutineScope.() -> Unit = {
       events += "started"
       suspendCancellableCoroutine<Nothing> { continuation ->
         continuation.invokeOnCancellation { events += "cancelled" }

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/RealRenderTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/RealRenderTester.kt
@@ -20,6 +20,7 @@ import com.squareup.workflow1.testing.RealRenderTester.Expectation.ExpectedWorkf
 import com.squareup.workflow1.testing.RenderTester.ChildWorkflowMatch
 import com.squareup.workflow1.testing.RenderTester.ChildWorkflowMatch.Matched
 import com.squareup.workflow1.testing.RenderTester.RenderChildInvocation
+import kotlinx.coroutines.CoroutineScope
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.allSupertypes
@@ -211,7 +212,7 @@ internal class RealRenderTester<PropsT, StateT, OutputT, RenderingT>(
 
   override fun runningSideEffect(
     key: String,
-    sideEffect: suspend () -> Unit
+    sideEffect: suspend CoroutineScope.() -> Unit
   ) {
     require(key !in ranSideEffects) { "Expected side effect keys to be unique: \"$key\"" }
     ranSideEffects += key

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderIdempotencyChecker.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderIdempotencyChecker.kt
@@ -8,6 +8,7 @@ import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
 import com.squareup.workflow1.WorkflowInterceptor
 import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
+import kotlinx.coroutines.CoroutineScope
 import java.util.LinkedList
 
 /**
@@ -86,7 +87,7 @@ private class RecordingRenderContext<PropsT, StateT, OutputT>(
 
   override fun runningSideEffect(
     key: String,
-    sideEffect: suspend () -> Unit
+    sideEffect: suspend CoroutineScope.() -> Unit
   ) {
     if (!replaying) {
       delegate.runningSideEffect(key, sideEffect)


### PR DESCRIPTION
This is more idiomatic for coroutine-builder-style functions like this,
and makes it easy to write fire-and-forget side effects.

Closes #263.