### PR TITLE
bindShowRendering no longer calls showRendering.

### DIFF
--- a/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/BackStackContainerTest.kt
+++ b/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/BackStackContainerTest.kt
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @RunWith(AndroidJUnit4::class)
-class BackStackContainerTest {
+internal class BackStackContainerTest {
 
   @Rule @JvmField val scenarioRule = ActivityScenarioRule(BackStackTestActivity::class.java)
   private val scenario get() = scenarioRule.scenario

--- a/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/fixtures/BackStackTestActivity.kt
+++ b/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/fixtures/BackStackTestActivity.kt
@@ -25,7 +25,7 @@ import com.squareup.workflow1.ui.showRendering
  * [onRetainNonConfigurationInstance].
  */
 @OptIn(WorkflowUiExperimentalApi::class)
-class BackStackTestActivity : Activity() {
+internal class BackStackTestActivity : Activity() {
 
   /**
    * A simple string holder that creates [ViewStateTestView]s with their ID and tag derived from
@@ -35,7 +35,7 @@ class BackStackTestActivity : Activity() {
    * @param onViewCreated An optional function that will be called by the view factory after the
    * view is created but before [bindShowRendering].
    */
-  class TestRendering(
+  internal class TestRendering(
     val name: String,
     val onViewCreated: (ViewStateTestView) -> Unit = {},
     val onShowRendering: (ViewStateTestView) -> Unit = {},
@@ -96,6 +96,7 @@ class BackStackTestActivity : Activity() {
     check(backstackContainer == null)
     backstackContainer =
       NoTransitionBackStackContainer.buildView(backstack!!, viewEnvironment, this)
+    backstackContainer!!.showRendering(backstack!!, viewEnvironment)
     setContentView(backstackContainer)
   }
 

--- a/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/fixtures/NoTransitionBackStackContainer.kt
+++ b/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/fixtures/NoTransitionBackStackContainer.kt
@@ -16,7 +16,7 @@ import com.squareup.workflow1.ui.bindShowRendering
  * actual backstack logic. Views are just swapped instantly.
  */
 @OptIn(WorkflowUiExperimentalApi::class)
-class NoTransitionBackStackContainer(context: Context) : BackStackContainer(context) {
+internal class NoTransitionBackStackContainer(context: Context) : BackStackContainer(context) {
 
   override fun performTransition(oldViewMaybe: View?, newView: View, popped: Boolean) {
     oldViewMaybe?.let(::removeView)

--- a/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
+++ b/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
@@ -66,7 +66,12 @@ public open class BackStackContainer @JvmOverloads constructor(
           return
         }
 
-    val newView = environment[ViewRegistry].buildView(named.top, environment, this)
+    val newView = environment[ViewRegistry].buildView(
+      initialRendering = named.top,
+      initialViewEnvironment = environment,
+      contextForNewView = this.context,
+      container = this
+    )
     viewStateCache.update(named.backStack, oldViewMaybe, newView)
 
     val popped = currentRendering?.backStack?.any { compatible(it, named.top) } == true

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -127,9 +127,9 @@ public final class com/squareup/workflow1/ui/ViewRegistry$Companion : com/square
 public final class com/squareup/workflow1/ui/ViewRegistryKt {
 	public static final fun ViewRegistry ()Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun ViewRegistry ([Lcom/squareup/workflow1/ui/ViewFactory;)Lcom/squareup/workflow1/ui/ViewRegistry;
-	public static final fun buildView (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
-	public static final fun buildView (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/view/ViewGroup;)Landroid/view/View;
-	public static synthetic fun buildView$default (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;ILjava/lang/Object;)Landroid/view/View;
+	public static final fun buildView (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;Lkotlin/jvm/functions/Function1;)Landroid/view/View;
+	public static synthetic fun buildView$default (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroid/view/View;
+	public static final fun getFactoryForRendering (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;)Lcom/squareup/workflow1/ui/ViewFactory;
 	public static final fun plus (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewFactory;)Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun plus (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewRegistry;
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunner.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunner.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import androidx.viewbinding.ViewBinding
-import com.squareup.workflow1.ui.LayoutRunner.Companion.bind
 
 @WorkflowUiExperimentalApi
 public typealias ViewBindingInflater<BindingT> = (LayoutInflater, ViewGroup?, Boolean) -> BindingT
@@ -93,16 +92,10 @@ public fun interface LayoutRunner<RenderingT : Any> {
      * Creates a [ViewFactory] that inflates [layoutId] to "show" renderings of type [RenderingT],
      * with a no-op [LayoutRunner]. Handy for showing static views, e.g. when prototyping.
      */
+    @Suppress("unused")
     public inline fun <reified RenderingT : Any> bindNoRunner(
       @LayoutRes layoutId: Int
-    ): ViewFactory<RenderingT> = bind(layoutId) {
-      object : LayoutRunner<RenderingT> {
-        override fun showRendering(
-          rendering: RenderingT,
-          viewEnvironment: ViewEnvironment
-        ) = Unit
-      }
-    }
+    ): ViewFactory<RenderingT> = bind(layoutId) { LayoutRunner { _, _ -> } }
   }
 }
 

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunnerViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunnerViewFactory.kt
@@ -25,13 +25,12 @@ internal class LayoutRunnerViewFactory<RenderingT : Any>(
     container: ViewGroup?
   ): View {
     return contextForNewView.viewBindingLayoutInflater(container)
-        .inflate(layoutId, container, false)
-        .apply {
-          bindShowRendering(
-              initialRendering,
-              initialViewEnvironment,
-              runnerConstructor.invoke(this)::showRendering
-          )
+      .inflate(layoutId, container, false)
+      .also { view ->
+        val runner = runnerConstructor(view)
+        view.bindShowRendering(initialRendering, initialViewEnvironment) { rendering, environment ->
+          runner.showRendering(rendering, environment)
         }
+      }
   }
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewBindingViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewBindingViewFactory.kt
@@ -20,12 +20,14 @@ internal class ViewBindingViewFactory<BindingT : ViewBinding, RenderingT : Any>(
     container: ViewGroup?
   ): View =
     bindingInflater(contextForNewView.viewBindingLayoutInflater(container), container, false)
-        .also { binding ->
-          binding.root.bindShowRendering(
-              initialRendering,
-              initialViewEnvironment,
-              runnerConstructor.invoke(binding)::showRendering
-          )
+      .also { binding ->
+        val runner = runnerConstructor(binding)
+        binding.root.bindShowRendering(
+          initialRendering,
+          initialViewEnvironment
+        ) { rendering, environment ->
+          runner.showRendering(rendering, environment)
         }
-        .root
+      }
+      .root
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
@@ -25,13 +25,13 @@ public data class ShowRenderingTag<out RenderingT : Any>(
 )
 
 /**
- * It is usually more convenient to use [WorkflowViewStub] than to call this method directly.
- *
  * Establishes [showRendering] as the implementation of [View.showRendering]
- * for the receiver, possibly replacing the existing one. Immediately invokes [showRendering]
- * to display [initialRendering].
+ * for the receiver, possibly replacing the existing one. Likewise sets / updates
+ * the values returned by [View.getRendering] and [View.environment].
  *
  * Intended for use by implementations of [ViewFactory.buildView].
+ *
+ * @see DecorativeViewFactory
  */
 @WorkflowUiExperimentalApi
 public fun <RenderingT : Any> View.bindShowRendering(
@@ -43,7 +43,6 @@ public fun <RenderingT : Any> View.bindShowRendering(
     R.id.view_show_rendering_function,
     ShowRenderingTag(initialRendering, initialViewEnvironment, showRendering)
   )
-  showRendering.invoke(initialRendering, initialViewEnvironment)
 }
 
 /**
@@ -81,7 +80,10 @@ public fun <RenderingT : Any> View.showRendering(
           "Consider using ${WorkflowViewStub::class.java.simpleName} to display arbitrary types."
       }
 
+      // Update the tag's rendering and viewEnvironment.
       bindShowRendering(rendering, viewEnvironment, tag.showRendering)
+      // And do the actual showRendering work.
+      tag.showRendering.invoke(rendering, viewEnvironment)
     }
     ?: error(
       "Expected $this to have a showRendering function to show $rendering. " +

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
@@ -93,7 +93,7 @@ public class WorkflowViewStub @JvmOverloads constructor(
 
   init {
     val attrs = context.obtainStyledAttributes(
-        attributeSet, R.styleable.WorkflowViewStub, defStyle, defStyleRes
+      attributeSet, R.styleable.WorkflowViewStub, defStyle, defStyleRes
     )
     inflatedId = attrs.getResourceId(R.styleable.WorkflowViewStub_inflatedId, NO_ID)
     updatesVisibility = attrs.getBoolean(R.styleable.WorkflowViewStub_updatesVisibility, true)
@@ -121,8 +121,8 @@ public class WorkflowViewStub @JvmOverloads constructor(
     val index = parent.indexOfChild(actual)
     parent.removeView(actual)
     actual.layoutParams
-        ?.let { parent.addView(newView, index, it) }
-        ?: run { parent.addView(newView, index) }
+      ?.let { parent.addView(newView, index, it) }
+      ?: run { parent.addView(newView, index) }
   }
 
   /**
@@ -195,23 +195,27 @@ public class WorkflowViewStub @JvmOverloads constructor(
     viewEnvironment: ViewEnvironment
   ): View {
     actual.takeIf { it.canShowRendering(rendering) }
-        ?.let {
-          it.showRendering(rendering, viewEnvironment)
-          return it
-        }
+      ?.let {
+        it.showRendering(rendering, viewEnvironment)
+        return it
+      }
 
     val parent = actual.parent as? ViewGroup
-        ?: throw IllegalStateException(
-            "WorkflowViewStub must have a non-null ViewGroup parent"
-        )
+      ?: throw IllegalStateException("WorkflowViewStub must have a non-null ViewGroup parent")
 
-    return viewEnvironment[ViewRegistry].buildView(rendering, viewEnvironment, parent)
-        .also { newView ->
-          if (inflatedId != NO_ID) newView.id = inflatedId
-          if (updatesVisibility) newView.visibility = visibility
-          background?.let { newView.background = it }
-          replaceOldViewInParent(parent, newView)
-          actual = newView
-        }
+    return viewEnvironment[ViewRegistry]
+      .buildView(
+        rendering,
+        viewEnvironment,
+        parent.context,
+        parent
+      )
+      .also { newView ->
+        if (inflatedId != NO_ID) newView.id = inflatedId
+        if (updatesVisibility) newView.visibility = visibility
+        background?.let { newView.background = it }
+        replaceOldViewInParent(parent, newView)
+        actual = newView
+      }
   }
 }

--- a/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/ModalViewContainer.kt
+++ b/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/ModalViewContainer.kt
@@ -62,7 +62,12 @@ public open class ModalViewContainer @JvmOverloads constructor(
     initialViewEnvironment: ViewEnvironment
   ): DialogRef<Any> {
     val view = initialViewEnvironment[ViewRegistry]
-        .buildView(initialModalRendering, initialViewEnvironment, this)
+        .buildView(
+          initialRendering = initialModalRendering,
+          initialViewEnvironment = initialViewEnvironment,
+          contextForNewView = this.context,
+          container = this
+        )
         .apply {
           // If the modal's root view has no backPressedHandler, add a no-op one to
           // ensure that the `onBackPressed` call below will not leak up to handlers


### PR DESCRIPTION
That was always a weird coupling, and it caused the nasty compounding double
update behavior in `DecorativeViewFactory`.

To prevent `ViewFactory` implementations from having to remember to call
`showRendering`, we make `ViewRegistry.buildView` do so. And to allow more
sophisticiated `ViewFactory` implementations to prevent that call from
happening prematurely, we build it into the default value for a new
`initializeView` method on `ViewRegistry.buildView`.

`DecorativeViewFactory` takes advantage by passing a no-op function in for
`initializeView` when the view is built, and then making its own explicit call
to `showRendering` after it's done playing wrapping games.

Closes #397
