### PR TITLE
Introduce support for ViewTreeSavedStateRegistryOwner in BackStackContainer.

### DIFF
--- a/workflow-ui/backstack-android/api/backstack-android.api
+++ b/workflow-ui/backstack-android/api/backstack-android.api
@@ -19,6 +19,8 @@ public class com/squareup/workflow1/ui/backstack/BackStackContainer : android/wi
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected fun onAttachedToWindow ()V
+	protected fun onDetachedFromWindow ()V
 	protected fun onRestoreInstanceState (Landroid/os/Parcelable;)V
 	protected fun onSaveInstanceState ()Landroid/os/Parcelable;
 	protected fun performTransition (Landroid/view/View;Landroid/view/View;Z)V
@@ -34,7 +36,9 @@ public final class com/squareup/workflow1/ui/backstack/BackStackContainer$Compan
 public final class com/squareup/workflow1/ui/backstack/ViewStateCache : android/os/Parcelable {
 	public static final field CREATOR Lcom/squareup/workflow1/ui/backstack/ViewStateCache$CREATOR;
 	public fun <init> ()V
+	public final fun attachToParentRegistry (Ljava/lang/String;Landroidx/savedstate/SavedStateRegistryOwner;)V
 	public fun describeContents ()I
+	public final fun detachFromParentRegistry ()V
 	public final fun prune (Ljava/util/Collection;)V
 	public final fun restore (Lcom/squareup/workflow1/ui/backstack/ViewStateCache;)V
 	public final fun update (Ljava/util/Collection;Landroid/view/View;Landroid/view/View;)V

--- a/workflow-ui/backstack-android/build.gradle.kts
+++ b/workflow-ui/backstack-android/build.gradle.kts
@@ -33,6 +33,12 @@ dependencies {
   implementation(Dependencies.Kotlin.Coroutines.android)
   implementation(Dependencies.Kotlin.Coroutines.core)
 
+  testImplementation(Dependencies.Kotlin.Test.common)
+  testImplementation(Dependencies.Kotlin.Test.jdk)
+  testImplementation(Dependencies.Test.AndroidX.truthExt)
+  testImplementation(Dependencies.Test.AndroidX.junitExt)
+  testImplementation(Dependencies.Test.robolectric)
+
   androidTestImplementation(Dependencies.Test.AndroidX.core)
   androidTestImplementation(Dependencies.Test.AndroidX.truthExt)
 }

--- a/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/ViewStateCacheTest.kt
+++ b/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/ViewStateCacheTest.kt
@@ -9,7 +9,9 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import com.squareup.workflow1.ui.Named
 import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.WorkflowLifecycleOwner
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.backstack.KeyedStateRegistryOwner
 import com.squareup.workflow1.ui.backstack.ViewStateCache
 import com.squareup.workflow1.ui.backstack.ViewStateFrame
 import com.squareup.workflow1.ui.backstack.test.fixtures.ViewStateTestView
@@ -63,6 +65,8 @@ internal class ViewStateCacheTest {
 
     // Set some state on the first view that will be saved.
     firstView.viewState = "hello world"
+    // Cache expects there to be a registry owner on old views.
+    KeyedStateRegistryOwner.installAsSavedStateRegistryOwnerOn(firstView, "first")
 
     // "Navigate" to the second screen, saving the first screen.
     cache.update(listOf(firstRendering), oldViewMaybe = firstView, newView = secondView)
@@ -85,6 +89,8 @@ internal class ViewStateCacheTest {
     // Android requires ID to be set for view hierarchy to be saved or restored.
     val firstView = createTestView(firstRendering, id = 1)
     val secondView = createTestView(secondRendering)
+    // Cache expects there to be a registry owner on old views.
+    KeyedStateRegistryOwner.installAsSavedStateRegistryOwnerOn(firstView, "first")
 
     // Set some state on the first view that will be saved.
     firstView.viewState = "hello world"
@@ -98,6 +104,7 @@ internal class ViewStateCacheTest {
     // "Navigate" back to the first screen, restoring state.
     val firstViewRestored = ViewStateTestView(instrumentation.context).apply {
       id = 2
+      WorkflowLifecycleOwner.installOn(this)
       bindShowRendering(firstRendering, viewEnvironment) { _, _ -> /* Noop */ }
     }
     cache.update(listOf(firstRendering), oldViewMaybe = secondView, newView = firstViewRestored)
@@ -115,6 +122,8 @@ internal class ViewStateCacheTest {
 
     // Set some state on the first view that will be saved.
     firstView.viewState = "hello world"
+    // Cache expects there to be a registry owner on old views.
+    KeyedStateRegistryOwner.installAsSavedStateRegistryOwnerOn(firstView, "first")
 
     // "Navigate" to the second screen, saving the first screen.
     cache.update(listOf(firstRendering), oldViewMaybe = firstView, newView = secondView)
@@ -161,6 +170,7 @@ internal class ViewStateCacheTest {
     id: Int? = null
   ) = ViewStateTestView(instrumentation.context).also { view ->
     id?.let { view.id = id }
+    WorkflowLifecycleOwner.installOn(view)
     view.bindShowRendering(firstRendering, viewEnvironment) { _, _ -> /* Noop */ }
   }
 

--- a/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
+++ b/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
@@ -9,6 +9,8 @@ import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.FrameLayout
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.ViewTreeSavedStateRegistryOwner
 import androidx.transition.Scene
 import androidx.transition.Slide
 import androidx.transition.TransitionManager
@@ -18,6 +20,7 @@ import com.squareup.workflow1.ui.Named
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewRegistry
+import com.squareup.workflow1.ui.WorkflowAndroidXSupport.stateRegistryOwnerFromViewTreeOrContext
 import com.squareup.workflow1.ui.WorkflowLifecycleOwner
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.backstack.BackStackConfig.First
@@ -26,11 +29,33 @@ import com.squareup.workflow1.ui.bindShowRendering
 import com.squareup.workflow1.ui.buildView
 import com.squareup.workflow1.ui.canShowRendering
 import com.squareup.workflow1.ui.compatible
+import com.squareup.workflow1.ui.getRendering
 import com.squareup.workflow1.ui.showFirstRendering
 import com.squareup.workflow1.ui.showRendering
 
 /**
  * A container view that can display a stream of [BackStackScreen] instances.
+ *
+ * This container supports saving and restoring the view state of each of its subviews corresponding
+ * to the renderings in its [BackStackScreen]. It supports two distinct state mechanisms:
+ *  1. Classic view hierarchy state ([View.onSaveInstanceState]/[View.onRestoreInstanceState])
+ *  2. AndroidX [SavedStateRegistry] via [ViewTreeSavedStateRegistryOwner].
+ *
+ * ## A note about `SavedStateRegistry` support.
+ *
+ * The [SavedStateRegistry] API involves defining string keys to associate with state bundles. These
+ * keys must be unique relative to the instance of the registry they are saved in. To support this
+ * requirement, [BackStackContainer] tries to generate a best-effort unique key by combining its
+ * fully-qualified class name with both its [view ID][View.getId] and the
+ * [compatibility key][com.squareup.workflow1.ui.Compatible.compatibilityKey] of its rendering.
+ * This method isn't guaranteed to give a unique registry key, but it should be good enough: If you
+ * need to nest multiple [BackStackContainer]s under the same `SavedStateRegistry`, just wrap each
+ * [BackStackScreen] with a [Named], or give each [BackStackContainer] a unique view ID.
+ *
+ * There's a potential issue here where if our ID is changed to something else, then another
+ * [BackStackContainer] is added with our old ID, that container will overwrite our state. Since
+ * they'd both be using the same key, [SavedStateRegistry] would throw an exception. As long as this
+ * container is detached before its ID is changed, it shouldn't be a problem.
  */
 @WorkflowUiExperimentalApi
 public open class BackStackContainer @JvmOverloads constructor(
@@ -152,6 +177,35 @@ public open class BackStackContainer @JvmOverloads constructor(
       ?: super.onRestoreInstanceState(super.onSaveInstanceState())
     // Some other class wrote state, but we're not allowed to skip
     // the call to super. Make a no-op call.
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+
+    // Wire up our viewStateCache to our parent SavedStateRegistry.
+    val parentRegistryOwner = stateRegistryOwnerFromViewTreeOrContext(this)!!
+    val key = getStateRegistryKey()
+    viewStateCache.attachToParentRegistry(key, parentRegistryOwner)
+  }
+
+  override fun onDetachedFromWindow() {
+    // Disconnect our state cache from our parent SavedStateRegistry so that it doesn't get asked
+    // to save state anymore.
+    viewStateCache.detachFromParentRegistry()
+    super.onDetachedFromWindow()
+  }
+
+  /**
+   * See the note about SavedStateRegistry support in this class's kdoc for some caveats.
+   */
+  private fun getStateRegistryKey(): String {
+    val namedKeyOrNull = run {
+      val rendering = getRendering<Any>() as? Named<*>
+      rendering?.compatibilityKey
+    }
+    val nameSuffix = namedKeyOrNull?.let { "-$it" } ?: ""
+    val idSuffix = if (id == NO_ID) "" else "-$id"
+    return BackStackContainer::class.java.name + nameSuffix + idSuffix
   }
 
   public companion object : ViewFactory<BackStackScreen<*>>

--- a/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/KeyedStateRegistryOwner.kt
+++ b/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/KeyedStateRegistryOwner.kt
@@ -1,0 +1,56 @@
+package com.squareup.workflow1.ui.backstack
+
+import android.view.View
+import androidx.lifecycle.LifecycleOwner
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.ViewTreeSavedStateRegistryOwner
+import com.squareup.workflow1.ui.WorkflowLifecycleOwner
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.backstack.KeyedStateRegistryOwner.Companion.installAsSavedStateRegistryOwnerOn
+
+/**
+ * The implementation of [SavedStateRegistryOwner] that is installed on every immediate child view
+ * of a [BackStackContainer]. In other words, when a view inside a [BackStackContainer] calls
+ * [ViewTreeSavedStateRegistryOwner.get] on itself, one of these is returned.
+ *
+ * Internally, this class exposes a [controller] to allow the [ViewStateCache] to save and restore
+ * any state registered by child views.
+ *
+ * To create an instance, call [installAsSavedStateRegistryOwnerOn].
+ *
+ * @param key The key used to save and restore this controller from a [SavedStateRegistry].
+ * @param lifecycleOwner The [LifecycleOwner] that will be delegated to by this instance. Note that
+ * [SavedStateRegistryOwner] extends [LifecycleOwner].
+ */
+internal class KeyedStateRegistryOwner private constructor(
+  val key: String,
+  lifecycleOwner: LifecycleOwner
+) : SavedStateRegistryOwner, LifecycleOwner by lifecycleOwner {
+  val controller = SavedStateRegistryController.create(this)
+  override fun getSavedStateRegistry(): SavedStateRegistry = controller.savedStateRegistry
+
+  companion object {
+    /**
+     * Creates a new [KeyedStateRegistryOwner] that is bound to [view]'s [WorkflowLifecycleOwner]
+     * and sets it as the [ViewTreeSavedStateRegistryOwner] on [view].
+     *
+     * Note that, once installed, the owner does not need to be "uninstalled". It can live on the
+     * view instance as long as it exists, and just be garbage-collected with the view.
+     */
+    @OptIn(WorkflowUiExperimentalApi::class)
+    fun installAsSavedStateRegistryOwnerOn(
+      view: View,
+      key: String
+    ): KeyedStateRegistryOwner {
+      val lifecycleOwner = checkNotNull(WorkflowLifecycleOwner.get(view)) {
+        "Expected back stack container view to set a WorkflowLifecycleOwner on its immediate " +
+          "child views."
+      }
+      val registryOwner = KeyedStateRegistryOwner(key, lifecycleOwner)
+      ViewTreeSavedStateRegistryOwner.set(view, registryOwner)
+      return registryOwner
+    }
+  }
+}

--- a/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/StateRegistryAggregator.kt
+++ b/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/StateRegistryAggregator.kt
@@ -1,0 +1,230 @@
+package com.squareup.workflow1.ui.backstack
+
+import android.os.Bundle
+import androidx.lifecycle.Lifecycle.Event
+import androidx.lifecycle.Lifecycle.Event.ON_CREATE
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+
+/**
+ * Manages a group of [SavedStateRegistryController]s that are all saved to and restored from a single
+ * "parent" [SavedStateRegistryOwner].
+ *
+ * This class is designed to support a navigation container that owns a
+ * [SavedStateRegistryController] for each of a set of navigation "frames", where a frame is
+ * something that can be navigated to/from. A frame loosely consists of a [View][android.view.View]
+ * as well as a [SavedStateRegistryOwner]/[SavedStateRegistryController] that is set on that view
+ * via [androidx.savedstate.ViewTreeSavedStateRegistryOwner]. The view associated with the
+ * controller is considered the "owning" view.
+ *
+ * To save a child registry to the parent registry, call [saveRegistryController]. This should be
+ * done whenever the "navigation frame" associated with the child registry is about to be hidden,
+ * and from the [onWillSave] callback. To restore a child registry, call
+ * [restoreRegistryControllerIfReady]. This should be done when a navigation frame that was
+ * previously hidden is being shown again, and from the [onRestored] callback. See the kdoc on these
+ * methods and callbacks for more information.
+ *
+ * [attachToParentRegistry] should be called when the owning view is attached to a window, and
+ * passed the parent registry. [detachFromParentRegistry] should be called when the view is
+ * detached. See the kdoc on those methods for more information about what they do.
+ *
+ * @param onWillSave Called whenever the parent registry is performing a save operation. Provides an
+ * opportunity to save any active child registries via [saveRegistryController].
+ * @param onRestored Called as soon as this instance has been restored from a parent registry, after
+ * [attachToParentRegistry] and the parent registry's lifecycle is in the `CREATED` state.
+ */
+@OptIn(WorkflowUiExperimentalApi::class)
+internal class StateRegistryAggregator(
+  private val onWillSave: (StateRegistryAggregator) -> Unit,
+  private val onRestored: (StateRegistryAggregator) -> Unit,
+) {
+
+  /**
+   * Holds any states restored from the parent registry, as well as any states saved after that time
+   * via [saveRegistryController].
+   *
+   * Will be null until we are restored from the parent registry. After being restored, it will
+   * never be re-assigned again.
+   */
+  private var states: MutableMap<String, Bundle>? = null
+
+  private val isRestored get() = states != null
+
+  /** Memoizes the registry owner passed to [attachToParentRegistry] so it can be detached later. */
+  private var parentRegistryOwner: SavedStateRegistryOwner? = null
+  private var parentKey: String? = null
+
+  /**
+   * Used to observe the parent registry's lifecycle to know when it becomes `CREATED` and is ready
+   * for us to restore ourselves. This observer is only registered between calls to
+   * [attachToParentRegistry] and [detachFromParentRegistry], and will only be registered if this
+   * instance has not already been restored.
+   */
+  private val lifecycleObserver = object : LifecycleEventObserver {
+    override fun onStateChanged(
+      source: LifecycleOwner,
+      event: Event
+    ) {
+      // We should always get all the events required to bring this observer from it's initial state
+      // (INITIALIZED) up to the current state, as per the contract of Lifecycle. But double-check
+      // here just in case we're dealing with a bad implementation, so that this state machine
+      // doesn't hang forever in a bad state.
+      check(event == ON_CREATE) {
+        "Expected to receive ON_CREATE event before anything else, but got $event"
+      }
+      check(!isRestored) { "Expected not to be observing lifecycle after restoration." }
+
+      // We don't care about the lifecycle anymore, we've got what we need.
+      source.lifecycle.removeObserver(this)
+
+      // These properties are guaranteed to be non-null because this observer is only registered
+      // while attached, and these properties are always non-null while attached.
+      val restoredState =
+        parentRegistryOwner!!.savedStateRegistry.consumeRestoredStateForKey(parentKey!!)
+      restoreFromBundle(restoredState)
+    }
+  }
+
+  /**
+   * Must be called when the owning view gets attached to the window. The owning view should find
+   * its [SavedStateRegistryOwner] (probably via
+   * [androidx.savedstate.ViewTreeSavedStateRegistryOwner]) and determine a string key unique within
+   * its parent to save and restore this class in that registry. These values will be cached in this
+   * object for [detachment][detachFromParentRegistry] later.
+   *
+   * This method will register on the parent registry to save any child registries registered with
+   * [saveRegistryController].
+   *
+   * If this object has not been restored yet, this method will start listening to the parent
+   * lifecycle to know when to restore.
+   *
+   * Must be accompanied by a call to [detachFromParentRegistry] when the view is detached.
+   */
+  fun attachToParentRegistry(
+    key: String,
+    parentOwner: SavedStateRegistryOwner
+  ) {
+    // attachToParentRegistry may be called multiple times without a matching detach in some cases,
+    // eg. when certain UI tests have failed and are being torn down. Ensure that if that happens
+    // we detach from the previous parent first.
+    detachFromParentRegistry()
+
+    this.parentRegistryOwner = parentOwner
+    this.parentKey = key
+
+    // We can only be restored once.
+    if (isRestored) return
+
+    val parentRegistry = parentOwner.savedStateRegistry
+    val parentLifecycle = parentOwner.lifecycle
+
+    // If the key is already registered, SavedStateRegistry throws an exception that doesn't provide
+    // enough information to troubleshoot, so we add some ourselves.
+    try {
+      parentRegistry.registerSavedStateProvider(key, ::saveToBundle)
+    } catch (e: IllegalArgumentException) {
+      throw IllegalArgumentException(
+        "Error registering StateRegistryHolder as SavedStateProvider with key \"$key\" on parent " +
+          "SavedStateRegistryOwner $parentOwner.\n" +
+          "You might need to set a view ID on your BackStackContainer or wrap your " +
+          "BackStackScreen with a Named rendering.",
+        e
+      )
+    }
+
+    // Even if the parent lifecycle is in a state further than CREATED, new observers are sent all
+    // the lifecycle events required to catch the observer up to the current state, so this handles
+    // both the cases where we're ready to immediately restore, and where we have to wait.
+    parentLifecycle.addObserver(lifecycleObserver)
+  }
+
+  /**
+   * Must be called when the owning view detaches from the window.
+   *
+   * Stops listening to the parent lifecycle and unregisters from the parent registry.
+   */
+  fun detachFromParentRegistry() {
+    // parentKey will only be null if parentRegistryOwner is also null.
+    parentRegistryOwner?.savedStateRegistry?.unregisterSavedStateProvider(parentKey!!)
+    parentRegistryOwner?.lifecycle?.removeObserver(lifecycleObserver)
+    parentRegistryOwner = null
+    parentKey = null
+  }
+
+  /**
+   * Asks [controller] to [save itself][SavedStateRegistryController.performSave] and caches that
+   * saved state for when our parent registry gets saved. This should be called any time the owning
+   * viewis going away but may be shown again later, and from the [onWillSave] callback.
+   *
+   * @param key The key used to distinguish [controller] from other controllers saved to this
+   * object. Must be the same key used to [restore][restoreRegistryControllerIfReady] the controller
+   * later.
+   */
+  fun saveRegistryController(
+    key: String,
+    controller: SavedStateRegistryController
+  ) {
+    doIfRestored { states ->
+      val state = Bundle()
+      controller.performSave(state)
+      states += key to state
+    }
+  }
+
+  /**
+   * If this object has been restored from its parent registry, restored the child [controller]
+   * that was previously [saved][saveRegistryController] with the same [key]. This should be called
+   * any time the view associated with the child controller is being shown again, and from the
+   * [onRestored] callback.
+   *
+   * This method can only be called once per key per instance of this class. After a key has been
+   * restored, its data will be removed from this object.
+   *
+   * @param key The key used to distinguish [controller] from other controllers saved to this
+   * object. Must be the same key used to [save][saveRegistryController] the controller earlier.
+   */
+  fun restoreRegistryControllerIfReady(
+    key: String,
+    controller: SavedStateRegistryController
+  ) {
+    doIfRestored { states ->
+      val state = states.remove(key)
+      controller.performRestore(state)
+    }
+  }
+
+  /**
+   * Removes all entries from [states] that don't have keys in [retaining].
+   */
+  fun pruneKeys(retaining: Collection<String>) {
+    doIfRestored { states ->
+      val deadKeys = states.keys - retaining
+      states -= deadKeys
+    }
+  }
+
+  private inline fun doIfRestored(block: (MutableMap<String, Bundle>) -> Unit) {
+    states?.let(block)
+  }
+
+  private fun saveToBundle() = Bundle().apply {
+    doIfRestored { states ->
+      onWillSave(this@StateRegistryAggregator)
+
+      // Convert states map to a bundle.
+      states.forEach { (key, state) -> putBundle(key, state) }
+    }
+  }
+
+  private fun restoreFromBundle(restoredState: Bundle?) {
+    check(states == null) { "Expected performRestore to be called only once." }
+    states = mutableMapOf()
+    restoredState?.keySet()?.forEach { key ->
+      states!! += key to restoredState.getBundle(key)!!
+    }
+    onRestored(this)
+  }
+}

--- a/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/ViewStateCache.kt
+++ b/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/ViewStateCache.kt
@@ -8,6 +8,8 @@ import android.view.View
 import android.view.View.BaseSavedState
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.ViewTreeSavedStateRegistryOwner
 import com.squareup.workflow1.ui.Named
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.backstack.ViewStateCache.SavedState
@@ -20,6 +22,10 @@ import com.squareup.workflow1.ui.getRendering
  * This class implements [Parcelable] so that it can be preserved from
  * a container view's own [View.saveHierarchyState] method. A simple container can
  * return [SavedState] from that method rather than creating its own persistence class.
+ *
+ * Container views using this class must call [attachToParentRegistry] and
+ * [detachFromParentRegistry] when they are [attached][View.onAttachedToWindow] and
+ * [detached][View.onDetachedFromWindow], respectively.
  */
 @WorkflowUiExperimentalApi
 public class ViewStateCache
@@ -29,6 +35,26 @@ internal constructor(
   internal val viewStates: MutableMap<String, ViewStateFrame>
 ) : Parcelable {
   public constructor() : this(mutableMapOf())
+
+  /**
+   * Cache of the last [KeyedStateRegistryOwner] created by [update], so we can restore it when we
+   * are restored.
+   */
+  private var currentOwner: KeyedStateRegistryOwner? = null
+
+  private val registryHolder = StateRegistryAggregator(
+    onWillSave = { aggregator ->
+      // Give the current view a chance to save itself.
+      currentOwner?.let { owner ->
+        aggregator.saveRegistryController(owner.key, owner.controller)
+      }
+    },
+    onRestored = { aggregator ->
+      currentOwner?.let { owner ->
+        aggregator.restoreRegistryControllerIfReady(owner.key, owner.controller)
+      }
+    }
+  )
 
   /**
    * To be called when the set of hidden views changes but the visible view remains
@@ -42,6 +68,7 @@ internal constructor(
   private fun pruneKeys(retaining: Collection<String>) {
     val deadKeys = viewStates.keys - retaining
     viewStates -= deadKeys
+    registryHolder.pruneKeys(retaining)
   }
 
   /**
@@ -75,20 +102,59 @@ internal constructor(
         }
       }
 
+    // Create and install a new SavedStateRegistryOwner for the new view and wire it up to the
+    // view's lifecycle. We need to do this even if the StateRegistryHolder hasn't been restored
+    // yet, the view can ask for it as soon as it's attached.
+    val registryOwner = KeyedStateRegistryOwner.installAsSavedStateRegistryOwnerOn(newView, newKey)
+    currentOwner = registryOwner
+
+    // If the aggregator hasn't been restored yet, this will be a no-op, but the currentOwner will be
+    // restored by the onRestored callback to the aggregator constructor.
+    registryHolder.restoreRegistryControllerIfReady(newKey, registryOwner.controller)
     viewStates.remove(newKey)
       ?.let { newView.restoreHierarchyState(it.viewState) }
 
+    // Save both the view state and state registry of the view that's going away, as long as it's
+    // still in the backstack.
     if (oldViewMaybe != null) {
       oldViewMaybe.namedKey.takeIf { hiddenKeys.contains(it) }
         ?.let { savedKey ->
+          // View state
           val saved = SparseArray<Parcelable>().apply {
             oldViewMaybe.saveHierarchyState(this)
           }
           viewStates += savedKey to ViewStateFrame(savedKey, saved)
+
+          // Registry state (note reverse order as saved above)
+          val owner = ViewTreeSavedStateRegistryOwner.get(oldViewMaybe) as KeyedStateRegistryOwner
+          registryHolder.saveRegistryController(savedKey, owner.controller)
         }
     }
 
     pruneKeys(hiddenKeys)
+  }
+
+  /**
+   * Must be called whenever the owning view is [attached to a window][View.onAttachedToWindow].
+   * Must eventually be matched with a call to [detachFromParentRegistry].
+   *
+   * Calls [StateRegistryAggregator.attachToParentRegistry] – see that method for more information.
+   */
+  public fun attachToParentRegistry(
+    key: String,
+    parentOwner: SavedStateRegistryOwner
+  ) {
+    registryHolder.attachToParentRegistry(key, parentOwner)
+  }
+
+  /**
+   * Must be called whenever the owning view is [detached from a window][View.onDetachedFromWindow].
+   * Must be matched with a call to [attachToParentRegistry].
+   *
+   * Calls [StateRegistryAggregator.detachFromParentRegistry] – see that method for more information.
+   */
+  public fun detachFromParentRegistry() {
+    registryHolder.detachFromParentRegistry()
   }
 
   /**

--- a/workflow-ui/backstack-android/src/test/java/com/squareup/workflow1/ui/backstack/StateRegistryAggregatorTest.kt
+++ b/workflow-ui/backstack-android/src/test/java/com/squareup/workflow1/ui/backstack/StateRegistryAggregatorTest.kt
@@ -1,0 +1,375 @@
+package com.squareup.workflow1.ui.backstack
+
+import android.os.Bundle
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.Event.ON_CREATE
+import androidx.lifecycle.Lifecycle.State.RESUMED
+import androidx.lifecycle.LifecycleRegistry
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertFailsWith
+
+@RunWith(RobolectricTestRunner::class)
+class StateRegistryAggregatorTest {
+
+  @Test fun `attach stops observing previous parent when called multiple times without detach`() {
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+    val parent1 = SimpleStateRegistry()
+    val parent2 = SimpleStateRegistry()
+
+    aggregator.attachToParentRegistry("key", parent1)
+    assertThat(parent1.lifecycleRegistry.observerCount).isEqualTo(1)
+
+    aggregator.attachToParentRegistry("key", parent2)
+    assertThat(parent1.lifecycleRegistry.observerCount).isEqualTo(0)
+  }
+
+  @Test fun `attach throws more helpful exception when key already registered`() {
+    val key = "fizzbuz"
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+    val parent = SimpleStateRegistry().apply {
+      stateRegistryController.savedStateRegistry.registerSavedStateProvider(key) { Bundle() }
+    }
+
+    val error = assertFailsWith<IllegalArgumentException> {
+      aggregator.attachToParentRegistry(key, parent)
+    }
+
+    assertThat(error).hasMessageThat()
+      .contains("Error registering StateRegistryHolder as SavedStateProvider with key \"$key\"")
+  }
+
+  @Test fun `attach observes parent lifecycle`() {
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+    val parent = SimpleStateRegistry().apply {
+      stateRegistryController.performRestore(null)
+    }
+
+    aggregator.attachToParentRegistry("key", parent)
+
+    // The androidx internals add 2 additional observers. This test could break if that changes, but
+    // unfortunately there's no other public API to check.
+    assertThat(parent.lifecycleRegistry.observerCount).isEqualTo(3)
+  }
+
+  @Test fun `attach doesn't observe parent when already restored`() {
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+    val parent = SimpleStateRegistry().apply {
+      stateRegistryController.performRestore(null)
+    }
+
+    // Restore the aggregator.
+    aggregator.attachToParentRegistry("key", parent)
+    parent.lifecycleRegistry.currentState = RESUMED
+
+    // Re-attach it.
+    aggregator.detachFromParentRegistry()
+    aggregator.attachToParentRegistry("key", parent)
+
+    // The androidx internals add 2 additional observers. This test could break if that changes, but
+    // unfortunately there's no other public API to check.
+    assertThat(parent.lifecycleRegistry.observerCount).isEqualTo(1)
+  }
+
+  @Test fun `stops observing parent after ON_CREATED`() {
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+    val parent = SimpleStateRegistry().apply {
+      // Must restore parent in order to advance lifecycle.
+      stateRegistryController.performRestore(null)
+    }
+
+    aggregator.attachToParentRegistry("key", parent)
+    parent.lifecycleRegistry.handleLifecycleEvent(ON_CREATE)
+
+    // The androidx internals add 1 additional observer. This test could break if that changes, but
+    // unfortunately there's no other public API to check.
+    assertThat(parent.lifecycleRegistry.observerCount).isEqualTo(1)
+  }
+
+  @Test fun `detach stops observing parent lifecycle`() {
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+    val parent = SimpleStateRegistry()
+
+    aggregator.attachToParentRegistry("key", parent)
+    aggregator.detachFromParentRegistry()
+
+    assertThat(parent.lifecycleRegistry.observerCount).isEqualTo(0)
+  }
+
+  @Test fun `saveRegistryController saves when parent is restored`() {
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+    val parent = SimpleStateRegistry().apply {
+      // Must restore the parent controller in order to initialize the aggregator.
+      stateRegistryController.performRestore(null)
+    }
+    var childSaveCount = 0
+    val child = SimpleStateRegistry().apply {
+      savedStateRegistry.registerSavedStateProvider("key") {
+        childSaveCount++
+        Bundle()
+      }
+    }
+    aggregator.attachToParentRegistry("parentKey", parent)
+    // Advancing the lifecycle triggers restoration.
+    parent.lifecycleRegistry.currentState = RESUMED
+
+    aggregator.saveRegistryController("childKey", child.stateRegistryController)
+
+    assertThat(childSaveCount).isEqualTo(1)
+  }
+
+  @Test fun `saveRegistryController doesn't save if not restored`() {
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+    val parent = SimpleStateRegistry().apply {
+      stateRegistryController.performRestore(null)
+    }
+    var childSaveCount = 0
+    val child = SimpleStateRegistry().apply {
+      savedStateRegistry.registerSavedStateProvider("key") {
+        childSaveCount++
+        Bundle()
+      }
+    }
+    aggregator.attachToParentRegistry("parentKey", parent)
+    // Not advancing the lifecycle here means we don't trigger restoration.
+
+    aggregator.saveRegistryController("childKey", child.stateRegistryController)
+
+    assertThat(childSaveCount).isEqualTo(0)
+  }
+
+  @Test fun `restoreRegistryControllerIfReady restores when parent is restored`() {
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+    val parent = SimpleStateRegistry().apply {
+      stateRegistryController.performRestore(null)
+    }
+    val child = SimpleStateRegistry()
+    aggregator.attachToParentRegistry("parentKey", parent)
+    // Advancing the lifecycle triggers restoration.
+    parent.lifecycleRegistry.currentState = RESUMED
+
+    aggregator.restoreRegistryControllerIfReady("childKey", child.stateRegistryController)
+
+    assertThat(child.savedStateRegistry.isRestored).isTrue()
+  }
+
+  @Test fun `restoreRegistryControllerIfReady doesn't restore if not restored`() {
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+    val parent = SimpleStateRegistry().apply {
+      stateRegistryController.performRestore(null)
+    }
+    val child = SimpleStateRegistry()
+    aggregator.attachToParentRegistry("parentKey", parent)
+    // Not advancing the lifecycle here means we don't trigger restoration.
+
+    aggregator.restoreRegistryControllerIfReady("childKey", child.stateRegistryController)
+
+    assertThat(child.savedStateRegistry.isRestored).isFalse()
+  }
+
+  // This is really more of an integration test.
+  @Test fun `saves and restores child state controller`() {
+    val holderToSave = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+    val parentToSave = SimpleStateRegistry().apply {
+      // Need to call restore before moving lifecycle state past INITIALIZED.
+      stateRegistryController.performRestore(null)
+    }
+    holderToSave.attachToParentRegistry("parentKey", parentToSave)
+    parentToSave.lifecycleRegistry.currentState = RESUMED
+
+    // Store some data in the system.
+    val childToSave = stateRegistryOf("key" to bundleOf("data" to "value"))
+    holderToSave.saveRegistryController("childKey", childToSave.stateRegistryController)
+
+    // Save the entire tree. This simulates what would happen just before a config change, e.g.
+    val parentSavedBundle = parentToSave.saveToBundle()
+
+    // Create a whole new tree, restored from our bundle.
+    val holderToRestore = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+    val parentToRestore = SimpleStateRegistry().apply {
+      stateRegistryController.performRestore(parentSavedBundle)
+    }
+    holderToRestore.attachToParentRegistry("parentKey", parentToRestore)
+    parentToRestore.lifecycleRegistry.currentState = RESUMED
+    val childToRestore = SimpleStateRegistry()
+    holderToRestore.restoreRegistryControllerIfReady(
+      "childKey",
+      childToRestore.stateRegistryController
+    )
+    val restoredChildContent = childToRestore.savedStateRegistry.consumeRestoredStateForKey("key")!!
+
+    // Verify that our leaf data was restored.
+    assertThat(restoredChildContent.getString("data")).isEqualTo("value")
+  }
+
+  @Test fun `restores child state controller`() {
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+    val parent = stateRegistryOf(
+      "parentKey" to bundleOf(
+        // The childKey is associated with a "saved" SavedStateRegistryController, so we need to
+        // give it the special internal bundle structure instead of just using bundleOf() directly.
+        "childKey" to stateRegistryOf(
+          "key" to bundleOf(
+            "data" to "value"
+          )
+        ).saveToBundle()
+      )
+    )
+
+    aggregator.attachToParentRegistry("parentKey", parent)
+    parent.lifecycleRegistry.handleLifecycleEvent(ON_CREATE)
+
+    val child = SimpleStateRegistry()
+    aggregator.restoreRegistryControllerIfReady("childKey", child.stateRegistryController)
+
+    val childState = child.savedStateRegistry.consumeRestoredStateForKey("key")!!
+    assertThat(childState.getString("data")).isEqualTo("value")
+  }
+
+  @Test fun `detach doesn't throws when called without attach`() {
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = {}
+    )
+
+    aggregator.detachFromParentRegistry()
+  }
+
+  @Test fun `save callback is invoked`() {
+    var saveCount = 0
+    val aggregator = StateRegistryAggregator(
+      onWillSave = { saveCount++ },
+      onRestored = {}
+    )
+    val parent = SimpleStateRegistry().apply {
+      // Must restore the parent controller in order to initialize the aggregator.
+      stateRegistryController.performRestore(null)
+    }
+    aggregator.attachToParentRegistry("parentKey", parent)
+    // Advancing the lifecycle triggers restoration.
+    parent.lifecycleRegistry.currentState = RESUMED
+
+    parent.saveToBundle()
+
+    assertThat(saveCount).isEqualTo(1)
+  }
+
+  @Test fun `restore callback is invoked when restored`() {
+    var restoreCount = 0
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = { restoreCount++ }
+    )
+    val parent = SimpleStateRegistry().apply {
+      // Must restore the parent controller in order to initialize the aggregator.
+      stateRegistryController.performRestore(null)
+    }
+    aggregator.attachToParentRegistry("parentKey", parent)
+    // Advancing the lifecycle triggers restoration.
+    parent.lifecycleRegistry.currentState = RESUMED
+
+    assertThat(restoreCount).isEqualTo(1)
+  }
+
+  @Test fun `restore callback is not invoked when attached`() {
+    var restoreCount = 0
+    val aggregator = StateRegistryAggregator(
+      onWillSave = {},
+      onRestored = { restoreCount++ }
+    )
+    val parent = SimpleStateRegistry().apply {
+      // Must restore the parent controller in order to initialize the aggregator.
+      stateRegistryController.performRestore(null)
+    }
+    aggregator.attachToParentRegistry("parentKey", parent)
+
+    assertThat(restoreCount).isEqualTo(0)
+  }
+
+  /**
+   * Creates a [SimpleStateRegistry] that is seeded with [pairs], where each key in the pair is the
+   * state registry key passed to [SavedStateRegistry.consumeRestoredStateForKey], and each value
+   * in the pair is the [Bundle] returned from that consume method.
+   */
+  private fun stateRegistryOf(vararg pairs: Pair<String, Bundle>): SimpleStateRegistry {
+    val stagingRegistry = SimpleStateRegistry()
+    pairs.forEach { (key, bundle) ->
+      stagingRegistry.savedStateRegistry.registerSavedStateProvider(key) { bundle }
+    }
+    val savedBundle = stagingRegistry.saveToBundle()
+    return SimpleStateRegistry().apply {
+      stateRegistryController.performRestore(savedBundle)
+    }
+  }
+
+  @JvmName("bundleOfBundles")
+  private fun bundleOf(vararg pairs: Pair<String, Bundle?>): Bundle = Bundle().apply {
+    pairs.forEach { (key, bundle) ->
+      putBundle(key, bundle)
+    }
+  }
+
+  @JvmName("bundleOfStrings")
+  private fun bundleOf(vararg pairs: Pair<String, String>): Bundle = Bundle().apply {
+    pairs.forEach { (key, string) ->
+      putString(key, string)
+    }
+  }
+
+  private class SimpleStateRegistry : SavedStateRegistryOwner {
+    val lifecycleRegistry = LifecycleRegistry(this)
+    val stateRegistryController = SavedStateRegistryController.create(this)
+
+    override fun getLifecycle(): Lifecycle = lifecycleRegistry
+    override fun getSavedStateRegistry(): SavedStateRegistry =
+      stateRegistryController.savedStateRegistry
+
+    fun saveToBundle(): Bundle = Bundle().also { bundle ->
+      stateRegistryController.performSave(bundle)
+    }
+  }
+}

--- a/workflow-ui/backstack-common/src/main/java/com/squareup/workflow1/ui/backstack/BackStackScreen.kt
+++ b/workflow-ui/backstack-common/src/main/java/com/squareup/workflow1/ui/backstack/BackStackScreen.kt
@@ -3,12 +3,16 @@ package com.squareup.workflow1.ui.backstack
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
 /**
- * Represents an active screen ([top]), and a set of previously visited
- * screens to which we may return ([backStack]). By rendering the entire
- * history we allow the UI to do things like maintain cached view state,
- * implement drag-back gestures without waiting for the workflow, etc.
+ * Represents an active screen ([top]), and a set of previously visited screens to which we may
+ * return ([backStack]). By rendering the entire history we allow the UI to do things like maintain
+ * cached view state, implement drag-back gestures without waiting for the workflow, etc.
  *
  * Effectively a list that can never be empty.
+ *
+ * If multiple [BackStackScreen]s are used as sibling renderings within the same parent navigation
+ * container (either the root activity or another [BackStackScreen]), then the siblings must be
+ * distinguished by wrapping them in [Named][com.squareup.workflow1.ui.Named] renderings in order to
+ * correctly support AndroidX `SavedStateRegistry`.
  *
  * @param bottom the bottom-most entry in the stack
  * @param rest the rest of the stack, empty by default

--- a/workflow-ui/compose/build.gradle.kts
+++ b/workflow-ui/compose/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
   api(project(":workflow-core"))
   api(project(":workflow-ui:backstack-android"))
   api(project(":workflow-ui:core-android"))
+  api(project(":workflow-ui:modal-android"))
 
   api(Dependencies.AndroidX.Compose.foundation)
 

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -147,6 +147,7 @@ public final class com/squareup/workflow1/ui/ViewShowRenderingKt {
 public final class com/squareup/workflow1/ui/WorkflowAndroidXSupport {
 	public static final field INSTANCE Lcom/squareup/workflow1/ui/WorkflowAndroidXSupport;
 	public final fun lifecycleOwnerFromViewTreeOrContext (Landroid/view/View;)Landroidx/lifecycle/LifecycleOwner;
+	public final fun stateRegistryOwnerFromViewTreeOrContext (Landroid/view/View;)Landroidx/savedstate/SavedStateRegistryOwner;
 }
 
 public abstract class com/squareup/workflow1/ui/WorkflowFragment : androidx/fragment/app/Fragment {

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/WorkflowViewStubLifecycleActivity.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/WorkflowViewStubLifecycleActivity.kt
@@ -1,6 +1,5 @@
 package com.squareup.workflow1.ui
 
-import android.os.Bundle
 import android.widget.FrameLayout
 import com.squareup.workflow1.ui.WorkflowViewStubLifecycleActivity.TestRendering.LeafRendering
 import com.squareup.workflow1.ui.WorkflowViewStubLifecycleActivity.TestRendering.RecurseRendering
@@ -14,7 +13,9 @@ internal class WorkflowViewStubLifecycleActivity : AbstractLifecycleTestActivity
       override val compatibilityKey: String get() = name
     }
 
-    data class RecurseRendering(val wrapped: LeafRendering) : TestRendering()
+    data class RecurseRendering(val wrapped: TestRendering) : TestRendering()
+
+    abstract class ViewRendering<T : ViewRendering<T>> : TestRendering(), AndroidViewRendering<T>
   }
 
   override val viewRegistry: ViewRegistry = ViewRegistry(
@@ -36,9 +37,4 @@ internal class WorkflowViewStubLifecycleActivity : AbstractLifecycleTestActivity
   )
 
   fun update(rendering: TestRendering) = super.setRendering(rendering)
-
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    update(LeafRendering("initial"))
-  }
 }

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/WorkflowViewStubLifecycleTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/WorkflowViewStubLifecycleTest.kt
@@ -1,18 +1,42 @@
 package com.squareup.workflow1.ui
 
+import android.os.Bundle
+import android.view.View
+import android.view.View.OnAttachStateChangeListener
+import android.widget.Button
+import android.widget.FrameLayout
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.Event
+import androidx.lifecycle.Lifecycle.Event.ON_CREATE
 import androidx.lifecycle.Lifecycle.State.CREATED
 import androidx.lifecycle.Lifecycle.State.RESUMED
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.ViewTreeSavedStateRegistryOwner
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withTagValue
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.common.truth.Truth.assertThat
+import com.squareup.workflow1.ui.WorkflowViewStubLifecycleActivity.TestRendering
 import com.squareup.workflow1.ui.WorkflowViewStubLifecycleActivity.TestRendering.LeafRendering
 import com.squareup.workflow1.ui.WorkflowViewStubLifecycleActivity.TestRendering.RecurseRendering
+import com.squareup.workflow1.ui.WorkflowViewStubLifecycleActivity.TestRendering.ViewRendering
+import org.hamcrest.Matchers.equalTo
 import org.junit.Rule
 import org.junit.Test
 
 /**
  * Tests for [WorkflowViewStub]'s [LifecycleOwner] integration.
  */
+@OptIn(WorkflowUiExperimentalApi::class)
 internal class WorkflowViewStubLifecycleTest {
 
   @Rule @JvmField internal val scenarioRule =
@@ -29,6 +53,7 @@ internal class WorkflowViewStubLifecycleTest {
   @Test fun stop_then_resume() {
     assertThat(scenario.state).isEqualTo(RESUMED)
     scenario.onActivity {
+      it.update(LeafRendering("initial"))
       assertThat(it.consumeLifecycleEvents()).containsExactly(
         "activity onCreate",
         "activity onStart",
@@ -68,6 +93,7 @@ internal class WorkflowViewStubLifecycleTest {
 
     assertThat(scenario.state).isEqualTo(RESUMED)
     scenario.onActivity {
+      it.update(LeafRendering("initial"))
       assertThat(it.consumeLifecycleEvents()).containsExactly(
         "activity onCreate",
         "activity onStart",
@@ -86,6 +112,7 @@ internal class WorkflowViewStubLifecycleTest {
     scenario.recreate()
 
     scenario.onActivity {
+      it.update(LeafRendering("initial"))
       assertThat(initialActivity.consumeLifecycleEvents()).containsExactly(
         "LeafView initial ON_PAUSE",
         "activity onPause",
@@ -111,6 +138,7 @@ internal class WorkflowViewStubLifecycleTest {
   @Test fun replace_child() {
     assertThat(scenario.state).isEqualTo(RESUMED)
     scenario.onActivity {
+      it.update(LeafRendering("initial"))
       assertThat(it.consumeLifecycleEvents()).containsExactly(
         "activity onCreate",
         "activity onStart",
@@ -139,6 +167,7 @@ internal class WorkflowViewStubLifecycleTest {
   @Test fun replace_after_stop() {
     assertThat(scenario.state).isEqualTo(RESUMED)
     scenario.onActivity {
+      it.update(LeafRendering("initial"))
       assertThat(it.consumeLifecycleEvents()).containsExactly(
         "activity onCreate",
         "activity onStart",
@@ -171,6 +200,7 @@ internal class WorkflowViewStubLifecycleTest {
   @Test fun nested_lifecycle() {
     assertThat(scenario.state).isEqualTo(RESUMED)
     scenario.onActivity {
+      it.update(LeafRendering("initial"))
       it.consumeLifecycleEvents()
       it.update(RecurseRendering(LeafRendering("wrapped")))
 
@@ -197,6 +227,132 @@ internal class WorkflowViewStubLifecycleTest {
         "LeafView unwrapped ON_START",
         "LeafView unwrapped ON_RESUME",
       )
+    }
+  }
+
+  @Test fun restores_registry_state_on_subview_after_config_change() {
+    scenario.onActivity {
+      it.update(CounterRendering())
+    }
+
+    onView(withTagValue(equalTo(CounterRendering.Tag)))
+      .check(matches(withText("Counter: 0")))
+      .perform(click())
+      .check(matches(withText("Counter: 1")))
+
+    scenario.recreate()
+
+    onView(withTagValue(equalTo(CounterRendering.Tag)))
+      .check(matches(withText("Counter: 1")))
+  }
+
+  @Test fun propagates_savedstateregistryowner_to_subviews() {
+    val expectedRegistryOwner = object : SavedStateRegistryOwner {
+      private val controller = SavedStateRegistryController.create(this)
+      private val lifecycleRegistry = LifecycleRegistry(this)
+      override fun getLifecycle(): Lifecycle = lifecycleRegistry
+      override fun getSavedStateRegistry(): SavedStateRegistry = controller.savedStateRegistry
+    }
+
+    data class RegistrySetter(val wrapped: TestRendering) : ViewRendering<RegistrySetter>() {
+      override val viewFactory: ViewFactory<RegistrySetter> = BuilderViewFactory(
+        RegistrySetter::class
+      ) { initialRendering, initialViewEnvironment, context, _ ->
+        val stub = WorkflowViewStub(context)
+        ViewTreeSavedStateRegistryOwner.set(stub, expectedRegistryOwner)
+
+        FrameLayout(context).apply {
+          addView(stub)
+
+          bindShowRendering(initialRendering, initialViewEnvironment) { r, e ->
+            stub.update(r.wrapped, e)
+          }
+        }
+      }
+    }
+
+    var initialRegistryOwner: SavedStateRegistryOwner? = null
+    scenario.onActivity {
+      it.update(RegistrySetter(CounterRendering("initial") { view ->
+        initialRegistryOwner = ViewTreeSavedStateRegistryOwner.get(view)
+      }))
+    }
+
+    assertThat(initialRegistryOwner).isSameInstanceAs(expectedRegistryOwner)
+
+    var subsequentRegistryOwner: SavedStateRegistryOwner? = null
+    scenario.onActivity {
+      it.update(RegistrySetter(CounterRendering("second") { view ->
+        subsequentRegistryOwner = ViewTreeSavedStateRegistryOwner.get(view)
+      }))
+    }
+
+    assertThat(subsequentRegistryOwner).isSameInstanceAs(expectedRegistryOwner)
+  }
+
+  private data class CounterRendering(
+    override val compatibilityKey: String = "",
+    val onViewAttached: (View) -> Unit = {}
+  ) : ViewRendering<CounterRendering>(), Compatible {
+    companion object {
+      const val Tag = "counter"
+    }
+
+    override val viewFactory: ViewFactory<CounterRendering> = BuilderViewFactory(
+      CounterRendering::class
+    ) { initialRendering, initialViewEnvironment, context, _ ->
+      var counter = 0
+      Button(context).apply button@{
+        tag = Tag
+
+        fun updateText() {
+          text = "Counter: $counter"
+        }
+
+        addOnAttachStateChangeListener(object : OnAttachStateChangeListener {
+          lateinit var registryOwner: SavedStateRegistryOwner
+          lateinit var lifecycleObserver: LifecycleObserver
+
+          override fun onViewAttachedToWindow(v: View) {
+            onViewAttached(this@button)
+            registryOwner = ViewTreeSavedStateRegistryOwner.get(this@button)!!
+            lifecycleObserver = object : LifecycleEventObserver {
+              override fun onStateChanged(
+                source: LifecycleOwner,
+                event: Event
+              ) {
+                if (event == ON_CREATE) {
+                  source.lifecycle.removeObserver(this)
+                  registryOwner.savedStateRegistry.consumeRestoredStateForKey("counter")
+                    ?.let { restoredState ->
+                      counter = restoredState.getInt("value")
+                      updateText()
+                    }
+                }
+              }
+            }
+            registryOwner.lifecycle.addObserver(lifecycleObserver)
+            registryOwner.savedStateRegistry.registerSavedStateProvider("counter") {
+              Bundle().apply { putInt("value", counter) }
+            }
+          }
+
+          override fun onViewDetachedFromWindow(v: View) {
+            registryOwner.lifecycle.removeObserver(lifecycleObserver)
+            registryOwner.savedStateRegistry.unregisterSavedStateProvider("counter")
+          }
+        })
+
+        updateText()
+        setOnClickListener {
+          counter++
+          updateText()
+        }
+
+        bindShowRendering(initialRendering, initialViewEnvironment) { _, _ ->
+          // Noop
+        }
+      }
     }
   }
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
@@ -6,6 +6,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.IdRes
+import androidx.savedstate.ViewTreeSavedStateRegistryOwner
 
 /**
  * A placeholder [View] that can replace itself with ones driven by workflow renderings,
@@ -232,8 +233,31 @@ public class WorkflowViewStub @JvmOverloads constructor(
         if (inflatedId != NO_ID) newView.id = inflatedId
         if (updatesVisibility) newView.visibility = visibility
         background?.let { newView.background = it }
+        propagateSavedStateRegistryOwner(newView)
         replaceOldViewInParent(parent, newView)
         actual = newView
       }
+  }
+
+  /**
+   * If a [ViewTreeSavedStateRegistryOwner] was set on this [WorkflowViewStub], sets that owner on
+   * [newView]. Note that this _only_ copies an owner if it was set _directly_ on this view with
+   * [ViewTreeSavedStateRegistryOwner.set]. If [ViewTreeSavedStateRegistryOwner.get] would return an
+   * owner that was set on a parent view, this method does nothing.
+   *
+   * Must be called before [newView] gets attached to the window.
+   */
+  private fun propagateSavedStateRegistryOwner(newView: View) {
+    // There's no way to ask for the owner only on this view, without looking up the tree, so
+    // we have to compare the results from searching from this view to searching from our parent
+    // (if we have a parent) to determine if we have our own owner.
+    val myStateRegistryOwner = ViewTreeSavedStateRegistryOwner.get(this)
+    val parentStateRegistryOwner =
+      (this.parent as? ViewGroup)?.let(ViewTreeSavedStateRegistryOwner::get)
+    if (myStateRegistryOwner !== parentStateRegistryOwner) {
+      // Someone has set an owner on the stub itself, so we need to also set it on the new
+      // subview.
+      ViewTreeSavedStateRegistryOwner.set(newView, myStateRegistryOwner)
+    }
   }
 }

--- a/workflow-ui/modal-android/src/androidTest/java/com/squareup/workflow1/ui/modal/test/ModalViewContainerLifecycleTest.kt
+++ b/workflow-ui/modal-android/src/androidTest/java/com/squareup/workflow1/ui/modal/test/ModalViewContainerLifecycleTest.kt
@@ -235,7 +235,7 @@ internal class ModalViewContainerLifecycleTest {
   @Test fun nested_lifecycle() {
     assertThat(scenario.state).isEqualTo(RESUMED)
     scenario.onActivity {
-      it.consumeLifecycleEvents().let { println("OMG $it") }
+      it.consumeLifecycleEvents()
       it.update(RecurseRendering(LeafRendering("wrapped")))
     }
 

--- a/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/ModalContainer.kt
+++ b/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/ModalContainer.kt
@@ -21,10 +21,12 @@ import com.squareup.workflow1.ui.WorkflowLifecycleOwner
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.WorkflowViewStub
 import com.squareup.workflow1.ui.compatible
-import kotlin.LazyThreadSafetyMode.NONE
 
 /**
  * Base class for containers that show [HasModals.modals] in [Dialog] windows.
+ *
+ * It is not currently supported to make a [ModalContainer] the immediate child of a
+ * `BackStackContainer`. See https://github.com/square/workflow-kotlin/issues/470.
  *
  * @param ModalRenderingT the type of the nested renderings to be shown in a dialog window.
  */


### PR DESCRIPTION
This PR introduces the ability for `BackStackContainer` to manage `SavedStateRegistryOwner`s on the subviews it creates for navigation frames. Every immediate child view gets a registry owner, and that owner is set on the child view via `ViewTreeSavedStateRegistryOwner`. Any views in the subtree underneath a `BackStackContainer` can then query `ViewTreeSavedStateRegistryOwner` for a `SavedStateRegistry` and use that registry to save and restore their state. The registry will be correctly saved when something else is pushed on the backstack on top of that view, and restored when the view is shown again.

This motivation for adding this support is to support `AbstractComposeView` in workflows. Compose uses the `SavedStateRegistry` to save internal state for things like scrollables.

This change builds on #381 which adds support for `ViewTreeLifecycleOwner`. It is not my first attempt at adding support for this: see #463, which superseded #284. This PR is one more step in completing #458.