### PR TITLE
Remove explicit buildToolsVersion.

### DIFF
--- a/.buildscript/configure-android-defaults.gradle
+++ b/.buildscript/configure-android-defaults.gradle
@@ -1,6 +1,5 @@
 android {
   compileSdkVersion Versions.targetSdk
-  buildToolsVersion '29.0.2'
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8

--- a/samples/tutorial/tutorial-1-complete/build.gradle
+++ b/samples/tutorial/tutorial-1-complete/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
   compileSdkVersion 30
-  buildToolsVersion "30.0.1"
 
   defaultConfig {
     applicationId "com.squareup.workflow.tutorial"

--- a/samples/tutorial/tutorial-2-complete/build.gradle
+++ b/samples/tutorial/tutorial-2-complete/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
   compileSdkVersion 30
-  buildToolsVersion "30.0.1"
 
   defaultConfig {
     applicationId "workflow.tutorial"

--- a/samples/tutorial/tutorial-3-complete/build.gradle
+++ b/samples/tutorial/tutorial-3-complete/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
   compileSdkVersion 30
-  buildToolsVersion "30.0.1"
 
   defaultConfig {
     applicationId "workflow.tutorial"

--- a/samples/tutorial/tutorial-4-complete/build.gradle
+++ b/samples/tutorial/tutorial-4-complete/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
   compileSdkVersion 30
-  buildToolsVersion "30.0.1"
 
   defaultConfig {
     applicationId "workflow.tutorial"

--- a/samples/tutorial/tutorial-base/build.gradle
+++ b/samples/tutorial/tutorial-base/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
   compileSdkVersion 30
-  buildToolsVersion "30.0.1"
 
   defaultConfig {
     applicationId "workflow.tutorial"

--- a/samples/tutorial/tutorial-final/build.gradle
+++ b/samples/tutorial/tutorial-final/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
   compileSdkVersion 30
-  buildToolsVersion "30.0.1"
 
   defaultConfig {
     applicationId "workflow.tutorial"

--- a/samples/tutorial/tutorial-views/build.gradle
+++ b/samples/tutorial/tutorial-views/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
   compileSdkVersion 30
-  buildToolsVersion "30.0.1"
 
   defaultConfig {
     minSdkVersion 21


### PR DESCRIPTION
This has not been required since AGP 3.1.0: https://developer.android.com/studio/releases/gradle-plugin#3-1-0