### PR TITLE
Don't try to restore unrecognized view state.

### DIFF
--- a/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/fixtures/BackStackTestActivity.kt
+++ b/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/fixtures/BackStackTestActivity.kt
@@ -49,26 +49,28 @@ internal class BackStackTestActivity : Activity() {
      * - [tag][View.getTag] is set to [name] for easy Espresso matching.
      */
     companion object : ViewFactory<TestRendering> by (
-        BuilderViewFactory(TestRendering::class) {
-          initialRendering, initialViewEnvironment, context, _ ->
-          ViewStateTestView(context).apply {
-            id = initialRendering.name.hashCode()
-            // For espresso matching.
-            tag = initialRendering.name
-            viewHooks = initialRendering.viewHooks
-            initialRendering.onViewCreated(this)
-            bindShowRendering(initialRendering, initialViewEnvironment) { rendering, _ ->
-              rendering.onShowRendering(this)
-              viewHooks = rendering.viewHooks
-            }
-      }
-    })
+      BuilderViewFactory(
+        TestRendering::class
+      ) { initialRendering, initialViewEnvironment, context, _ ->
+        ViewStateTestView(context).apply {
+          id = initialRendering.name.hashCode()
+          // For espresso matching.
+          tag = initialRendering.name
+          viewHooks = initialRendering.viewHooks
+          initialRendering.onViewCreated(this)
+          bindShowRendering(initialRendering, initialViewEnvironment) { rendering, _ ->
+            rendering.onShowRendering(this)
+            viewHooks = rendering.viewHooks
+          }
+        }
+      })
   }
 
   private val viewEnvironment = ViewEnvironment(
     mapOf(ViewRegistry to ViewRegistry(NamedViewFactory, TestRendering))
   )
-  private var backstackContainer: View? = null
+  var backstackContainer: View? = null
+    private set
 
   var backstack: BackStackScreen<TestRendering>? = null
     set(value) {

--- a/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/fixtures/ViewStateTestView.kt
+++ b/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/fixtures/ViewStateTestView.kt
@@ -10,7 +10,7 @@ import android.view.View
  * Simple view that has a string [viewState] property that will be saved and restored by the
  * [onSaveInstanceState] and [onRestoreInstanceState] methods.
  */
-class ViewStateTestView(context: Context) : View(context) {
+internal class ViewStateTestView(context: Context) : View(context) {
 
   var viewState: String = ""
 
@@ -33,7 +33,7 @@ class ViewStateTestView(context: Context) : View(context) {
     (state as? SavedState)?.let {
       viewState = it.viewState
       super.onRestoreInstanceState(state.superState)
-    } ?: super.onRestoreInstanceState(state)
+    }
     viewHooks?.onRestoreInstanceState(this)
   }
 

--- a/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
+++ b/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
@@ -14,11 +14,11 @@ import androidx.transition.Slide
 import androidx.transition.TransitionManager
 import androidx.transition.TransitionSet
 import com.squareup.workflow1.ui.BuilderViewFactory
-import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.Named
-import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewRegistry
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.backstack.BackStackConfig.First
 import com.squareup.workflow1.ui.backstack.BackStackConfig.Other
 import com.squareup.workflow1.ui.bindShowRendering
@@ -51,20 +51,20 @@ public open class BackStackContainer @JvmOverloads constructor(
     val environment = newViewEnvironment + (BackStackConfig to config)
 
     val named: BackStackScreen<Named<*>> = newRendering
-        // ViewStateCache requires that everything be Named.
-        // It's fine if client code is already using Named for its own purposes, recursion works.
-        .map { Named(it, "backstack") }
+      // ViewStateCache requires that everything be Named.
+      // It's fine if client code is already using Named for its own purposes, recursion works.
+      .map { Named(it, "backstack") }
 
     val oldViewMaybe = currentView
 
     // If existing view is compatible, just update it.
     oldViewMaybe
-        ?.takeIf { it.canShowRendering(named.top) }
-        ?.let {
-          viewStateCache.prune(named.frames)
-          it.showRendering(named.top, environment)
-          return
-        }
+      ?.takeIf { it.canShowRendering(named.top) }
+      ?.let {
+        viewStateCache.prune(named.frames)
+        it.showRendering(named.top, environment)
+        return
+      }
 
     val newView = environment[ViewRegistry].buildView(
       initialRendering = named.top,
@@ -98,33 +98,33 @@ public open class BackStackContainer @JvmOverloads constructor(
   ) {
     // Showing something already, transition with push or pop effect.
     oldViewMaybe
-        ?.let { oldView ->
-          val oldBody: View? = oldView.findViewById(R.id.back_stack_body)
-          val newBody: View? = newView.findViewById(R.id.back_stack_body)
+      ?.let { oldView ->
+        val oldBody: View? = oldView.findViewById(R.id.back_stack_body)
+        val newBody: View? = newView.findViewById(R.id.back_stack_body)
 
-          val oldTarget: View
-          val newTarget: View
-          if (oldBody != null && newBody != null) {
-            oldTarget = oldBody
-            newTarget = newBody
-          } else {
-            oldTarget = oldView
-            newTarget = newView
-          }
-
-          val (outEdge, inEdge) = when (popped) {
-            false -> Gravity.START to Gravity.END
-            true -> Gravity.END to Gravity.START
-          }
-
-          val transition = TransitionSet()
-              .addTransition(Slide(outEdge).addTarget(oldTarget))
-              .addTransition(Slide(inEdge).addTarget(newTarget))
-              .setInterpolator(AccelerateDecelerateInterpolator())
-
-          TransitionManager.go(Scene(this, newView), transition)
-          return
+        val oldTarget: View
+        val newTarget: View
+        if (oldBody != null && newBody != null) {
+          oldTarget = oldBody
+          newTarget = newBody
+        } else {
+          oldTarget = oldView
+          newTarget = newView
         }
+
+        val (outEdge, inEdge) = when (popped) {
+          false -> Gravity.START to Gravity.END
+          true -> Gravity.END to Gravity.START
+        }
+
+        val transition = TransitionSet()
+          .addTransition(Slide(outEdge).addTarget(oldTarget))
+          .addTransition(Slide(inEdge).addTarget(newTarget))
+          .setInterpolator(AccelerateDecelerateInterpolator())
+
+        TransitionManager.go(Scene(this, newView), transition)
+        return
+      }
 
     // This is the first view, just show it.
     addView(newView)
@@ -136,23 +136,25 @@ public open class BackStackContainer @JvmOverloads constructor(
 
   override fun onRestoreInstanceState(state: Parcelable) {
     (state as? ViewStateCache.SavedState)
-        ?.let {
-          viewStateCache.restore(it.viewStateCache)
-          super.onRestoreInstanceState(state.superState)
-        }
-        ?: super.onRestoreInstanceState(state)
+      ?.let {
+        viewStateCache.restore(it.viewStateCache)
+        super.onRestoreInstanceState(state.superState)
+      }
+    // Some other class wrote state, but we're not allowed to skip
+    // the call to super. Make a no-op call.
+      ?: super.onRestoreInstanceState(super.onSaveInstanceState())
   }
 
   public companion object : ViewFactory<BackStackScreen<*>>
   by BuilderViewFactory(
-      type = BackStackScreen::class,
-      viewConstructor = { initialRendering, initialEnv, context, _ ->
-        BackStackContainer(context)
-            .apply {
-              id = R.id.workflow_back_stack_container
-              layoutParams = (ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
-              bindShowRendering(initialRendering, initialEnv, ::update)
-            }
-      }
+    type = BackStackScreen::class,
+    viewConstructor = { initialRendering, initialEnv, context, _ ->
+      BackStackContainer(context)
+        .apply {
+          id = R.id.workflow_back_stack_container
+          layoutParams = (ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
+          bindShowRendering(initialRendering, initialEnv, ::update)
+        }
+    }
   )
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
@@ -95,7 +95,10 @@ public class WorkflowLayout(
         restoredChildState = it.childState
         super.onRestoreInstanceState(state.superState)
       }
-      ?: super.onRestoreInstanceState(state)
+
+    // Some other class wrote state, but we're not allowed to skip
+    // the call to super. Make a no-op call.
+      ?: super.onRestoreInstanceState(super.onSaveInstanceState())
   }
 
   private class SavedState : BaseSavedState {

--- a/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/ModalContainer.kt
+++ b/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/ModalContainer.kt
@@ -106,7 +106,10 @@ public abstract class ModalContainer<ModalRenderingT : Any> @JvmOverloads constr
           }
           super.onRestoreInstanceState(state.superState)
         }
-        ?: super.onRestoreInstanceState(state)
+
+    // Some other class wrote state, but we're not allowed to skip
+    // the call to super. Make a no-op call.
+      ?: super.onRestoreInstanceState(super.onSaveInstanceState())
   }
 
   internal data class KeyAndBundle(


### PR DESCRIPTION
Defangs a few dangerous calls to super from `View.onRestoreInstanceState`.
We'd crash in cases where the app was saved while showing a view of one type,
and then got restored showing another. Such a mismatch is reasonable --
imagine a configuration change that bounces between split pane and single, or
being saved on a logged in screen and restored after the session expires.

Such calls often accidentally work, if you follow the usual idiom of extending
`View.BaseSavedState`. But that idiom is not a requirement, and there's no
reason to believe it would be safe for a view of type A to try to restore the
state written by a view of type B.

It would be better to simply skip the call to super in such cases, but that's
not allowed. Instead we make a no-op call:

```
?: super.onRestoreInstanceState(super.onSaveInstanceState())
```

I've extended `BackStackContainerTest` to cover this, but we need new tests
for the other calls. Will add those in follow up.