### PR TITLE
Turn the dungeon lights back on (i.e. Upgrade ConstraintLayout library to 2.1.0-rc01)

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -21,7 +21,7 @@ object Dependencies {
       const val ui = "androidx.compose.ui:ui:1.0.0-alpha12"
     }
 
-    const val constraint_layout = "androidx.constraintlayout:constraintlayout:2.0.4"
+    const val constraint_layout = "androidx.constraintlayout:constraintlayout:2.1.0-rc01"
     const val fragment = "androidx.fragment:fragment:1.3.5"
     const val fragmentKtx = "androidx.fragment:fragment-ktx:1.3.5"
     const val gridlayout = "androidx.gridlayout:gridlayout:1.0.0"


### PR DESCRIPTION
It seems that version 2.0.4 had a bug that causes the BoardView in the dungeon sample's gameplay screen to be measured with zero width and height. It's fixed in this version.

ConstraintLayout is only used in samples, so we are safe to consume a pre-release version.

Thanks to @SalvatoreT for catching this sample bug!