### PR TITLE
Update templates

### DIFF
--- a/fileTemplates/Layout Runner (ViewBinding).kt
+++ b/fileTemplates/Layout Runner (ViewBinding).kt
@@ -1,6 +1,5 @@
-#set( $LayoutRunnerName = "${NAME}LayoutRunner" )
-#set( $ViewBindingName = "YourViewBinding" )
-#set( $RenderingName = "YourRendering" )
+## Unlike the Workflow Templates, we never generate inner classes for view bindings
+## or rendering types. i.e. they are never "optional"
 package ${PACKAGE_NAME}
 
 import com.squareup.workflow1.ui.LayoutRunner
@@ -10,20 +9,19 @@ import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
 #parse("File Header.java")
-// TODO Change "YourViewBinding" and "YourRendering" to your actual types.
 @OptIn(WorkflowUiExperimentalApi::class)
-class $LayoutRunnerName(
-  private val binding: ${ViewBindingName}
-) : LayoutRunner<${RenderingName}> {
+class $Name(
+  private val binding: $VIEW_BINDING_TYPE
+) : LayoutRunner<$RENDERING_TYPE> {
 
   override fun showRendering(
-    rendering: ${RenderingName},
+    rendering: $RENDERING_TYPE,
     viewEnvironment: ViewEnvironment
   ) {
     TODO("Update ViewBinding from rendering")
   }
 
-  companion object : ViewFactory<${RenderingName}> by bind(
-      ${ViewBindingName}::inflate, ::$LayoutRunnerName
+  companion object : ViewFactory<$RENDERING_TYPE> by bind(
+      $VIEW_BINDING_TYPE::inflate, ::$NAME
   )
 }

--- a/fileTemplates/Stateful Workflow.kt
+++ b/fileTemplates/Stateful Workflow.kt
@@ -1,35 +1,87 @@
-#set( $WorkflowName = "${NAME}Workflow" )
-package ${PACKAGE_NAME}
+#set ($prefix = $NAME.replace('Workflow', '') )
+## build props string
+#if( $PROPS_TYPE_OPTIONAL == '')
+    #set ($props_type = $prefix + "Props")
+#else
+    #set ($props_type = $PROPS_TYPE_OPTIONAL)
+#end
+## build state string 
+#if( $STATE_TYPE_OPTIONAL == '')
+    #set ($state_type = $prefix + "State")
+#else
+    #set ($state_type = $STATE_TYPE_OPTIONAL)
+#end
+## build output string
+#if( $OUTPUT_TYPE_OPTIONAL == '')
+    #set ($output_type = $prefix + "Output")
+#else
+    #set ($output_type = $OUTPUT_TYPE_OPTIONAL)
+#end
+## build rendering string
+#if( $RENDERING_TYPE_OPTIONAL == '')
+    #set ($rendering_type = $prefix + "Rendering")
+#else
+    #set ($rendering_type = $RENDERING_TYPE_OPTIONAL)
+#end
+package $PACKAGE_NAME
 
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
-import ${PACKAGE_NAME}.${WorkflowName}.Output
-import ${PACKAGE_NAME}.${WorkflowName}.Props
-import ${PACKAGE_NAME}.${WorkflowName}.Rendering
-import ${PACKAGE_NAME}.${WorkflowName}.State
+
+#if( $PROPS_TYPE_OPTIONAL == '') ## import if we create below
+import $PACKAGE_NAME.$NAME.$props_type     
+#end
+#if( $STATE_TYPE_OPTIONAL == '') ## import if we create below
+import $PACKAGE_NAME.$NAME.$state_type     
+#end
+#if( $OUTPUT_TYPE_OPTIONAL == '') ## import if we create below
+import $PACKAGE_NAME.$NAME.$output_type     
+#end
+#if( $RENDERING_TYPE_OPTIONAL == '') ## import if we create below
+import $PACKAGE_NAME.$NAME.$rendering_type     
+#end
 
 #parse("File Header.java")
-class ${WorkflowName} : StatefulWorkflow<Props, State, Output, Rendering>() {
+object $NAME : StatefulWorkflow<$props_type, $state_type, $output_type, $rendering_type>() {
 
-  data class Props
-  data class State
-  data class Output
-  data class Rendering
+   #if( $PROPS_TYPE_OPTIONAL == '') ## create if not supplied
+   data class $props_type(
+     // TODO add args   
+   )     
+   #end
+   
+   #if( $STATE_TYPE_OPTIONAL == '') ## create if not supplied
+   data class $state_type(
+     // TODO add args   
+   )     
+   #end
+   
+  #if( $OUTPUT_TYPE_OPTIONAL == '') ## create if not supplied
+   data class $output_type(
+     // TODO add args   
+   )     
+   #end
+   
+   #if( $RENDERING_TYPE_OPTIONAL == '') ## create if not supplied
+   data class $rendering_type(
+     // TODO add args   
+   )     
+   #end
 
   override fun initialState(
-    props: Props,
+    props: $props_type,
     snapshot: Snapshot?
-  ): State = TODO("Initialize state")
+  ): $state_type = TODO("Initialize state")
 
   override fun render(
-    renderProps: Props,
-    renderState: State,
+    props: $props_type,
+    state: $state_type,
     context: RenderContext
-  ): Rendering {
+  ): $rendering_type {
     TODO("Render")
   }
 
-  override fun snapshotState(state: State): Snapshot? = Snapshot.write {
+  override fun snapshotState(state: $state_type): Snapshot? = Snapshot.write {
     TODO("Save state")
   }
 }

--- a/fileTemplates/Stateless Workflow.kt
+++ b/fileTemplates/Stateless Workflow.kt
@@ -1,22 +1,61 @@
-#set( $WorkflowName = "${NAME}Workflow" )
-package ${PACKAGE_NAME}
+#set ($prefix = $NAME.replace('Workflow', '') )
+## build props string
+#if( $PROPS_TYPE_OPTIONAL == '')
+    #set ($props_type = $prefix + "Props")
+#else
+    #set ($props_type = $PROPS_TYPE_OPTIONAL)
+#end
+## build output string
+#if( $OUTPUT_TYPE_OPTIONAL == '')
+    #set ($output_type = $prefix + "Output")
+#else
+    #set ($output_type = $OUTPUT_TYPE_OPTIONAL)
+#end
+## build rendering string
+#if( $RENDERING_TYPE_OPTIONAL == '')
+    #set ($rendering_type = $prefix + "Rendering")
+#else
+    #set ($rendering_type = $RENDERING_TYPE_OPTIONAL)
+#end
+package $PACKAGE_NAME
 
 import com.squareup.workflow1.StatelessWorkflow
-import ${PACKAGE_NAME}.${WorkflowName}.Output
-import ${PACKAGE_NAME}.${WorkflowName}.Props
-import ${PACKAGE_NAME}.${WorkflowName}.Rendering
+
+#if( $PROPS_TYPE_OPTIONAL == '') ## import if we create below
+import $PACKAGE_NAME.$NAME.$props_type     
+#end
+#if( $OUTPUT_TYPE_OPTIONAL == '') ## import if we create below
+import $PACKAGE_NAME.$NAME.$output_type     
+#end
+#if( $RENDERING_TYPE_OPTIONAL == '') ## import if we create below
+import $PACKAGE_NAME.$NAME.$rendering_type     
+#end
 
 #parse("File Header.java")
-class ${WorkflowName} : StatelessWorkflow<Props, Output, Rendering>() {
+object $NAME : StatelessWorkflow<$props_type, $output_type, $rendering_type>() {
 
-  data class Props
-  data class Output
-  data class Rendering
+   #if( $PROPS_TYPE_OPTIONAL == '') ## create if not supplied
+   data class $props_type(
+     // TODO add args   
+   )     
+   #end
+
+  #if( $OUTPUT_TYPE_OPTIONAL == '') ## create if not supplied
+   data class $output_type(
+     // TODO add args   
+   )     
+   #end
+   
+   #if( $RENDERING_TYPE_OPTIONAL == '') ## create if not supplied
+   data class $rendering_type(
+     // TODO add args   
+   )     
+   #end
 
   override fun render(
-    renderProps: Props,
+    props: $props_type,
     context: RenderContext
-  ): Rendering {
+  ): $rendering_type {
     TODO("Render")
   }
 }


### PR DESCRIPTION
IMO these templates would be more helpful if they let users set types in the creation dialog, not with a later refactor.

We don't always want state/props/rendering/output to have the same name as the workflow. Nor
do we always want to create those states/props/renderings/output. Sometimes those classes already
exist (e.g. Unit, Nothing, Any).

Stateful and Stateless Workflow templates now take in *optional* props/state/rendering/output. If these are left blank they will be auto created

Test
----

1. In Android Studio -> File -> New -> Edit File Templates....
2. create a new template or update existing and copy/paste code from these .kt files
3. File -> New -> select a template
4. see generated file

## StatefulWorkflow Template

### optionals left blank

![Screen Shot 2021-03-11 at 7 07 34 PM](https://user-images.githubusercontent.com/1980553/110871828-1a70ab80-829d-11eb-9e76-bccd721c5984.png)

generates:

```kotlin
package workflow.tutorial

import com.squareup.workflow1.Snapshot
import com.squareup.workflow1.StatefulWorkflow

import workflow.tutorial.MyFancyWorkflow.MyFancyProps
import workflow.tutorial.MyFancyWorkflow.MyFancyState
import workflow.tutorial.MyFancyWorkflow.MyFancyOutput
import workflow.tutorial.MyFancyWorkflow.MyFancyRendering

object MyFancyWorkflow : StatefulWorkflow<MyFancyProps, MyFancyState, MyFancyOutput, MyFancyRendering>() {

  data class MyFancyProps(
    // TODO add args
  )

  data class MyFancyState(
    // TODO add args
  )

  data class MyFancyOutput(
    // TODO add args
  )

  data class MyFancyRendering(
    // TODO add args
  )

  override fun initialState(
    props: MyFancyProps,
    snapshot: Snapshot?
  ): MyFancyState = TODO("Initialize state")

  override fun render(
    props: MyFancyProps,
    state: MyFancyState,
    context: RenderContext
  ): MyFancyRendering {
    TODO("Render")
  }

  override fun snapshotState(state: MyFancyState): Snapshot? = Snapshot.write {
    TODO("Save state")
  }
}
```

### optionals supplied

![Screen Shot 2021-03-11 at 7 09 03 PM](https://user-images.githubusercontent.com/1980553/110871917-4724c300-829d-11eb-8e6b-63c19548a744.png)

generates:

```kotlin
package workflow.tutorial

import com.squareup.workflow1.Snapshot
import com.squareup.workflow1.StatefulWorkflow

object MyFancyWorkflow : StatefulWorkflow<ExistingProps, ExistingState, Unit, ExistingScreen>() {

  override fun initialState(
    props: ExistingProps,
    snapshot: Snapshot?
  ): ExistingState = TODO("Initialize state")

  override fun render(
    props: ExistingProps,
    state: ExistingState,
    context: RenderContext
  ): ExistingScreen {
    TODO("Render")
  }

  override fun snapshotState(state: ExistingState): Snapshot? = Snapshot.write {
    TODO("Save state")
  }
}
```

## StatelessWorkflow template

### optionals left blank

![Screen Shot 2021-03-11 at 7 09 57 PM](https://user-images.githubusercontent.com/1980553/110871975-6a4f7280-829d-11eb-8163-a74c45e23649.png)

generates:

```kotlin
package workflow.tutorial

import com.squareup.workflow1.StatelessWorkflow

import workflow.tutorial.MyFancyWorkflow.MyFancyProps
import workflow.tutorial.MyFancyWorkflow.MyFancyOutput
import workflow.tutorial.MyFancyWorkflow.MyFancyRendering

object MyFancyWorkflow : StatelessWorkflow<MyFancyProps, MyFancyOutput, MyFancyRendering>() {

  data class MyFancyProps(
    // TODO add args   
  )

  data class MyFancyOutput(
    // TODO add args   
  )

  data class MyFancyRendering(
    // TODO add args   
  )

  override fun render(
    props: MyFancyProps,
    context: RenderContext
  ): MyFancyRendering {
    TODO("Render")
  }
}

```

### optionals supplied

![Screen Shot 2021-03-11 at 7 10 55 PM](https://user-images.githubusercontent.com/1980553/110872221-894e0480-829d-11eb-896e-ae129fb9533d.png)

generates:

```kotlin
package workflow.tutorial

import com.squareup.workflow1.StatelessWorkflow

object MyFancyWorkflow : StatelessWorkflow<ExistingProps, Nothing, ExistingScreen>() {

  override fun render(
    props: ExistingProps,
    context: RenderContext
  ): ExistingScreen {
    TODO("Render")
  }
}

```

## LayoutRunner template

![Screen Shot 2021-03-11 at 7 11 48 PM](https://user-images.githubusercontent.com/1980553/110872366-a682d300-829d-11eb-8ee0-1418ef735ce5.png)

generates:

```kotlin
package workflow.tutorial

import com.squareup.workflow1.ui.LayoutRunner
import com.squareup.workflow1.ui.LayoutRunner.Companion.bind
import com.squareup.workflow1.ui.ViewEnvironment
import com.squareup.workflow1.ui.ViewFactory
import com.squareup.workflow1.ui.WorkflowUiExperimentalApi

@OptIn(WorkflowUiExperimentalApi::class)
class MyFancyLayoutRunner(
  private val binding: MyExistingBindings
) : LayoutRunner<MyExistingScreen> {

  override fun showRendering(
    rendering: MyExistingScreen,
    viewEnvironment: ViewEnvironment
  ) {
    TODO("Update ViewBinding from rendering")
  }

  companion object : ViewFactory<MyExistingScreen> by bind(
    MyExistingBindings::inflate, ::MyFancyLayoutRunner
  )
}
```