### PR TITLE
Fix the double showRendering call when initializing DecorativeViewFactory views.

### DIFF
--- a/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/BackStackContainerTest.kt
+++ b/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/BackStackContainerTest.kt
@@ -121,7 +121,6 @@ class BackStackContainerTest {
     assertThat(consumeEvents()).containsExactly(
       "first onViewCreated viewState=",
       "first onShowRendering viewState=",
-      "first onShowRendering viewState=",
       "first onAttach viewState="
     )
 
@@ -130,7 +129,6 @@ class BackStackContainerTest {
     waitForScreen(secondRendering.name)
     assertThat(consumeEvents()).containsExactly(
       "second onViewCreated viewState=",
-      "second onShowRendering viewState=",
       "second onShowRendering viewState=",
       "first onSave viewState=hello",
       "first onDetach viewState=hello",
@@ -142,7 +140,6 @@ class BackStackContainerTest {
     waitForScreen(firstRendering.name)
     assertThat(consumeEvents()).containsExactly(
       "first onViewCreated viewState=",
-      "first onShowRendering viewState=",
       "first onShowRendering viewState=",
       "first onRestore viewState=hello",
       "second onDetach viewState=",

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -62,6 +62,12 @@ public final class com/squareup/workflow1/ui/NamedViewFactory : com/squareup/wor
 	public fun getType ()Lkotlin/reflect/KClass;
 }
 
+public final class com/squareup/workflow1/ui/NoopViewInitializer : com/squareup/workflow1/ui/ViewInitializer {
+	public static final field INSTANCE Lcom/squareup/workflow1/ui/NoopViewInitializer;
+	public fun onViewCreated (Landroid/view/View;)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/squareup/workflow1/ui/ShowRenderingTag {
 	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)V
 	public final fun component1 ()Ljava/lang/Object;
@@ -69,6 +75,7 @@ public final class com/squareup/workflow1/ui/ShowRenderingTag {
 	public final fun component3 ()Lkotlin/jvm/functions/Function2;
 	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow1/ui/ShowRenderingTag;
 	public static synthetic fun copy$default (Lcom/squareup/workflow1/ui/ShowRenderingTag;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/ShowRenderingTag;
+	public final fun doShowRendering ()V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnvironment ()Lcom/squareup/workflow1/ui/ViewEnvironment;
 	public final fun getShowRendering ()Lkotlin/jvm/functions/Function2;
@@ -117,6 +124,10 @@ public final class com/squareup/workflow1/ui/ViewFactory$DefaultImpls {
 	public static synthetic fun buildView$default (Lcom/squareup/workflow1/ui/ViewFactory;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;ILjava/lang/Object;)Landroid/view/View;
 }
 
+public abstract interface class com/squareup/workflow1/ui/ViewInitializer {
+	public abstract fun onViewCreated (Landroid/view/View;)V
+}
+
 public abstract interface class com/squareup/workflow1/ui/ViewRegistry {
 	public static final field Companion Lcom/squareup/workflow1/ui/ViewRegistry$Companion;
 	public abstract fun getFactoryFor (Lkotlin/reflect/KClass;)Lcom/squareup/workflow1/ui/ViewFactory;
@@ -132,9 +143,9 @@ public final class com/squareup/workflow1/ui/ViewRegistryKt {
 	public static final fun ViewRegistry ()Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun ViewRegistry ([Lcom/squareup/workflow1/ui/ViewFactory;)Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun ViewRegistry ([Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewRegistry;
-	public static final fun buildView (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public static final fun buildView (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;Lcom/squareup/workflow1/ui/ViewInitializer;)Landroid/view/View;
 	public static final fun buildView (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/view/ViewGroup;)Landroid/view/View;
-	public static synthetic fun buildView$default (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;ILjava/lang/Object;)Landroid/view/View;
+	public static synthetic fun buildView$default (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;Lcom/squareup/workflow1/ui/ViewInitializer;ILjava/lang/Object;)Landroid/view/View;
 	public static final fun plus (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewFactory;)Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun plus (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewRegistry;
 }

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/DecorativeViewFactoryTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/DecorativeViewFactoryTest.kt
@@ -44,10 +44,7 @@ class DecorativeViewFactoryTest {
       instrumentation.context
     )
 
-    // Note that showRendering is called twice. Technically this behavior is not incorrect, although
-    // it's not necessary. Fix coming soon.
     assertThat(events).containsExactly(
-      "inner showRendering InnerRendering(innerData=inner)",
       "initView OuterRendering(outerData=outer, wrapped=InnerRendering(innerData=inner))",
       "inner showRendering InnerRendering(innerData=inner)"
     )
@@ -86,10 +83,7 @@ class DecorativeViewFactoryTest {
       instrumentation.context
     )
 
-    // Note that showRendering is called twice. Technically this behavior is not incorrect, although
-    // it's not necessary. Fix coming soon.
     assertThat(events).containsExactly(
-      "inner showRendering InnerRendering(innerData=inner)",
       "doShowRendering OuterRendering(outerData=outer, wrapped=InnerRendering(innerData=inner))",
       "inner showRendering InnerRendering(innerData=inner)"
     )

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/ViewInitializerTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/ViewInitializerTest.kt
@@ -1,0 +1,34 @@
+package com.squareup.workflow1.ui
+
+import org.junit.Test
+
+class ViewInitializerTest {
+
+  @Test fun viewInitializer_callsShowRendering_fromParameter() {
+    TODO()
+  }
+
+  @Test fun viewInitializer_canCallShowRendering_fromTag() {
+    TODO()
+  }
+
+  @Test fun viewInitializer_canCallBindShowRendering() {
+    TODO()
+  }
+
+  @Test fun viewInitializer_notCalled_forNestedBuildView() {
+    TODO()
+  }
+
+  @Test fun viewInitializer_notCalledInSubsequentShowRenderings() {
+    TODO()
+  }
+
+  @Test fun buildView_throwsWhen_viewInitializerDoesntCallShowRendering() {
+    TODO()
+  }
+
+  @Test fun buildView_throwsWhen_viewInitializerCallsShowRenderingMultipleTimes() {
+    TODO()
+  }
+}

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewInitializer.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewInitializer.kt
@@ -1,0 +1,67 @@
+package com.squareup.workflow1.ui
+
+import android.view.View
+
+/**
+ * A single-method interface that can be passed to [buildView] to run logic after the [ViewFactory]
+ * creates the view, but before it's [ViewShowRendering] is invoked for the first time.
+ *
+ * See the documentation on [onViewCreated] for more information about how to implement this
+ * interface.
+ */
+@WorkflowUiExperimentalApi
+public fun interface ViewInitializer {
+  /**
+   * Called by [bindShowRendering] the first time it's called for a particular [View], inside a
+   * [ViewFactory.buildView] method. This function will run before the [ViewShowRendering], which
+   * gives you the chance to initialize any properties of the view that need to be set before the
+   * first [ViewShowRendering] call (e.g. [LayoutRunner.showRendering]).
+   *
+   * The [ShowRenderingTag] tag is set _before_ calling this function, so this function can use
+   * [showRenderingTag], [getShowRendering], [getRendering], etc.
+   *
+   * This function must invoke the ViewFactory's initial [`showRendering`][ViewShowRendering] logic,
+   * and it can do so in a number of ways:
+   *
+   *  - Call [getShowRendering] to get the [ViewShowRendering] and pass it the initial rendering
+   *    and [ViewEnvironment] yourself. Eg.:
+   *    ```
+   *    view.getShowRendering()!!.showRendering(rendering, viewEnvironment)
+   *    ```
+   *  - Call [bindShowRendering], and pass it a [ViewShowRendering] that in turn invokes either of
+   *    the above two functions. Eg.:
+   *    ```
+   *    val innerShowRendering = view.getShowRendering()!!
+   *    view.bindShowRendering(initialRendering, initialViewEnvironment) { rendering, environment ->
+   *      innerShowRendering(rendering, environment)
+   *    }
+   *    ```
+   *
+   * If none of these are done, or if the initial [ViewShowRendering] is invoked more than once,
+   * an [IllegalStateException] will be thrown.
+   *
+   * @param view The [View] that was just created by the [ViewFactory].
+   */
+  public fun onViewCreated(view: View)
+}
+
+/**
+ * A static [ViewInitializer] that acts as a sentinel meaning no [ViewInitializer] was specified.
+ *
+ * Its [onViewCreated] throws an exception, so code that needs to call [onViewCreated] should first
+ * check if the instance is this object, and skip the call if so.
+ */
+@OptIn(WorkflowUiExperimentalApi::class)
+public object NoopViewInitializer : ViewInitializer {
+  public override fun onViewCreated(view: View) {
+    throw UnsupportedOperationException("$this.onViewCreated should never be invoked.")
+  }
+
+  override fun toString(): String = javaClass.simpleName
+}
+
+@OptIn(WorkflowUiExperimentalApi::class)
+internal object ViewInitializerKey :
+  ViewEnvironmentKey<ViewInitializer>(ViewInitializer::class) {
+  override val default: ViewInitializer get() = NoopViewInitializer
+}


### PR DESCRIPTION
Introduces `ViewInitializer` which gets executed by `bindShowRendering` between setting
the tag and actually invoking `showRendering`, which gives the `DecorativeViewFactory`
logic the chance to cancel the original `showRendering` call since it wraps it.

This initializer concept will also be used in a follow-up PR to allow `ViewStateCache`
to correctly initialize AndroidX view tree owners.