### PR TITLE
Fix bad syntax in CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence.
-* @square/mobile-foundation-android zach-klippenstein
+* @square/mobile-foundation-android @zach-klippenstein
 
 # Any files under the compose directory in the repo root should
 # be reviewed by UI Systems as well.

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,0 +1,23 @@
+name: Validate Codeowners
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  codeowners:
+    name: Validate Codeowners
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # https://github.com/marketplace/actions/github-codeowners-validator
+      - uses: mszostok/codeowners-validator@v0.6.0
+        with:
+          checks: "files,syntax,owners,duppatterns"
+          experimental_checks: "notowned"
+          # Wardell is not in the Square org apparently.
+          owner_checker_ignored_owners: "@wardellbagby"
+          # GitHub access token is required only if the `owners` check is enabled
+          github_access_token: "${{ secrets.OWNERS_VALIDATOR_GITHUB_SECRET }}"


### PR DESCRIPTION
Adds a new validation workflow for the file as well: https://github.com/marketplace/actions/github-codeowners-validator

I ran the PR first without the CODEOWNERs fix to ensure it caught the error, and it did:
```
==> Executing Duplicated Pattern Checker (5.8µs)
    Check OK
==> Executing Valid Syntax Checker (33.6µs)
    [err] line 3: Owner 'zach-klippenstein' does not look like an email
==> Executing File Exist Checker (12.902889ms)
    Check OK
==> Executing [Experimental] Not Owned File Checker (186.369983ms)
    Check OK
==> Executing Valid Owner Checker (305.003698ms)
    [err] line 3: Not valid owner definition "zach-klippenstein"
```

This plugin requires a github access token with `public_repo` and `read:org` permissions in order to validate that teams and users actually exist, so I made a personal access token with those permissions and created a new secret for it in this repository, `OWNERS_VALIDATOR_GITHUB_SECRET`.