### PR TITLE
Clean up color-related deprecation warning

### DIFF
--- a/samples/containers/android/src/main/java/com/squareup/sample/container/panel/ScrimContainer.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/panel/ScrimContainer.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import com.squareup.sample.container.R
 import com.squareup.workflow1.ui.BuilderViewFactory
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
@@ -26,8 +27,7 @@ class ScrimContainer @JvmOverloads constructor(
 ) : ViewGroup(context, attributeSet, defStyle, defStyleRes) {
   private val scrim = object : View(context, attributeSet, defStyle, defStyleRes) {
     init {
-      @Suppress("DEPRECATION")
-      setBackgroundColor(resources.getColor(R.color.scrim))
+      setBackgroundColor(ContextCompat.getColor(context, R.color.scrim))
     }
   }
 

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardView.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardView.kt
@@ -28,8 +28,7 @@ class BoardView(context: Context) : View(context) {
   private val textPaint = Paint().apply {
     // Set the text color correctly in case the map contains regular text characters (emojis ignore
     // the text paint color).
-    @Suppress("DEPRECATION")
-    color = ContextCompat.getColor(context, android.R.color.primary_text_dark)
+    color = ContextCompat.getColor(context, R.color.design_default_color_on_primary)
   }
   private val glyphBounds = Rect()
   private var board: Board? = null


### PR DESCRIPTION
- use ContextCompat for loading color resource
- use the Material color resource instead of the deprecated system one
https://developer.android.com/reference/android/R.color#primary_text_dark
https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/color/res/values/colors.xml#L23