### PR TITLE
Replace experimental time API in TraceEncoder with custom implementation of TimeMark

### DIFF
--- a/trace-encoder/api/trace-encoder.api
+++ b/trace-encoder/api/trace-encoder.api
@@ -1,6 +1,10 @@
+public abstract interface class com/squareup/tracing/TimeMark {
+	public abstract fun getElapsedNow ()J
+}
+
 public final class com/squareup/tracing/TraceEncoder : java/io/Closeable {
-	public fun <init> (Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/TimeMark;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/TimeMark;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/tracing/TimeMark;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/tracing/TimeMark;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
 	public final fun createLogger (Ljava/lang/String;Ljava/lang/String;)Lcom/squareup/tracing/TraceLogger;
 	public static synthetic fun createLogger$default (Lcom/squareup/tracing/TraceEncoder;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/tracing/TraceLogger;

--- a/trace-encoder/src/main/java/com/squareup/tracing/TimeMark.kt
+++ b/trace-encoder/src/main/java/com/squareup/tracing/TimeMark.kt
@@ -1,0 +1,15 @@
+package com.squareup.tracing
+
+/**
+ * Interface that represents a time point. Remains bound to the time source it was taken from and
+ * allows querying for the duration of time elapsed from that point (see the val [elapsedNow]).
+ */
+public interface TimeMark {
+  /**
+   * Returns the amount of time passed from this mark measured with the time source from which this
+   * mark was taken.
+   *
+   * Note that the content of this val can change on subsequent invocations.
+   */
+  public val elapsedNow: Long
+}

--- a/trace-encoder/src/test/java/com/squareup/tracing/TraceEncoderTest.kt
+++ b/trace-encoder/src/test/java/com/squareup/tracing/TraceEncoderTest.kt
@@ -5,25 +5,22 @@ import kotlinx.coroutines.runBlocking
 import okio.Buffer
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
-import kotlin.time.TimeMark
 
-@OptIn(ExperimentalTime::class)
-class TraceEncoderTest {
+internal class TraceEncoderTest {
 
   /**
    * [TimeMark] that always returns [now] as [elapsedNow].
    */
-  private class FakeTimeMark : TimeMark() {
-    var now: Duration = Duration.microseconds(0)
-    override fun elapsedNow(): Duration = now
+  private class FakeTimeMark : TimeMark {
+    var now: Long = 0L
+    override val elapsedNow: Long
+      get() = now
   }
 
   @Test fun `multiple events sanity check`() {
     val firstBatch = listOf(
-        traceEvent("one"),
-        traceEvent("two")
+      traceEvent("one"),
+      traceEvent("two")
     )
     val secondBatch = listOf(traceEvent("three"))
 
@@ -33,10 +30,10 @@ class TraceEncoderTest {
       val encoder = TraceEncoder(this, start = fakeTimeMark) { buffer }
       val logger = encoder.createLogger("process", "thread")
 
-      fakeTimeMark.now = Duration.microseconds(1)
+      fakeTimeMark.now = 1L
       logger.log(firstBatch)
 
-      fakeTimeMark.now = Duration.microseconds(2)
+      fakeTimeMark.now = 2L
       logger.log(secondBatch)
 
       encoder.close()

--- a/workflow-tracing/src/test/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptorTest.kt
+++ b/workflow-tracing/src/test/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptorTest.kt
@@ -1,6 +1,7 @@
 package com.squareup.workflow1.diagnostic.tracing
 
 import com.nhaarman.mockito_kotlin.mock
+import com.squareup.tracing.TimeMark
 import com.squareup.tracing.TraceEncoder
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
@@ -34,9 +35,6 @@ import okio.source
 import kotlin.coroutines.coroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
-import kotlin.time.TimeMark
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class TracingWorkflowInterceptorTest {
@@ -163,7 +161,6 @@ internal class TracingWorkflowInterceptorTest {
   }
 }
 
-@OptIn(ExperimentalTime::class)
-private object ZeroTimeMark : TimeMark() {
-  override fun elapsedNow(): Duration = Duration.ZERO
+private object ZeroTimeMark : TimeMark {
+  override val elapsedNow: Long = 0L
 }


### PR DESCRIPTION
* Replace experimental time API in TraceEncoder with custom implementation of TimeMark
* The default implementation, TraceEncoderTimeMark, holds a starting value from `System.nanoTime()` which it compares to future calls to `System.nanoTime()` to calculate elapsed time