### PR TITLE
Add a module that provides a ViewStateRenderer for Radiography that describes workflow views.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -50,6 +50,7 @@ object Dependencies {
   // Required for Dungeon Crawler sample.
   const val desugar_jdk_libs = "com.android.tools:desugar_jdk_libs:_"
   const val moshi = "com.squareup.moshi:moshi:_"
+  const val radiography = "com.squareup.radiography:radiography:_"
   const val rxandroid2 = "io.reactivex.rxjava2:rxandroid:_"
   const val seismic = "com.squareup:seismic:_"
   const val timber = "com.jakewharton.timber:timber:_"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,7 +37,8 @@ include(
     ":workflow-ui:core-android",
     ":workflow-ui:internal-testing-android",
     ":workflow-ui:modal-common",
-    ":workflow-ui:modal-android"
+    ":workflow-ui:modal-android",
+    ":workflow-ui:radiography"
 )
 
 // Include the tutorial build so the IDE sees it when syncing the main project.

--- a/versions.properties
+++ b/versions.properties
@@ -49,3 +49,5 @@ version.org.jetbrains.kotlinx..binary-compatibility-validator=0.2.3
 version.org.jlleitschuh.gradle..ktlint-gradle=9.4.1
 version.org.openjdk.jmh..jmh-core=1.25.2
 version.org.openjdk.jmh..jmh-generator-annprocess=1.25.2
+
+version.radiography=2.3.0

--- a/workflow-ui/radiography/README.md
+++ b/workflow-ui/radiography/README.md
@@ -1,0 +1,4 @@
+# radiography
+
+This module provides support for configuring [Radiography](https://github.com/square/radiography)
+to show more helpful information about views created by workflow view factories.

--- a/workflow-ui/radiography/api/radiography.api
+++ b/workflow-ui/radiography/api/radiography.api
@@ -1,0 +1,4 @@
+public final class com/squareup/workflow1/ui/radiography/WorkflowViewRendererKt {
+	public static final fun getWorkflowViewRenderer (Lradiography/ViewStateRenderers;)Lradiography/ViewStateRenderer;
+}
+

--- a/workflow-ui/radiography/build.gradle.kts
+++ b/workflow-ui/radiography/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+  id("com.android.library")
+  kotlin("android")
+  id("org.jetbrains.dokka")
+}
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+apply(from = rootProject.file(".buildscript/configure-maven-publish.gradle"))
+apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
+apply(from = rootProject.file(".buildscript/android-ui-tests.gradle"))
+
+android {
+  // See https://github.com/Kotlin/kotlinx.coroutines/issues/1064#issuecomment-479412940
+  packagingOptions.exclude("**/*.kotlin_*")
+}
+
+dependencies {
+  api(project(":workflow-ui:core-android"))
+  api(Dependencies.radiography)
+  api(Dependencies.Kotlin.Stdlib.jdk6)
+
+  implementation(project(":workflow-runtime"))
+  implementation(Dependencies.AndroidX.activity)
+  implementation(Dependencies.AndroidX.fragment)
+  implementation(Dependencies.AndroidX.savedstate)
+  implementation(Dependencies.Kotlin.Coroutines.android)
+  implementation(Dependencies.Kotlin.Coroutines.core)
+
+  androidTestImplementation(project(":workflow-ui:backstack-android"))
+  androidTestImplementation(project(":workflow-ui:internal-testing-android"))
+  androidTestImplementation(project(":workflow-ui:modal-android"))
+  androidTestImplementation(Dependencies.Test.AndroidX.core)
+  androidTestImplementation(Dependencies.Test.AndroidX.truthExt)
+}

--- a/workflow-ui/radiography/gradle.properties
+++ b/workflow-ui/radiography/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=workflow-ui-radiography
+POM_NAME=Workflow UI Radiography Support
+POM_PACKAGING=aar

--- a/workflow-ui/radiography/src/androidTest/AndroidManifest.xml
+++ b/workflow-ui/radiography/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.squareup.workflow1.ui.radiography.test"/>

--- a/workflow-ui/radiography/src/androidTest/java/com/squareup/workflow1/ui/radiography/WorkflowViewRendererTest.kt
+++ b/workflow-ui/radiography/src/androidTest/java/com/squareup/workflow1/ui/radiography/WorkflowViewRendererTest.kt
@@ -1,0 +1,102 @@
+package com.squareup.workflow1.ui.radiography
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.squareup.workflow1.ui.NamedViewFactory
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewFactory
+import com.squareup.workflow1.ui.ViewRegistry
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.backstack.BackStackContainer
+import com.squareup.workflow1.ui.backstack.BackStackScreen
+import com.squareup.workflow1.ui.bindShowRendering
+import com.squareup.workflow1.ui.internal.test.WorkflowUiTestActivity
+import com.squareup.workflow1.ui.modal.HasModals
+import com.squareup.workflow1.ui.modal.ModalViewContainer
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import radiography.Radiography
+import radiography.ScanScopes
+import radiography.ViewStateRenderers
+import radiography.ViewStateRenderers.DefaultsNoPii
+import kotlin.reflect.KClass
+
+@RunWith(AndroidJUnit4::class)
+@OptIn(WorkflowUiExperimentalApi::class)
+internal class WorkflowViewRendererTest {
+
+  @get:Rule val scenarioRule = ActivityScenarioRule(WorkflowUiTestActivity::class.java)
+  private val scenario get() = scenarioRule.scenario
+
+  @Test fun view_renderer_works() {
+    val viewRegistry = ViewRegistry(
+      ModalViewContainer.binding<TestModals>(),
+      BackStackContainer,
+      NamedViewFactory,
+      TestRendering
+    )
+
+    scenario.onActivity {
+      it.viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+      it.setRendering(
+        TestModals(
+          beneathModals = BackStackScreen(TestRendering("base")),
+          modals = listOf(TestRendering("modal"))
+        )
+      )
+    }
+
+    lateinit var hierarchy: String
+    scenario.onActivity {
+      hierarchy = Radiography.scan(
+        // Explicitly select the view we want to avoid window focus flakiness.
+        scanScope = ScanScopes.singleViewScope(it.rootRenderedView),
+        viewStateRenderers = DefaultsNoPii + ViewStateRenderers.WorkflowViewRenderer
+      )
+    }
+    val hierarchyLines = hierarchy.lines()
+
+    assertThat(hierarchyLines.count {
+      "ModalViewContainer" in it &&
+        "workflow-rendering-type:${TestModals::class.java.name}" in it &&
+        "workflow-compatibility-key:${TestModals::class.java.name}-Named(0)" in it
+    }).isEqualTo(1)
+
+    assertThat(hierarchyLines.count {
+      "BackStackContainer" in it &&
+        "workflow-rendering-type:${BackStackScreen::class.java.name}" in it
+    }).isEqualTo(1)
+
+    assertThat(hierarchyLines.count {
+      "View" in it &&
+        "workflow-rendering-type:${TestRendering::class.java.name}" in it &&
+        "workflow-compatibility-key:${TestRendering::class.java.name}-Named(backstack)" in it
+    }).isEqualTo(1)
+  }
+
+  private data class TestModals(
+    override val beneathModals: BackStackScreen<Any>,
+    override val modals: List<Any>
+  ) : HasModals<BackStackScreen<Any>, Any>
+
+  private data class TestRendering(val text: String) {
+    companion object : ViewFactory<TestRendering> {
+      override val type: KClass<in TestRendering> = TestRendering::class
+      override fun buildView(
+        initialRendering: TestRendering,
+        initialViewEnvironment: ViewEnvironment,
+        contextForNewView: Context,
+        container: ViewGroup?
+      ): View = View(contextForNewView).apply {
+        bindShowRendering(initialRendering, initialViewEnvironment) { _, _ ->
+          // Noop
+        }
+      }
+    }
+  }
+}

--- a/workflow-ui/radiography/src/main/AndroidManifest.xml
+++ b/workflow-ui/radiography/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.squareup.workflow1.ui.radiography"/>

--- a/workflow-ui/radiography/src/main/java/com/squareup/workflow1/ui/radiography/WorkflowViewRenderer.kt
+++ b/workflow-ui/radiography/src/main/java/com/squareup/workflow1/ui/radiography/WorkflowViewRenderer.kt
@@ -1,0 +1,38 @@
+package com.squareup.workflow1.ui.radiography
+
+import com.squareup.workflow1.ui.Compatible
+import com.squareup.workflow1.ui.Named
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.getRendering
+import radiography.AttributeAppendable
+import radiography.ScannableView
+import radiography.ScannableView.AndroidView
+import radiography.ViewStateRenderer
+import radiography.ViewStateRenderers
+
+/**
+ * Renders information about views that were created by view factories, i.e. views with associated
+ * rendering tags.
+ */
+@Suppress("unused")
+public val ViewStateRenderers.WorkflowViewRenderer: ViewStateRenderer
+  get() = WorkflowViewRendererImpl
+
+@OptIn(WorkflowUiExperimentalApi::class)
+private object WorkflowViewRendererImpl : ViewStateRenderer {
+
+  override fun AttributeAppendable.render(view: ScannableView) {
+    val androidView = (view as? AndroidView)?.view ?: return
+    val rendering = androidView.getRendering<Any>() ?: return
+    renderRendering(rendering)
+  }
+
+  private fun AttributeAppendable.renderRendering(rendering: Any) {
+    val actualRendering = (rendering as? Named<*>)?.wrapped ?: rendering
+    append("workflow-rendering-type:${actualRendering::class.java.name}")
+
+    if (rendering is Compatible) {
+      append("workflow-compatibility-key:${rendering.compatibilityKey}")
+    }
+  }
+}


### PR DESCRIPTION
Example output:
```
window-focus:false
 ModalViewContainer { 1080×1962px, workflow-rendering-type:com.squareup.workflow1.ui.radiography.WorkflowViewRendererTest$TestModals, workflow-compatibility-key:com.squareup.workflow1.ui.radiography.WorkflowViewRendererTest$TestModals-Named(0) }
 ╰─BackStackContainer { id:workflow_back_stack_container, 1080×1962px, workflow-rendering-type:com.squareup.workflow1.ui.backstack.BackStackScreen }
   ╰─View { 1080×1962px, workflow-rendering-type:com.squareup.workflow1.ui.radiography.WorkflowViewRendererTest$TestRendering, workflow-compatibility-key:com.squareup.workflow1.ui.radiography.WorkflowViewRendererTest$TestRendering-Named(backstack) }
```