### PR TITLE
Stop leaking the viewbinding dependency to consumers.

### DIFF
--- a/.buildscript/android-sample-app.gradle
+++ b/.buildscript/android-sample-app.gradle
@@ -1,5 +1,7 @@
 apply from: rootProject.file('.buildscript/configure-android-defaults.gradle')
 
+android.buildFeatures.viewBinding = true
+
 dependencies {
   implementation(project(":workflow-core"))
   implementation(project(":workflow-runtime"))

--- a/.buildscript/configure-android-defaults.gradle
+++ b/.buildscript/configure-android-defaults.gradle
@@ -13,10 +13,7 @@ android {
     versionName "1.0"
   }
 
-  buildFeatures{
-    viewBinding = true
-    buildConfig = false
-  }
+  buildFeatures.buildConfig = false
 
   // See https://github.com/Kotlin/kotlinx.coroutines/issues/1064#issuecomment-479412940
   packagingOptions {

--- a/workflow-ui/backstack-android/api/backstack-android.api
+++ b/workflow-ui/backstack-android/api/backstack-android.api
@@ -63,12 +63,3 @@ public final class com/squareup/workflow1/ui/backstack/ViewStateCache$SavedState
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/squareup/workflow1/ui/backstack/databinding/ViewStackLayoutBinding : androidx/viewbinding/ViewBinding {
-	public final field viewStack Lcom/squareup/workflow1/ui/backstack/BackStackContainer;
-	public static fun bind (Landroid/view/View;)Lcom/squareup/workflow1/ui/backstack/databinding/ViewStackLayoutBinding;
-	public synthetic fun getRoot ()Landroid/view/View;
-	public fun getRoot ()Lcom/squareup/workflow1/ui/backstack/BackStackContainer;
-	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/squareup/workflow1/ui/backstack/databinding/ViewStackLayoutBinding;
-	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/squareup/workflow1/ui/backstack/databinding/ViewStackLayoutBinding;
-}
-


### PR DESCRIPTION
We specify it as a `compileOnly` dependency, but we also had `viewBinding = true` by default for all Android modules.
This was causing the viewbinding artifact to be added as an `api` dependency for `:workflow-ui:core-android`, which meant it was leaking to consumers as a transitive dependency.

cc @Armaxis @christiandeange 