### PR TITLE
Drop the final dot in alpha versions.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.squareup.workflow1
-VERSION_NAME=1.0.0-alpha.13-SNAPSHOT
+VERSION_NAME=1.0.0-alpha13-SNAPSHOT
 
 POM_DESCRIPTION=Reactive workflows
 


### PR DESCRIPTION
Gradle and Android studio are stupid about semver, and keep insisting
that, say, `1.0.0-alpha.12` < `1.0.0-alpha.9`. To cope with that we drop
the last dot, so our next release will be `1.0.0-alpha13`.