### PR TITLE
Cleans up view initialization in DecorativeViewFactory.

### DIFF
--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -24,10 +24,10 @@ public final class com/squareup/workflow1/ui/BuilderViewFactory : com/squareup/w
 }
 
 public final class com/squareup/workflow1/ui/DecorativeViewFactory : com/squareup/workflow1/ui/ViewFactory {
-	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function4;)V
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function4;)V
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public fun getType ()Lkotlin/reflect/KClass;
 }
@@ -132,6 +132,7 @@ public final class com/squareup/workflow1/ui/ViewRegistryKt {
 	public static final fun getFactoryForRendering (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;)Lcom/squareup/workflow1/ui/ViewFactory;
 	public static final fun plus (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewFactory;)Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun plus (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewRegistry;
+	public static final fun showFirstRendering (Landroid/view/View;)V
 }
 
 public final class com/squareup/workflow1/ui/ViewShowRenderingKt {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
@@ -133,8 +133,9 @@ public fun <RenderingT : Any>
  * [bindShowRendering] has been called on this view.
  *
  * @param initializeView Optional function invoked immediately after the [View] is
- * created (that is, immediately after the call to [ViewFactory.buildView]). Defaults
- * to a call to [View.showRendering].
+ * created (that is, immediately after the call to [ViewFactory.buildView]).
+ * [showRendering], [getRendering] and [environment] are all available when this is called.
+ * Defaults to a call to [View.showFirstRendering].
  *
  * @throws IllegalArgumentException if no factory can be find for type [RenderingT]
  *
@@ -147,9 +148,7 @@ public fun <RenderingT : Any> ViewRegistry.buildView(
   initialViewEnvironment: ViewEnvironment,
   contextForNewView: Context,
   container: ViewGroup? = null,
-  initializeView: View.() -> Unit = {
-    showRendering(getRendering<RenderingT>()!!, environment!!)
-  }
+  initializeView: View.() -> Unit = { showFirstRendering<RenderingT>() }
 ): View {
   return getFactoryForRendering(initialRendering).buildView(
     initialRendering, initialViewEnvironment, contextForNewView, container
@@ -170,3 +169,13 @@ public operator fun ViewRegistry.plus(binding: ViewFactory<*>): ViewRegistry =
 @WorkflowUiExperimentalApi
 public operator fun ViewRegistry.plus(other: ViewRegistry): ViewRegistry =
   CompositeViewRegistry(this, other)
+
+/**
+ * Default implementation for the `initializeView` argument of [ViewRegistry.buildView],
+ * and for [DecorativeViewFactory.initializeView]. Calls [showRendering] against
+ * [getRendering] and [environment].
+ */
+@WorkflowUiExperimentalApi
+public fun <RenderingT : Any> View.showFirstRendering() {
+  showRendering(getRendering<RenderingT>()!!, environment!!)
+}


### PR DESCRIPTION
```kotlin
initView: (OuterRenderingT, ViewEnvironment) -> Unit
```

is now

```kotlin
initializeView: View.() -> Unit
```

just like the param on `ViewRegistry.buildView`. We also eliminate
the hard coded call to `showRendering()`, giving authors complete control
over when / if it's called. Again, this is in parallel with `ViewRegistry`'s
behavior.

`View.showFirstRendering()` is introduced, to simplify the 99% case.

Closes #396