### PR TITLE
Cleanup `this.state`

### DIFF
--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
@@ -38,14 +38,14 @@ object HelloBackButtonWorkflow : StatefulWorkflow<
     return HelloBackButtonRendering(
         message = "$renderState",
         onClick = context.eventHandler {
-          this.state = when (this.state) {
+          state = when (state) {
             Able -> Baker
             Baker -> Charlie
             Charlie -> Able
           }
         },
         onBackPressed = if (renderState == Able) null else context.eventHandler {
-          this.state = when (this.state) {
+          state = when (state) {
             Able -> throw IllegalStateException()
             Baker -> Able
             Charlie -> Baker

--- a/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
+++ b/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
@@ -24,8 +24,8 @@ class TimeMachineWorkflowTest {
 
     val delegateWorkflow = Workflow.stateful<String, Nothing, DelegateRendering>(
         initialState = "initial",
-        render = { state ->
-          DelegateRendering(state, setState = eventHandler { s -> this.state = s })
+        render = { renderState ->
+          DelegateRendering(renderState, setState = eventHandler { s -> state = s })
         }
     )
     val clock = TestTimeSource()

--- a/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
+++ b/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
@@ -51,7 +51,7 @@ class EditTextWorkflow : StatefulWorkflow<EditTextProps, EditTextState, String, 
   ): String {
     context.runningWorker(
       renderProps.terminalProps.keyStrokes
-    ) { key -> onKeystroke(renderProps, key) }
+    ) { key -> onKeystroke(key) }
 
     return buildString {
       renderProps.text.forEachIndexed { index, c ->
@@ -64,7 +64,6 @@ class EditTextWorkflow : StatefulWorkflow<EditTextProps, EditTextState, String, 
   override fun snapshotState(state: EditTextState): Snapshot? = null
 
   private fun onKeystroke(
-    props: EditTextProps,
     key: KeyStroke
   ) = action {
     when (key.keyType) {

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
@@ -78,7 +78,7 @@ class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
           LoginScreen(
               renderState.errorMessage,
               onLogin = context.eventHandler { email, password ->
-                this.state = when {
+                state = when {
                   email.isValidEmail -> Authorizing(email, password)
                   else -> LoginPrompt(email.emailValidationErrorMessage)
                 }
@@ -106,11 +106,11 @@ class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
           SecondFactorScreen(
               renderState.errorMessage,
               onSubmit = context.eventHandler { secondFactor ->
-                (this.state as? SecondFactorPrompt)?.let { oldState ->
-                  this.state = AuthorizingSecondFactor(oldState.tempToken, secondFactor)
+                (state as? SecondFactorPrompt)?.let { oldState ->
+                  state = AuthorizingSecondFactor(oldState.tempToken, secondFactor)
                 }
               },
-              onCancel = context.eventHandler { this.state = LoginPrompt() }
+              onCancel = context.eventHandler { state = LoginPrompt() }
           )
       )
     }

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
@@ -79,7 +79,7 @@ class RealRunGameWorkflow(
               renderState.defaultXName,
               renderState.defaultOName,
               onCancel = context.eventHandler { setOutput(CanceledStart) },
-              onStartGame = context.eventHandler { x, o -> this.state = Playing(PlayerInfo(x, o)) }
+              onStartGame = context.eventHandler { x, o -> state = Playing(PlayerInfo(x, o)) }
           )
       )
     }
@@ -103,13 +103,13 @@ class RealRunGameWorkflow(
           base = GamePlayScreen(renderState.playerInfo, renderState.completedGame.lastTurn),
           alert = maybeQuitScreen(
               confirmQuit = context.eventHandler {
-                (this.state as? MaybeQuitting)?.let { oldState ->
-                  this.state = MaybeQuittingForSure(oldState.playerInfo, oldState.completedGame)
+                (state as? MaybeQuitting)?.let { oldState ->
+                  state = MaybeQuittingForSure(oldState.playerInfo, oldState.completedGame)
                 }
               },
               continuePlaying = context.eventHandler {
-                (this.state as? MaybeQuitting)?.let { oldState ->
-                  this.state = Playing(oldState.playerInfo, oldState.completedGame.lastTurn)
+                (state as? MaybeQuitting)?.let { oldState ->
+                  state = Playing(oldState.playerInfo, oldState.completedGame.lastTurn)
                 }
               }
           )
@@ -125,13 +125,13 @@ class RealRunGameWorkflow(
               positive = "Yes!!",
               negative = "Sigh, no",
               confirmQuit = context.eventHandler {
-                (this.state as? MaybeQuittingForSure)?.let { oldState ->
-                  this.state = GameOver(oldState.playerInfo, oldState.completedGame)
+                (state as? MaybeQuittingForSure)?.let { oldState ->
+                  state = GameOver(oldState.playerInfo, oldState.completedGame)
                 }
               },
               continuePlaying = context.eventHandler {
-                (this.state as? MaybeQuittingForSure)?.let { oldState ->
-                  this.state = Playing(oldState.playerInfo, oldState.completedGame.lastTurn)
+                (state as? MaybeQuittingForSure)?.let { oldState ->
+                  state = Playing(oldState.playerInfo, oldState.completedGame.lastTurn)
                 }
               }
           )
@@ -171,14 +171,14 @@ class RealRunGameWorkflow(
   }
 
   private fun RenderContext.playAgain() = eventHandler {
-    (this.state as? GameOver)?.let { oldState ->
+    (state as? GameOver)?.let { oldState ->
       val (x, o) = oldState.playerInfo
       state = NewGame(x, o)
     }
   }
 
   private fun RenderContext.trySaveAgain() = eventHandler {
-    (this.state as? GameOver)?.let { oldState ->
+    (state as? GameOver)?.let { oldState ->
       check(oldState.syncState == SAVE_FAILED) {
         "Should only fire trySaveAgain in syncState $SAVE_FAILED, " +
             "was ${oldState.syncState}"

--- a/samples/tutorial/Tutorial1.md
+++ b/samples/tutorial/Tutorial1.md
@@ -186,7 +186,7 @@ The `action` function is a shorthand for implementing the `WorkflowAction` class
   private fun onUsernameChanged(username: String) =
     object : WorkflowAction<Unit, State, Nothing>() {
       override fun Updater.apply() {
-        this.state = this.state.copy(username = username)
+        state = state.copy(username = username)
       }
     }
 ```

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/RenderWorkflowInTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/RenderWorkflowInTest.kt
@@ -128,10 +128,10 @@ class RenderWorkflowInTest {
         snapshot = { state ->
           Snapshot.write { it.writeUtf8WithLength(state) }
         },
-        render = { _, state ->
+        render = { _, renderState ->
           Pair(
-              state,
-              { newState -> actionSink.send(action { this.state = newState }) }
+              renderState,
+              { newState -> actionSink.send(action { state = newState }) }
           )
         }
     )
@@ -171,9 +171,9 @@ class RenderWorkflowInTest {
             ByteString.of(1)
           }
         },
-        render = { _, state ->
-          sink = actionSink.contraMap { action { this.state = it } }
-          state
+        render = { _, renderState ->
+          sink = actionSink.contraMap { action { state = it } }
+          renderState
         }
     )
     val props = MutableStateFlow(Unit)
@@ -464,14 +464,14 @@ class RenderWorkflowInTest {
     // A workflow whose state and rendering is the last output that it emitted.
     val workflow = Workflow.stateful<Unit, String, String, String>(
         initialState = { "{no output}" },
-        render = { _, state ->
+        render = { _, renderState ->
           runningWorker(Worker.from { outputTrigger.await() }) { output ->
             action {
               setOutput(output)
-              this.state = output
+              state = output
             }
           }
-          return@stateful state
+          return@stateful renderState
         }
     )
     val events = mutableListOf<String>()

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -1083,9 +1083,9 @@ class WorkflowNodeTest {
   @Test fun `actionSink action changes state`() {
     val workflow = Workflow.stateful<Unit, String, Nothing, Pair<String, Sink<String>>>(
         initialState = { "initial" },
-        render = { _, state ->
-          state to actionSink.contraMap {
-            action { this.state = "${this.state}->$it" }
+        render = { _, renderState ->
+          renderState to actionSink.contraMap {
+            action { state = "$state->$it" }
           }
         }
     )
@@ -1163,11 +1163,11 @@ class WorkflowNodeTest {
   @Test fun `child action changes state`() {
     val workflow = Workflow.stateful<Unit, String, Nothing, String>(
         initialState = { "initial" },
-        render = { _, state ->
+        render = { _, renderState ->
           runningSideEffect("test") {
-            actionSink.send(action { this.state = "${this.state}->hello" })
+            actionSink.send(action { state = "$state->hello" })
           }
-          return@stateful state
+          return@stateful renderState
         }
     )
     val node = WorkflowNode(

--- a/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowRunnerTest.kt
+++ b/workflow-runtime/src/test/java/com/squareup/workflow1/internal/WorkflowRunnerTest.kt
@@ -92,14 +92,14 @@ class WorkflowRunnerTest {
   @Test fun `nextOutput() handles workflow update`() {
     val workflow = Workflow.stateful<Unit, String, String, String>(
         initialState = { "initial" },
-        render = { _, state ->
+        render = { _, renderState ->
           runningWorker(Worker.from { "work" }) {
             action {
-              this.state = "state: $it"
+              state = "state: $it"
               setOutput("output: $it")
             }
           }
-          return@stateful state
+          return@stateful renderState
         }
     )
     val runner = WorkflowRunner(workflow, MutableStateFlow(Unit))
@@ -119,14 +119,14 @@ class WorkflowRunnerTest {
   @Test fun `nextOutput() handles concurrent props change and workflow update`() {
     val workflow = Workflow.stateful<String, String, String, String>(
         initialState = { "initial state($it)" },
-        render = { props, state ->
+        render = { renderProps, renderState ->
           runningWorker(Worker.from { "work" }) {
             action {
-              this.state = "state: $it"
+              state = "state: $it"
               setOutput("output: $it")
             }
           }
-          return@stateful "$props|$state"
+          return@stateful "$renderProps|$renderState"
         }
     )
     val props = MutableStateFlow("initial props")


### PR DESCRIPTION
Now that `props` and `state` of `Workflow#render` have been [renamed](https://github.com/square/workflow-kotlin/pull/322) to
`renderProps` and `renderState`, `this` prefixing of `this.state` in
`WorkflowAction.Updater` lambdas is extraneous.