### PR TITLE
Prefix Props & Context with "Render"

### DIFF
--- a/fileTemplates/Stateful Workflow.kt
+++ b/fileTemplates/Stateful Workflow.kt
@@ -22,8 +22,8 @@ class ${WorkflowName} : StatefulWorkflow<Props, State, Output, Rendering>() {
   ): State = TODO("Initialize state")
 
   override fun render(
-    props: Props,
-    state: State,
+    renderProps: Props,
+    renderState: State,
     context: RenderContext
   ): Rendering {
     TODO("Render")

--- a/fileTemplates/Stateless Workflow.kt
+++ b/fileTemplates/Stateless Workflow.kt
@@ -14,7 +14,7 @@ class ${WorkflowName} : StatelessWorkflow<Props, Output, Rendering>() {
   data class Rendering
 
   override fun render(
-    props: Props,
+    renderProps: Props,
     context: RenderContext
   ): Rendering {
     TODO("Render")

--- a/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemListWorkflow.kt
+++ b/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemListWorkflow.kt
@@ -9,11 +9,11 @@ import com.squareup.workflow1.StatelessWorkflow
 object PoemListWorkflow : StatelessWorkflow<List<Poem>, Int, PoemListRendering>() {
 
   override fun render(
-    props: List<Poem>,
+    renderProps: List<Poem>,
     context: RenderContext
   ): PoemListRendering {
     return PoemListRendering(
-        poems = props,
+        poems = renderProps,
         onPoemSelected = context.eventHandler { index -> setOutput(index) }
     )
   }

--- a/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemsBrowserWorkflow.kt
+++ b/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemsBrowserWorkflow.kt
@@ -24,20 +24,20 @@ object PoemsBrowserWorkflow :
 
   @OptIn(WorkflowUiExperimentalApi::class)
   override fun render(
-    props: List<Poem>,
-    state: SelectedPoem,
+    renderProps: List<Poem>,
+    renderState: SelectedPoem,
     context: RenderContext
   ): OverviewDetailScreen {
     val poems: OverviewDetailScreen =
-      context.renderChild(PoemListWorkflow, props) { selected -> choosePoem(selected) }
-          .copy(selection = state)
+      context.renderChild(PoemListWorkflow, renderProps) { selected -> choosePoem(selected) }
+          .copy(selection = renderState)
           .let { OverviewDetailScreen(BackStackScreen(it)) }
 
-    return if (state == -1) {
+    return if (renderState == -1) {
       poems
     } else {
       val poem: OverviewDetailScreen =
-        context.renderChild(PoemWorkflow, props[state]) { clearSelection }
+        context.renderChild(PoemWorkflow, renderProps[renderState]) { clearSelection }
       poems + poem
     }
   }

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/AreYouSureWorkflow.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/AreYouSureWorkflow.kt
@@ -41,13 +41,13 @@ object AreYouSureWorkflow : StatefulWorkflow<Unit, State, Finished, AlertContain
   object Finished
 
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
   ): AlertContainerScreen<*> {
     val ableBakerCharlie = context.renderChild(HelloBackButtonWorkflow, Unit) { noAction() }
 
-    return when (state) {
+    return when (renderState) {
       Running -> {
         AlertContainerScreen(
             BackButtonScreen(ableBakerCharlie) {

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
@@ -31,12 +31,12 @@ object HelloBackButtonWorkflow : StatefulWorkflow<
   ): State = snapshot?.toParcelable() ?: Able
 
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
   ): HelloBackButtonRendering {
     return HelloBackButtonRendering(
-        message = "$state",
+        message = "$renderState",
         onClick = context.eventHandler {
           this.state = when (this.state) {
             Able -> Baker
@@ -44,7 +44,7 @@ object HelloBackButtonWorkflow : StatefulWorkflow<
             Charlie -> Able
           }
         },
-        onBackPressed = if (state == Able) null else context.eventHandler {
+        onBackPressed = if (renderState == Able) null else context.eventHandler {
           this.state = when (this.state) {
             Able -> throw IllegalStateException()
             Baker -> Able

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemWorkflow.kt
@@ -39,25 +39,25 @@ object PoemWorkflow : StatefulWorkflow<Poem, Int, ClosePoem, OverviewDetailScree
 
   @OptIn(WorkflowUiExperimentalApi::class)
   override fun render(
-    props: Poem,
-    state: Int,
+    renderProps: Poem,
+    renderState: Int,
     context: RenderContext
   ): OverviewDetailScreen {
     val previousStanzas: List<StanzaRendering> =
-      if (state == -1) emptyList()
-      else props.stanzas.subList(0, state)
+      if (renderState == -1) emptyList()
+      else renderProps.stanzas.subList(0, renderState)
           .mapIndexed { index, _ ->
-            context.renderChild(StanzaWorkflow, Props(props, index), "$index") {
+            context.renderChild(StanzaWorkflow, Props(renderProps, index), "$index") {
               noAction()
             }
           }
 
     val visibleStanza =
-      if (state < 0) {
+      if (renderState < 0) {
         null
       } else {
         context.renderChild(
-            StanzaWorkflow, Props(props, state), "$state"
+            StanzaWorkflow, Props(renderProps, renderState), "$renderState"
         ) {
           when (it) {
             CloseStanzas -> ClearSelection
@@ -72,10 +72,10 @@ object PoemWorkflow : StatefulWorkflow<Poem, Int, ClosePoem, OverviewDetailScree
     }
 
     val stanzaIndex =
-      context.renderChild(StanzaListWorkflow, props) { selected ->
+      context.renderChild(StanzaListWorkflow, renderProps) { selected ->
         HandleStanzaListOutput(selected)
       }
-          .copy(selection = state)
+          .copy(selection = renderState)
           .let { BackStackScreen<Any>(it) }
 
     return stackedStanzas

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
@@ -11,13 +11,13 @@ import com.squareup.workflow1.StatelessWorkflow
 object StanzaListWorkflow : StatelessWorkflow<Poem, Int, StanzaListRendering>() {
 
   override fun render(
-    props: Poem,
+    renderProps: Poem,
     context: RenderContext
   ): StanzaListRendering {
     return StanzaListRendering(
-        title = props.title,
-        subtitle = props.poet.fullName,
-        firstLines = props.initialStanzas,
+        title = renderProps.title,
+        subtitle = renderProps.poet.fullName,
+        firstLines = renderProps.initialStanzas,
         onStanzaSelected = context.eventHandler { index -> setOutput(index) },
         onExit = context.eventHandler { setOutput(-1) }
     )

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
@@ -21,10 +21,10 @@ object StanzaWorkflow : StatelessWorkflow<Props, Output, StanzaRendering>() {
   }
 
   override fun render(
-    props: Props,
+    renderProps: Props,
     context: RenderContext
   ): StanzaRendering {
-    with(props) {
+    with(renderProps) {
       val onGoBack: (() -> Unit)? = when (index) {
         0 -> null
         else -> {

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
@@ -39,26 +39,26 @@ class DungeonAppWorkflow(
   ): State = LoadingBoardList
 
   override fun render(
-    props: Props,
-    state: State,
+    renderProps: Props,
+    renderState: State,
     context: RenderContext
-  ): AlertContainerScreen<Any> = when (state) {
+  ): AlertContainerScreen<Any> = when (renderState) {
 
     LoadingBoardList -> {
       context.runningWorker(boardLoader.loadAvailableBoards()) { displayBoards(it) }
-      AlertContainerScreen(state)
+      AlertContainerScreen(renderState)
     }
 
     is ChoosingBoard -> {
       val screen = DisplayBoardsListScreen(
-          boards = state.boards.map { it.second },
+          boards = renderState.boards.map { it.second },
           onBoardSelected = { index -> context.actionSink.send(selectBoard(index)) }
       )
       AlertContainerScreen(screen)
     }
 
     is PlayingGame -> {
-      val sessionProps = GameSessionWorkflow.Props(state.boardPath, props.paused)
+      val sessionProps = GameSessionWorkflow.Props(renderState.boardPath, renderProps.paused)
       val gameScreen = context.renderChild(gameSessionWorkflow, sessionProps)
       gameScreen
     }

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameSessionWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameSessionWorkflow.kt
@@ -49,26 +49,26 @@ class GameSessionWorkflow(
   ): State = Loading
 
   override fun render(
-    props: Props,
-    state: State,
+    renderProps: Props,
+    renderState: State,
     context: RenderContext
-  ): AlertContainerScreen<Any> = when (state) {
+  ): AlertContainerScreen<Any> = when (renderState) {
 
     Loading -> {
-      context.runningWorker(boardLoader.loadBoard(props.boardPath)) { StartRunning(it) }
+      context.runningWorker(boardLoader.loadBoard(renderProps.boardPath)) { StartRunning(it) }
       AlertContainerScreen(Loading)
     }
 
     is Running -> {
-      val gameInput = GameWorkflow.Props(state.board, paused = props.paused)
+      val gameInput = GameWorkflow.Props(renderState.board, paused = renderProps.paused)
       val gameScreen = context.renderChild(gameWorkflow, gameInput) {
-        handleGameOutput(it, state.board)
+        handleGameOutput(it, renderState.board)
       }
       AlertContainerScreen(gameScreen)
     }
 
     is GameOver -> {
-      val gameInput = GameWorkflow.Props(state.board)
+      val gameInput = GameWorkflow.Props(renderState.board)
       val gameScreen = context.renderChild(gameWorkflow, gameInput) { noAction() }
 
       val gameOverDialog = AlertScreen(

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/TimeMachineAppWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/TimeMachineAppWorkflow.kt
@@ -26,7 +26,7 @@ class TimeMachineAppWorkflow(
     ShakeableTimeMachineWorkflow(TimeMachineWorkflow(appWorkflow, clock), context)
 
   override fun render(
-    props: BoardPath,
+    renderProps: BoardPath,
     context: RenderContext
   ): ShakeableTimeMachineRendering {
     val propsFactory = PropsFactory { recording ->

--- a/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/AiWorkflow.kt
+++ b/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/AiWorkflow.kt
@@ -50,13 +50,13 @@ class AiWorkflow(
   } else state
 
   override fun render(
-    props: ActorProps,
-    state: State,
+    renderProps: ActorProps,
+    renderState: State,
     context: RenderContext
   ): ActorRendering {
-    context.runningWorker(state.directionTicker) { updateDirection }
+    context.runningWorker(renderState.directionTicker) { updateDirection }
 
-    return ActorRendering(avatar, Movement(state.direction, cellsPerSecond = cellsPerSecond))
+    return ActorRendering(avatar, Movement(renderState.direction, cellsPerSecond = cellsPerSecond))
   }
 
   override fun snapshotState(state: State): Snapshot? = null

--- a/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/GameWorkflow.kt
+++ b/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/GameWorkflow.kt
@@ -15,7 +15,6 @@ import com.squareup.sample.dungeon.GameWorkflow.State
 import com.squareup.sample.dungeon.PlayerWorkflow.Rendering
 import com.squareup.sample.dungeon.board.Board
 import com.squareup.sample.dungeon.board.Board.Location
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.Worker
@@ -89,16 +88,16 @@ class GameWorkflow(
   }
 
   override fun render(
-    props: Props,
-    state: State,
+    renderProps: Props,
+    renderState: State,
     context: RenderContext
   ): GameRendering {
-    val running = !props.paused && !state.game.isPlayerEaten
+    val running = !renderProps.paused && !renderState.game.isPlayerEaten
     // Stop actors from ticking if the game is paused or finished.
     val ticker: Worker<Long> =
-      if (running) TickerWorker(props.ticksPerSecond) else Worker.finished()
-    val game = state.game
-    val board = props.board
+      if (running) TickerWorker(renderProps.ticksPerSecond) else Worker.finished()
+    val game = renderState.game
+    val board = renderProps.board
 
     // Render the player.
     val playerInput = ActorProps(board, game.playerLocation, ticker)
@@ -115,7 +114,7 @@ class GameWorkflow(
     if (running) {
       context.runningWorker(ticker) { tick ->
         return@runningWorker updateGame(
-            props.ticksPerSecond, tick, game, playerRendering, board, aiRenderings
+            renderProps.ticksPerSecond, tick, game, playerRendering, board, aiRenderings
         )
       }
     }

--- a/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/PlayerWorkflow.kt
+++ b/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/PlayerWorkflow.kt
@@ -6,11 +6,9 @@ import com.squareup.sample.dungeon.PlayerWorkflow.Action.StartMoving
 import com.squareup.sample.dungeon.PlayerWorkflow.Action.StopMoving
 import com.squareup.sample.dungeon.PlayerWorkflow.Rendering
 import com.squareup.sample.dungeon.board.BoardCell
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction
-import com.squareup.workflow1.WorkflowAction.Updater
 
 /**
  * Workflow that represents the actual player of the game in the [GameWorkflow].
@@ -47,11 +45,11 @@ class PlayerWorkflow(
   ): Movement = Movement(cellsPerSecond = cellsPerSecond)
 
   override fun render(
-    props: ActorProps,
-    state: Movement,
+    renderProps: ActorProps,
+    renderState: Movement,
     context: RenderContext
   ): Rendering = Rendering(
-      actorRendering = ActorRendering(avatar = avatar, movement = state),
+      actorRendering = ActorRendering(avatar = avatar, movement = renderState),
       onStartMoving = { context.actionSink.send(StartMoving(it)) },
       onStopMoving = { context.actionSink.send(StopMoving(it)) }
   )

--- a/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/RecorderWorkflow.kt
+++ b/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/RecorderWorkflow.kt
@@ -74,18 +74,18 @@ internal class RecorderWorkflow<T>(
   }
 
   override fun render(
-    props: RecorderProps<T>,
-    state: Recording<T>,
+    renderProps: RecorderProps<T>,
+    renderState: Recording<T>,
     context: RenderContext
   ): TimeMachineRendering<T> {
-    val value = when (props) {
-      is RecordValue -> props.value
-      is PlaybackAt -> state.series.findValueNearest(props.timestamp)
+    val value = when (renderProps) {
+      is RecordValue -> renderProps.value
+      is PlaybackAt -> renderState.series.findValueNearest(renderProps.timestamp)
     }
 
     return TimeMachineRendering(
         value = value,
-        totalDuration = state.series.duration
+        totalDuration = renderState.series.duration
     )
   }
 

--- a/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/TimeMachineWorkflow.kt
+++ b/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/TimeMachineWorkflow.kt
@@ -5,7 +5,6 @@ import com.squareup.sample.timemachine.RecorderWorkflow.RecorderProps.RecordValu
 import com.squareup.sample.timemachine.TimeMachineWorkflow.TimeMachineProps
 import com.squareup.sample.timemachine.TimeMachineWorkflow.TimeMachineProps.PlayingBackAt
 import com.squareup.sample.timemachine.TimeMachineWorkflow.TimeMachineProps.Recording
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.StatelessWorkflow
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.action
@@ -68,16 +67,16 @@ class TimeMachineWorkflow<P, O : Any, out R>(
   private val recordingWorkflow = RecorderWorkflow<R>(clock)
 
   override fun render(
-    props: TimeMachineProps<P>,
+    renderProps: TimeMachineProps<P>,
     context: RenderContext
   ): TimeMachineRendering<R> {
     // Always render the delegate, even if in playback mode, to keep it alive.
     val delegateRendering =
-      context.renderChild(delegateWorkflow, props.delegateProps) { forwardOutput(it) }
+      context.renderChild(delegateWorkflow, renderProps.delegateProps) { forwardOutput(it) }
 
-    val recorderProps = when (props) {
+    val recorderProps = when (renderProps) {
       is Recording -> RecordValue(delegateRendering)
-      is PlayingBackAt -> PlaybackAt(props.timestamp)
+      is PlayingBackAt -> PlaybackAt(renderProps.timestamp)
     }
 
     return context.renderChild(recordingWorkflow, recorderProps)

--- a/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
+++ b/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
@@ -33,12 +33,12 @@ class BlinkingCursorWorkflow(
   ): Boolean = true
 
   override fun render(
-    props: Unit,
-    state: Boolean,
+    renderProps: Unit,
+    renderState: Boolean,
     context: RenderContext
   ): String {
     context.runningWorker(intervalWorker) { setCursorShowing(it) }
-    return if (state) cursorString else ""
+    return if (renderState) cursorString else ""
   }
 
   override fun snapshotState(state: Boolean): Snapshot? = null

--- a/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/HelloTerminalWorkflow.kt
+++ b/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/HelloTerminalWorkflow.kt
@@ -35,11 +35,11 @@ class HelloTerminalWorkflow : TerminalWorkflow,
   ) = State()
 
   override fun render(
-    props: TerminalProps,
-    state: State,
+    renderProps: TerminalProps,
+    renderState: State,
     context: RenderContext
   ): TerminalRendering {
-    val (rows, columns) = props.size
+    val (rows, columns) = renderProps.size
     val header = """
           Hello world!
 
@@ -51,10 +51,10 @@ class HelloTerminalWorkflow : TerminalWorkflow,
     val prompt = "> "
     val cursor = context.renderChild(cursorWorkflow)
 
-    context.runningWorker(props.keyStrokes) { onKeystroke(it) }
+    context.runningWorker(renderProps.keyStrokes) { onKeystroke(it) }
 
     return TerminalRendering(
-        text = header + prompt + state.text + cursor,
+        text = header + prompt + renderState.text + cursor,
         textColor = GREEN
     )
   }

--- a/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
+++ b/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
@@ -45,17 +45,19 @@ class EditTextWorkflow : StatefulWorkflow<EditTextProps, EditTextState, String, 
   }
 
   override fun render(
-    props: EditTextProps,
-    state: EditTextState,
+    renderProps: EditTextProps,
+    renderState: EditTextState,
     context: RenderContext
   ): String {
-    context.runningWorker(props.terminalProps.keyStrokes) { key -> onKeystroke(props, key) }
+    context.runningWorker(
+      renderProps.terminalProps.keyStrokes
+    ) { key -> onKeystroke(renderProps, key) }
 
     return buildString {
-      props.text.forEachIndexed { index, c ->
-        append(if (index == state.cursorPosition) "|$c" else "$c")
+      renderProps.text.forEachIndexed { index, c ->
+        append(if (index == renderState.cursorPosition) "|$c" else "$c")
       }
-      if (state.cursorPosition == props.text.length) append("|")
+      if (renderState.cursorPosition == renderProps.text.length) append("|")
     }
   }
 

--- a/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/TodoWorkflow.kt
+++ b/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/TodoWorkflow.kt
@@ -59,18 +59,18 @@ class TodoWorkflow : TerminalWorkflow,
   )
 
   override fun render(
-    props: TerminalProps,
-    state: TodoList,
+    renderProps: TerminalProps,
+    renderState: TodoList,
     context: RenderContext
   ): TerminalRendering {
 
-    context.runningWorker(props.keyStrokes) { onKeystroke(it) }
+    context.runningWorker(renderProps.keyStrokes) { onKeystroke(it) }
 
     return TerminalRendering(buildString {
       @Suppress("UNCHECKED_CAST")
-      appendLine(state.renderTitle(props, context))
-      appendLine(renderSelection(state.titleSeparator, false))
-      appendLine(state.renderItems(props, context))
+      appendLine(renderState.renderTitle(renderProps, context))
+      appendLine(renderSelection(renderState.titleSeparator, false))
+      appendLine(renderState.renderItems(renderProps, context))
     })
   }
 

--- a/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
+++ b/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
@@ -21,12 +21,12 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, HelloRendering>() 
     ?: Hello
 
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
   ): HelloRendering {
     return HelloRendering(
-      message = state.name,
+      message = renderState.name,
       onClick = { context.actionSink.send(helloAction) }
     )
   }

--- a/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
+++ b/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
@@ -21,12 +21,12 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, HelloRendering>() 
     ?: Hello
 
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
   ): HelloRendering {
     return HelloRendering(
-      message = state.name,
+      message = renderState.name,
       onClick = { context.actionSink.send(helloAction) }
     )
   }

--- a/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityWorkflow.kt
+++ b/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityWorkflow.kt
@@ -23,10 +23,10 @@ object StubVisibilityWorkflow : StatefulWorkflow<Unit, State, Nothing, OuterRend
       ?: HideBottom
 
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
-  ): OuterRendering = when (state) {
+  ): OuterRendering = when (renderState) {
     HideBottom -> OuterRendering(
         top = ClickyTextRendering(message = "Click to show footer") {
           context.actionSink.send(action {

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
@@ -69,14 +69,14 @@ class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
   ): AuthState = LoginPrompt()
 
   override fun render(
-    props: Unit,
-    state: AuthState,
+    renderProps: Unit,
+    renderState: AuthState,
     context: RenderContext
-  ): BackStackScreen<Any> = when (state) {
+  ): BackStackScreen<Any> = when (renderState) {
     is LoginPrompt -> {
       BackStackScreen(
           LoginScreen(
-              state.errorMessage,
+              renderState.errorMessage,
               onLogin = context.eventHandler { email, password ->
                 this.state = when {
                   email.isValidEmail -> Authorizing(email, password)
@@ -90,7 +90,7 @@ class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
 
     is Authorizing -> {
       context.runningWorker(
-          authService.login(AuthRequest(state.email, state.password))
+          authService.login(AuthRequest(renderState.email, renderState.password))
               .asWorker()
       ) { handleAuthResponse(it) }
 
@@ -104,7 +104,7 @@ class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
       BackStackScreen(
           LoginScreen(),
           SecondFactorScreen(
-              state.errorMessage,
+              renderState.errorMessage,
               onSubmit = context.eventHandler { secondFactor ->
                 (this.state as? SecondFactorPrompt)?.let { oldState ->
                   this.state = AuthorizingSecondFactor(oldState.tempToken, secondFactor)
@@ -116,9 +116,9 @@ class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
     }
 
     is AuthorizingSecondFactor -> {
-      val request = SecondFactorRequest(state.tempToken, state.secondFactor)
+      val request = SecondFactorRequest(renderState.tempToken, renderState.secondFactor)
       context.runningWorker(authService.secondFactor(request).asWorker()) {
-        handleSecondFactorResponse(state.tempToken, it)
+        handleSecondFactorResponse(renderState.tempToken, it)
       }
 
       BackStackScreen(

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
@@ -67,12 +67,12 @@ class RealTakeTurnsWorkflow : TakeTurnsWorkflow,
   ): Turn = props.initialTurn
 
   override fun render(
-    props: TakeTurnsProps,
-    state: Turn,
+    renderProps: TakeTurnsProps,
+    renderState: Turn,
     context: RenderContext
   ): GamePlayScreen = GamePlayScreen(
-      playerInfo = props.playerInfo,
-      gameState = state,
+      playerInfo = renderProps.playerInfo,
+      gameState = renderState,
       onQuit = { context.actionSink.send(Quit) },
       onClick = { row, col -> context.actionSink.send(TakeSquare(row, col)) }
   )

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/TicTacToeWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/TicTacToeWorkflow.kt
@@ -49,10 +49,10 @@ class TicTacToeWorkflow(
 
   @OptIn(WorkflowUiExperimentalApi::class)
   override fun render(
-    props: Unit,
-    state: MainState,
+    renderProps: Unit,
+    renderState: MainState,
     context: RenderContext
-  ): RunGameScreen = when (state) {
+  ): RunGameScreen = when (renderState) {
     is Authenticating -> {
       val authScreen = context.renderChild(authWorkflow) { handleAuthResult(it) }
       val emptyGameScreen = GamePlayScreen()

--- a/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
+++ b/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
@@ -77,7 +77,7 @@ sealed class TodoEditorOutput {
 class TodoEditorWorkflow : StatelessWorkflow<TodoList, TodoEditorOutput, TodoRendering>() {
 
   override fun render(
-    props: TodoList,
+    renderProps: TodoList,
     context: RenderContext
   ): TodoRendering {
     // Make event handling idempotent until https://github.com/square/workflow/issues/541 is fixed.
@@ -89,11 +89,11 @@ class TodoEditorWorkflow : StatelessWorkflow<TodoList, TodoEditorOutput, TodoRen
     }
 
     return TodoRendering(
-        props.copy(rows = props.rows + TodoRow("")),
-        onTitleChanged = { sink.send(TitleChanged(props, it)) },
-        onDoneClicked = { sink.send(DoneClicked(props, it)) },
-        onTextChanged = { index, newText -> sink.send(TextChanged(props, index, newText)) },
-        onDeleteClicked = { sink.send(DeleteClicked(props, it)) },
+        renderProps.copy(rows = renderProps.rows + TodoRow("")),
+        onTitleChanged = { sink.send(TitleChanged(renderProps, it)) },
+        onDoneClicked = { sink.send(DoneClicked(renderProps, it)) },
+        onTextChanged = { index, newText -> sink.send(TextChanged(renderProps, index, newText)) },
+        onDeleteClicked = { sink.send(DeleteClicked(renderProps, it)) },
         onGoBackClicked = { sink.send(GoBackClicked) }
     )
   }

--- a/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
+++ b/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
@@ -64,16 +64,16 @@ object TodoListsAppWorkflow :
 
   @OptIn(WorkflowUiExperimentalApi::class)
   override fun render(
-    props: Unit,
-    state: TodoListsAppState,
+    renderProps: Unit,
+    renderState: TodoListsAppState,
     context: RenderContext
   ): OverviewDetailScreen {
     val listOfLists: TodoListsScreen = context.renderChild(
         listsWorkflow,
-        state.lists
+        renderState.lists
     ) { index -> onListSelected(index) }
 
-    return when (state) {
+    return when (renderState) {
       // Nothing is selected. We rest in this state on a phone in portrait orientation.
       // In a overview detail layout, selectDefault can be called immediately, so that
       // the detail panel is never seen to be empty.
@@ -91,10 +91,14 @@ object TodoListsAppWorkflow :
       // notion of selection, and leaves that field set to the default value of -1.
 
       is EditingList -> context.renderChild(
-          editorWorkflow, state.lists[state.editingIndex], handler = this::onEditOutput
+          editorWorkflow, renderState.lists[renderState.editingIndex], handler = this::onEditOutput
       ).let { editScreen ->
         OverviewDetailScreen(
-            overviewRendering = BackStackScreen(listOfLists.copy(selection = state.editingIndex)),
+            overviewRendering = BackStackScreen(
+              listOfLists.copy(
+                selection = renderState.editingIndex
+              )
+            ),
             detailRendering = BackStackScreen(editScreen)
         )
       }

--- a/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
+++ b/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
@@ -4,11 +4,11 @@ import com.squareup.workflow1.StatelessWorkflow
 
 class TodoListsWorkflow : StatelessWorkflow<List<TodoList>, Int, TodoListsScreen>() {
   override fun render(
-    props: List<TodoList>,
+    renderProps: List<TodoList>,
     context: RenderContext
   ): TodoListsScreen {
     return TodoListsScreen(
-        lists = props,
+        lists = renderProps,
         onRowClicked = context.eventHandler { index -> setOutput(index) }
     )
   }

--- a/samples/tutorial/Tutorial1.md
+++ b/samples/tutorial/Tutorial1.md
@@ -90,8 +90,8 @@ object WelcomeWorkflow : StatefulWorkflow<Unit, State, Output, WelcomeScreen>() 
   object Output
 
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
   ): WelcomeScreen = WelcomeScreen(
       username = state.username,
@@ -199,8 +199,8 @@ object WelcomeWorkflow : StatefulWorkflow<Unit, State, Output, WelcomeScreen>() 
   // …
 
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
   ): WelcomeScreen = WelcomeScreen(
       username = state.username,

--- a/samples/tutorial/Tutorial2.md
+++ b/samples/tutorial/Tutorial2.md
@@ -64,8 +64,8 @@ object TodoListWorkflow : StatefulWorkflow<Unit, State, Nothing, TodoListScreen>
   ) = Unit
 
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
   ): TodoListScreen {
     return TodoListScreen(
@@ -183,8 +183,8 @@ Finally, update `render` for `TodoListWorkflow` to send the titles of the todo m
 object TodoListWorkflow : StatefulWorkflow<Unit, State, Nothing, TodoListScreen>() {
 
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
   ): TodoListScreen {
     val titles = state.todos.map { it.title }
@@ -223,7 +223,7 @@ object RootWorkflow : StatefulWorkflow<Unit, Unit, Nothing, WelcomeScreen>() {
   ): Unit = Unit
 
   override fun render(
-    props: Unit,
+    renderProps: Unit,
     state: Unit,
     context: RenderContext
   ): Any {
@@ -323,8 +323,8 @@ And fire the `onLogin` action any time the login button is pressed:
 
 ```kotlin
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
   ): WelcomeScreen = WelcomeScreen(
       username = state.username,
@@ -340,7 +340,7 @@ Finally, map the output event from `WelcomeWorkflow` in `RootWorkflow` to the `L
 
 ```kotlin
   override fun render(
-    props: Unit,
+    renderProps: Unit,
     state: Unit,
     context: RenderContext
   ): Any {
@@ -374,8 +374,8 @@ object RootWorkflow : StatefulWorkflow<Unit, State, Nothing, Any>() {
   // …
 
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
   ): Any {
     when (state) {
@@ -447,8 +447,8 @@ object RootWorkflow : StatefulWorkflow<Unit, State, Nothing, BackStackScreen<Any
 
   @OptIn(WorkflowUiExperimentalApi::class)
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
   ): BackStackScreen<Any> {
 

--- a/samples/tutorial/Tutorial3.md
+++ b/samples/tutorial/Tutorial3.md
@@ -181,8 +181,8 @@ object TodoEditWorkflow : StatefulWorkflow<EditProps, State, Output, TodoEditScr
   // …
 
   override fun render(
-    props: EditProps,
-    state: State,
+    renderProps: EditProps,
+    renderState: State,
     context: RenderContext
   ): TodoEditScreen {
     return TodoEditScreen(
@@ -229,8 +229,8 @@ object TodoListWorkflow : StatefulWorkflow<ListProps, State, Back, List<Any>>() 
   // …
 
   override fun render(
-    props: ListProps,
-    state: State,
+    renderProps: ListProps,
+    renderState: State,
     context: RenderContext
   ): List<Any> {
     val titles = state.todos.map { it.title }
@@ -254,8 +254,8 @@ object RootWorkflow : StatefulWorkflow<Unit, State, Nothing, BackStackScreen<*>>
   // …
 
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
   ): BackStackScreen<*> {
     // Our list of back stack items. Will always include the "WelcomeScreen".
@@ -358,8 +358,8 @@ object TodoListWorkflow : StatefulWorkflow<ListProps, State, Back, List<Any>>() 
   // …
 
   override fun render(
-    props: ListProps,
-    state: State,
+    renderProps: ListProps,
+    renderState: State,
     context: RenderContext
   ): List<Any> {
     val titles = state.todos.map { it.title }

--- a/samples/tutorial/Tutorial4.md
+++ b/samples/tutorial/Tutorial4.md
@@ -99,7 +99,7 @@ object TodoListWorkflow : StatefulWorkflow<ListProps, Unit, Output, TodoListScre
   ) = Unit
 
   override fun render(
-    props: ListProps,
+    renderProps: ListProps,
     state: Unit,
     context: RenderContext
   ): TodoListScreen {
@@ -146,7 +146,7 @@ object TodoListWorkflow : StatefulWorkflow<ListProps, Unit, Output, TodoListScre
   // …
 
   override fun render(
-    props: ListProps,
+    renderProps: ListProps,
     state: Unit,
     context: RenderContext
   ): TodoListScreen {
@@ -176,7 +176,7 @@ object TodoListWorkflow : StatelessWorkflow<ListProps, Output, TodoListScreen>()
   // …
 
   override fun render(
-    props: ListProps,
+    renderProps: ListProps,
     context: RenderContext
   ): TodoListScreen {
     // …
@@ -194,8 +194,8 @@ object TodoWorkflow : StatefulWorkflow<TodoProps, State, Back, List<Any>>() {
   // …
 
   override fun render(
-    props: TodoProps,
-    state: State,
+    renderProps: TodoProps,
+    renderState: State,
     context: RenderContext
   ): List<Any> {
     val todoListScreen = context.renderChild(
@@ -245,8 +245,8 @@ object RootWorkflow : StatefulWorkflow<Unit, State, Nothing, BackStackScreen<*>>
   // …
 
   override fun render(
-    props: Unit,
-    state: State,
+    renderProps: Unit,
+    renderState: State,
     context: RenderContext
   ): BackStackScreen<*> {
 
@@ -323,8 +323,8 @@ object TodoWorkflow : StatefulWorkflow<TodoProps, State, Back, List<Any>>() {
   // …
 
   override fun render(
-    props: TodoProps,
-    state: State,
+    renderProps: TodoProps,
+    renderState: State,
     context: RenderContext
   ): List<Any> {
     val todoListScreen = context.renderChild(

--- a/workflow-core/src/main/java/com/squareup/workflow1/StatefulWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/StatefulWorkflow.kt
@@ -107,8 +107,8 @@ public abstract class StatefulWorkflow<
 
   /**
    * Called at least once† any time one of the following things happens:
-   *  - This workflow's [props] changes (via the parent passing a different one in).
-   *  - This workflow's [state] changes.
+   *  - This workflow's [renderProps] changes (via the parent passing a different one in).
+   *  - This workflow's [renderState] changes.
    *  - A descendant (immediate or transitive child) workflow:
    *    - Changes its internal state.
    *    - Emits an output.
@@ -124,8 +124,8 @@ public abstract class StatefulWorkflow<
    * multiple times. Allowing this method to be invoked multiple times makes the internals simpler._
    */
   public abstract fun render(
-    props: PropsT,
-    state: StateT,
+    renderProps: PropsT,
+    renderState: StateT,
     context: RenderContext
   ): RenderingT
 
@@ -192,10 +192,10 @@ public inline fun <PropsT, StateT, OutputT, RenderingT> Workflow.Companion.state
     ): StateT = onPropsChanged(old, new, state)
 
     override fun render(
-      props: PropsT,
-      state: StateT,
+      renderProps: PropsT,
+      renderState: StateT,
       context: RenderContext
-    ): RenderingT = render(context, props, state)
+    ): RenderingT = render(context, renderProps, renderState)
 
     override fun snapshotState(state: StateT) = snapshot(state)
   }

--- a/workflow-core/src/main/java/com/squareup/workflow1/StatelessWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/StatelessWorkflow.kt
@@ -37,7 +37,7 @@ public abstract class StatelessWorkflow<in PropsT, out OutputT, out RenderingT> 
 
   /**
    * Called at least once any time one of the following things happens:
-   *  - This workflow's [props] change (via the parent passing a different one in).
+   *  - This workflow's [renderProps] change (via the parent passing a different one in).
    *  - A descendant (immediate or transitive child) workflow:
    *    - Changes its internal state.
    *    - Emits an output.
@@ -50,7 +50,7 @@ public abstract class StatelessWorkflow<in PropsT, out OutputT, out RenderingT> 
    * work by calling methods on [context].
    */
   public abstract fun render(
-    props: PropsT,
+    renderProps: PropsT,
     context: RenderContext
   ): RenderingT
 
@@ -88,9 +88,9 @@ public inline fun <PropsT, OutputT, RenderingT> Workflow.Companion.stateless(
 ): Workflow<PropsT, OutputT, RenderingT> =
   object : StatelessWorkflow<PropsT, OutputT, RenderingT>() {
     override fun render(
-      props: PropsT,
+      renderProps: PropsT,
       context: RenderContext
-    ): RenderingT = render(context, props)
+    ): RenderingT = render(context, renderProps)
   }
 
 /**

--- a/workflow-core/src/main/java/com/squareup/workflow1/WorkerWorkflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/WorkerWorkflow.kt
@@ -48,14 +48,14 @@ internal class WorkerWorkflow<OutputT>(
   ): Int = if (!old.doesSameWorkAs(new)) state + 1 else state
 
   override fun render(
-    props: Worker<OutputT>,
-    state: Int,
+    renderProps: Worker<OutputT>,
+    renderState: Int,
     context: RenderContext
   ) {
     // Scope the side effect coroutine to the state value, so the worker will be re-started when
     // it changes (such that doesSameWorkAs returns false above).
-    context.runningSideEffect(state.toString()) {
-      runWorker(props, key, context.actionSink)
+    context.runningSideEffect(renderState.toString()) {
+      runWorker(renderProps, key, context.actionSink)
     }
   }
 

--- a/workflow-core/src/main/java/com/squareup/workflow1/Workflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow1/Workflow.kt
@@ -120,10 +120,10 @@ public fun <PropsT, OutputT, FromRenderingT, ToRenderingT>
     override val realIdentifier: WorkflowIdentifier get() = this@mapRendering.identifier
 
     override fun render(
-      props: PropsT,
+      renderProps: PropsT,
       context: RenderContext
     ): ToRenderingT {
-      val rendering = context.renderChild(this@mapRendering, props) { output ->
+      val rendering = context.renderChild(this@mapRendering, renderProps) { output ->
         action({ "mapRendering" }) { setOutput(output) }
       }
       return transform(rendering)

--- a/workflow-runtime/src/jmh/java/com/squareup/workflow1/WorkflowNodeBenchmark.kt
+++ b/workflow-runtime/src/jmh/java/com/squareup/workflow1/WorkflowNodeBenchmark.kt
@@ -147,26 +147,26 @@ private class FractalWorkflow(
   ) = Unit
 
   override fun render(
-    props: Props,
-    state: Unit,
+    renderProps: Props,
+    renderState: Unit,
     context: RenderContext
   ) {
-    if (childWorkflow != null && (props.renderLeaves || !areChildrenLeaves)) {
+    if (childWorkflow != null && (renderProps.renderLeaves || !areChildrenLeaves)) {
       for (i in 0 until childCount) {
-        if (props.skipFirstLeaf) {
+        if (renderProps.skipFirstLeaf) {
           // Don't render the first child if it's a leaf, otherwise render children using props that
           // will fractally result in the first leaf being skipped.
           if (!areChildrenLeaves || i > 0) {
-            val childProps = if (i == 0) props else RENDER_LEAVES
+            val childProps = if (i == 0) renderProps else RENDER_LEAVES
             context.renderChild(childWorkflow, childProps, key = i.toString())
           }
         } else {
-          context.renderChild(childWorkflow, props, key = i.toString())
+          context.renderChild(childWorkflow, renderProps, key = i.toString())
         }
       }
     }
 
-    if (props.runWorkers && depth == 0) {
+    if (renderProps.runWorkers && depth == 0) {
       context.runningWorker(NeverWorker) { noAction() }
     }
   }

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/SimpleLoggingWorkflowInterceptor.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/SimpleLoggingWorkflowInterceptor.kt
@@ -39,13 +39,13 @@ public open class SimpleLoggingWorkflowInterceptor : WorkflowInterceptor {
   }
 
   override fun <P, S, O, R> onRender(
-    props: P,
-    state: S,
+    renderProps: P,
+    renderState: S,
     context: BaseRenderContext<P, S, O>,
     proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
     session: WorkflowSession
   ): R = logMethod("onRender", session) {
-    proceed(props, state, context)
+    proceed(renderProps, renderState, context)
   }
 
   override fun <S> onSnapshotState(

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/WorkflowInterceptor.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/WorkflowInterceptor.kt
@@ -79,12 +79,12 @@ public interface WorkflowInterceptor {
    * Intercepts calls to [StatefulWorkflow.render].
    */
   public fun <P, S, O, R> onRender(
-    props: P,
-    state: S,
+    renderProps: P,
+    renderState: S,
     context: BaseRenderContext<P, S, O>,
     proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
     session: WorkflowSession
-  ): R = proceed(props, state, context)
+  ): R = proceed(renderProps, renderState, context)
 
   /**
    * Intercepts calls to [StatefulWorkflow.snapshotState].
@@ -150,11 +150,11 @@ internal fun <P, S, O, R> WorkflowInterceptor.intercept(
     ): S = onPropsChanged(old, new, state, workflow::onPropsChanged, workflowSession)
 
     override fun render(
-      props: P,
-      state: S,
+      renderProps: P,
+      renderState: S,
       context: RenderContext
     ): R = onRender(
-        props, state, context,
+      renderProps, renderState, context,
         proceed = { p, s, c -> workflow.render(p, s, RenderContext(c, this)) },
         session = workflowSession
     )

--- a/workflow-runtime/src/main/java/com/squareup/workflow1/internal/ChainedWorkflowInterceptor.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/internal/ChainedWorkflowInterceptor.kt
@@ -58,8 +58,8 @@ internal class ChainedWorkflowInterceptor(
   }
 
   override fun <P, S, O, R> onRender(
-    props: P,
-    state: S,
+    renderProps: P,
+    renderState: S,
     context: BaseRenderContext<P, S, O>,
     proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
     session: WorkflowSession
@@ -69,7 +69,7 @@ internal class ChainedWorkflowInterceptor(
         workflowInterceptor.onRender(props, state, context, proceedAcc, session)
       }
     }
-    return chainedProceed(props, state, context)
+    return chainedProceed(renderProps, renderState, context)
   }
 
   override fun <S> onSnapshotState(

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/WorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/WorkflowInterceptorTest.kt
@@ -98,10 +98,10 @@ class WorkflowInterceptorTest {
     ): String = "$old|$new|$state"
 
     override fun render(
-      props: String,
-      state: String,
+      renderProps: String,
+      renderState: String,
       context: RenderContext
-    ): String = "$props|$state"
+    ): String = "$renderProps|$renderState"
 
     override fun snapshotState(state: String): Snapshot = Snapshot.of(state)
   }

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/WorkflowOperatorsTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/WorkflowOperatorsTest.kt
@@ -22,7 +22,7 @@ class WorkflowOperatorsTest {
     val workflow = object : StatelessWorkflow<Unit, Nothing, Nothing>() {
       override fun toString(): String = "ChildWorkflow"
       override fun render(
-        props: Unit,
+        renderProps: Unit,
         context: RenderContext
       ): Nothing = fail()
     }
@@ -214,7 +214,7 @@ class WorkflowOperatorsTest {
     }
 
     override fun render(
-      props: Unit,
+      renderProps: Unit,
       context: RenderContext
     ): T {
       // Listen to the flow to trigger a re-render when it updates.

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
@@ -171,29 +171,29 @@ class ChainedWorkflowInterceptorTest {
   @Test fun `chains calls to onRender() in left-to-right order`() {
     val interceptor1 = object : WorkflowInterceptor {
       override fun <P, S, O, R> onRender(
-        props: P,
-        state: S,
+        renderProps: P,
+        renderState: S,
         context: BaseRenderContext<P, S, O>,
         proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
         session: WorkflowSession
       ): R = ("r1: " +
           proceed(
-              "props1: $props" as P,
-              "state1: $state" as S,
+              "props1: $renderProps" as P,
+              "state1: $renderState" as S,
               FakeRenderContext("context1: $context") as BaseRenderContext<P, S, O>
           )) as R
     }
     val interceptor2 = object : WorkflowInterceptor {
       override fun <P, S, O, R> onRender(
-        props: P,
-        state: S,
+        renderProps: P,
+        renderState: S,
         context: BaseRenderContext<P, S, O>,
         proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
         session: WorkflowSession
       ): R = ("r2: " +
           proceed(
-              "props2: $props" as P,
-              "state2: $state" as S,
+              "props2: $renderProps" as P,
+              "state2: $renderState" as S,
               FakeRenderContext("context2: $context") as BaseRenderContext<P, S, O>
           )) as R
     }

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/RealRenderContextTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/RealRenderContextTest.kt
@@ -71,8 +71,8 @@ class RealRenderContextTest {
     ): String = fail()
 
     override fun render(
-      props: String,
-      state: String,
+      renderProps: String,
+      renderState: String,
       context: RenderContext
     ): Rendering {
       fail("This shouldn't actually be called.")

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/SubtreeManagerTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/SubtreeManagerTest.kt
@@ -45,13 +45,13 @@ class SubtreeManagerTest {
     }
 
     override fun render(
-      props: String,
-      state: String,
+      renderProps: String,
+      renderState: String,
       context: RenderContext
     ): Rendering {
       return Rendering(
-          props,
-          state,
+        renderProps,
+        renderState,
           eventHandler = context.eventHandler { out -> setOutput("workflow output:$out") })
     }
 
@@ -70,8 +70,8 @@ class SubtreeManagerTest {
     }
 
     override fun render(
-      props: Unit,
-      state: Unit,
+      renderProps: Unit,
+      renderState: Unit,
       context: RenderContext
     ) {
     }

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -80,13 +80,13 @@ class WorkflowNodeTest {
     ): String = onPropsChanged.invoke(old, new, state)
 
     override fun render(
-      props: String,
-      state: String,
+      renderProps: String,
+      renderState: String,
       context: RenderContext
     ): String {
       return """
-        props:$props
-        state:$state
+        props:$renderProps
+        state:$renderState
       """.trimIndent()
     }
   }
@@ -159,8 +159,8 @@ class WorkflowNodeTest {
       }
 
       override fun render(
-        props: String,
-        state: String,
+        renderProps: String,
+        renderState: String,
         context: RenderContext
       ): (String) -> Unit {
         return context.eventHandler { event -> setOutput(event) }
@@ -193,8 +193,8 @@ class WorkflowNodeTest {
       }
 
       override fun render(
-        props: String,
-        state: String,
+        renderProps: String,
+        renderState: String,
         context: RenderContext
       ): (String) -> Unit {
         return context.eventHandler { event -> setOutput(event) }
@@ -232,8 +232,8 @@ class WorkflowNodeTest {
       }
 
       override fun render(
-        props: String,
-        state: String,
+        renderProps: String,
+        renderState: String,
         context: RenderContext
       ): String {
         sink = context.actionSink
@@ -871,17 +871,17 @@ class WorkflowNodeTest {
     lateinit var interceptedSession: WorkflowSession
     val interceptor = object : WorkflowInterceptor {
       override fun <P, S, O, R> onRender(
-        props: P,
-        state: S,
+        renderProps: P,
+        renderState: S,
         context: BaseRenderContext<P, S, O>,
         proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
         session: WorkflowSession
       ): R {
-        interceptedProps = props as String
-        interceptedState = state as String
+        interceptedProps = renderProps as String
+        interceptedState = renderState as String
         interceptedContext = context
         interceptedSession = session
-        return proceed(props, state, context)
+        return proceed(renderProps, renderState, context)
             .also { interceptedRendering = it as String }
       }
     }
@@ -997,12 +997,12 @@ class WorkflowNodeTest {
     val interceptor = object : WorkflowInterceptor {
       @Suppress("UNCHECKED_CAST")
       override fun <P, S, O, R> onRender(
-        props: P,
-        state: S,
+        renderProps: P,
+        renderState: S,
         context: BaseRenderContext<P, S, O>,
         proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
         session: WorkflowSession
-      ): R = "[${proceed("[$props]" as P, "[$state]" as S, context)}]" as R
+      ): R = "[${proceed("[$renderProps]" as P, "[$renderState]" as S, context)}]" as R
     }
     val leafWorkflow = Workflow.stateful<String, String, Nothing, String>(
         initialState = { props -> props },

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderIdempotencyChecker.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderIdempotencyChecker.kt
@@ -21,18 +21,18 @@ import java.util.LinkedList
 @OptIn(ExperimentalWorkflowApi::class)
 public object RenderIdempotencyChecker : WorkflowInterceptor {
   override fun <P, S, O, R> onRender(
-    props: P,
-    state: S,
+    renderProps: P,
+    renderState: S,
     context: BaseRenderContext<P, S, O>,
     proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
     session: WorkflowSession
   ): R {
     val recordingContext = RecordingRenderContext(context)
-    proceed(props, state, recordingContext)
+    proceed(renderProps, renderState, recordingContext)
 
     // The second render pass should not actually invoke any real behavior.
     recordingContext.startReplaying()
-    return proceed(props, state, recordingContext)
+    return proceed(renderProps, renderState, recordingContext)
         .also {
           // After the verification render pass, any calls to the context _should_ be passed
           // through, to allow the real context to run its usual post-render behavior.

--- a/workflow-testing/src/test/java/com/squareup/workflow1/TreeWorkflow.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/TreeWorkflow.kt
@@ -36,19 +36,19 @@ internal class TreeWorkflow(
   } ?: props
 
   override fun render(
-    props: String,
-    state: String,
+    renderProps: String,
+    renderState: String,
     context: RenderContext
   ): Rendering {
     val childRenderings = children
         .mapIndexed { index, child ->
-          val childRendering = context.renderChild(child, "$props[$index]", child.name)
+          val childRendering = context.renderChild(child, "$renderProps[$index]", child.name)
           Pair(child.name, childRendering)
         }
         .toMap()
 
     return Rendering(
-        data = "$name:$state",
+        data = "$name:$renderState",
         setData = { context.actionSink.send(onEvent(it)) },
         children = childRenderings
     )

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
@@ -489,7 +489,7 @@ class RealRenderTesterTest {
   @Test fun `renderChild throws when multiple expectations match`() {
     class Child : OutputNothingChild, StatelessWorkflow<Unit, Nothing, Unit>() {
       override fun render(
-        props: Unit,
+        renderProps: Unit,
         context: RenderContext
       ) {
         // Nothing to do.
@@ -754,7 +754,7 @@ class RealRenderTesterTest {
   @Test fun `expectWorkflow matches on workflow supertype`() {
     val child = object : OutputNothingChild, StatelessWorkflow<Unit, Nothing, Unit>() {
       override fun render(
-        props: Unit,
+        renderProps: Unit,
         context: RenderContext
       ) {
         // Do nothing.
@@ -1058,8 +1058,8 @@ class RealRenderTesterTest {
       ): Double = throw NotImplementedError()
 
       override fun render(
-        props: String,
-        state: Double,
+        renderProps: String,
+        renderState: Double,
         context: RenderContext
       ) = throw NotImplementedError()
 
@@ -1077,7 +1077,7 @@ class RealRenderTesterTest {
   @Test fun `createRenderChildInvocation() for anonymous StatelessWorkflow`() {
     val workflow = object : StatelessWorkflow<String, Int, Unit>() {
       override fun render(
-        props: String,
+        renderProps: String,
         context: RenderContext
       ) = throw NotImplementedError()
     }
@@ -1098,8 +1098,8 @@ class RealRenderTesterTest {
       ): Double = throw NotImplementedError()
 
       override fun render(
-        props: String,
-        state: Double,
+        renderProps: String,
+        renderState: Double,
         context: RenderContext
       ) = throw NotImplementedError()
 
@@ -1119,7 +1119,7 @@ class RealRenderTesterTest {
   @Test fun `createRenderChildInvocation() for non-anonymous StatelessWorkflow`() {
     class TestWorkflow : StatelessWorkflow<String, Int, Unit>() {
       override fun render(
-        props: String,
+        renderProps: String,
         context: RenderContext
       ) = throw NotImplementedError()
     }
@@ -1137,7 +1137,7 @@ class RealRenderTesterTest {
   @Test fun `workflow rendered after worker matches workflow expectation`() {
     class ChildWorkflow : StatelessWorkflow<Unit, Nothing, Int>() {
       override fun render(
-        props: Unit,
+        renderProps: Unit,
         context: RenderContext
       ): Int = fail()
     }
@@ -1157,7 +1157,7 @@ class RealRenderTesterTest {
   @Test fun `worker ran after workflow matches workflow expectation`() {
     class ChildWorkflow : StatelessWorkflow<Unit, Nothing, Int>() {
       override fun render(
-        props: Unit,
+        renderProps: Unit,
         context: RenderContext
       ): Int = fail()
     }

--- a/workflow-tracing/src/main/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptor.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptor.kt
@@ -18,7 +18,6 @@ import com.squareup.workflow1.ExperimentalWorkflowApi
 import com.squareup.workflow1.Sink
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.WorkflowAction
-import com.squareup.workflow1.WorkflowAction.Updater
 import com.squareup.workflow1.WorkflowInterceptor
 import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
 import com.squareup.workflow1.WorkflowOutput
@@ -193,20 +192,20 @@ public class TracingWorkflowInterceptor internal constructor(
   }
 
   override fun <P, S, O, R> onRender(
-    props: P,
-    state: S,
+    renderProps: P,
+    renderState: S,
     context: BaseRenderContext<P, S, O>,
     proceed: (P, S, BaseRenderContext<P, S, O>) -> R,
     session: WorkflowSession
   ): R {
     if (session.parent == null) {
       // Track the overall render pass for the whole tree.
-      onBeforeRenderPass(props)
+      onBeforeRenderPass(renderProps)
     }
-    onBeforeWorkflowRendered(session.sessionId, props, state)
+    onBeforeWorkflowRendered(session.sessionId, renderProps, renderState)
 
     val tracingContext = TracingRenderContext(context, session)
-    val rendering = proceed(props, state, tracingContext)
+    val rendering = proceed(renderProps, renderState, tracingContext)
 
     onAfterWorkflowRendered(session.sessionId, rendering)
     if (session.parent == null) {

--- a/workflow-tracing/src/test/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptorTest.kt
+++ b/workflow-tracing/src/test/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptorTest.kt
@@ -2,7 +2,6 @@ package com.squareup.workflow1.diagnostic.tracing
 
 import com.nhaarman.mockito_kotlin.mock
 import com.squareup.tracing.TraceEncoder
-import com.squareup.workflow1.RenderContext
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.action
@@ -143,19 +142,19 @@ class TracingWorkflowInterceptorTest {
     }
 
     override fun render(
-      props: Int,
-      state: String,
+      renderProps: Int,
+      renderState: String,
       context: RenderContext
     ): String {
-      if (props == 0) return "initial"
-      if (props in 1..6) context.renderChild(this, 0) { bubbleUp(it) }
-      if (props in 4..5) context.renderChild(this, props = 1, key = "second") { bubbleUp(it) }
-      if (props in 2..3) context.runningWorker(
+      if (renderProps == 0) return "initial"
+      if (renderProps in 1..6) context.renderChild(this, 0) { bubbleUp(it) }
+      if (renderProps in 4..5) context.renderChild(this, props = 1, key = "second") { bubbleUp(it) }
+      if (renderProps in 2..3) context.runningWorker(
           channel.receiveAsFlow()
               .asWorker()
       ) { bubbleUp(it) }
 
-      return if (props > 10) "final" else "rendering"
+      return if (renderProps > 10) "final" else "rendering"
     }
 
     override fun snapshotState(state: String): Snapshot? = null


### PR DESCRIPTION
Prefixes `Workflow#render` `props` and `context` with "render" to better
remind users they should avoid using using the props and state of the
rendering pass as there is the possibility they are stale.

https://github.com/square/workflow-kotlin/issues/307.