### PR TITLE
Deletes ViewRegistry(vararg registries: ViewRegistry).

### DIFF
--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -127,7 +127,6 @@ public final class com/squareup/workflow1/ui/ViewRegistry$Companion : com/square
 public final class com/squareup/workflow1/ui/ViewRegistryKt {
 	public static final fun ViewRegistry ()Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun ViewRegistry ([Lcom/squareup/workflow1/ui/ViewFactory;)Lcom/squareup/workflow1/ui/ViewRegistry;
-	public static final fun ViewRegistry ([Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun buildView (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public static final fun buildView (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/view/ViewGroup;)Landroid/view/View;
 	public static synthetic fun buildView$default (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;ILjava/lang/Object;)Landroid/view/View;

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
@@ -90,13 +90,6 @@ public fun ViewRegistry(vararg bindings: ViewFactory<*>): ViewRegistry =
   TypedViewRegistry(*bindings)
 
 /**
- * Returns a [ViewRegistry] that merges all the given [registries].
- */
-@WorkflowUiExperimentalApi
-public fun ViewRegistry(vararg registries: ViewRegistry): ViewRegistry =
-  CompositeViewRegistry(*registries)
-
-/**
  * Returns a [ViewRegistry] that contains no bindings.
  *
  * Exists as a separate overload from the other two functions to disambiguate between them.
@@ -170,4 +163,5 @@ public operator fun ViewRegistry.plus(binding: ViewFactory<*>): ViewRegistry =
   this + ViewRegistry(binding)
 
 @WorkflowUiExperimentalApi
-public operator fun ViewRegistry.plus(other: ViewRegistry): ViewRegistry = ViewRegistry(this, other)
+public operator fun ViewRegistry.plus(other: ViewRegistry): ViewRegistry =
+  CompositeViewRegistry(this, other)


### PR DESCRIPTION
By having two vararg factory functions, we made it impossible to use the
spread operator with either, because these are ambiguous:

```
val registries = listOf(ViewRegistry(), ViewRegistry())
val reg = ViewRegistry(*registries)
```

```
val factories: List<ViewFactory<*>> = ...
val reg = ViewRegistry(*factories)
```

And note that there are no uses of the deleted variant across all the samples.