### PR TITLE
Introduce ComposeViewFactory as a convenient way to define ViewFactories as composable functions.

### DIFF
--- a/workflow-ui/compose/api/compose.api
+++ b/workflow-ui/compose/api/compose.api
@@ -1,0 +1,11 @@
+public abstract class com/squareup/workflow1/ui/compose/ComposeViewFactory : com/squareup/workflow1/ui/ViewFactory {
+	public static final field $stable I
+	public fun <init> ()V
+	public abstract fun Content (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroidx/compose/runtime/Composer;I)V
+	public final fun buildView (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+}
+
+public final class com/squareup/workflow1/ui/compose/ComposeViewFactoryKt {
+	public static final fun composeViewFactory (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function4;)Lcom/squareup/workflow1/ui/ViewFactory;
+}
+

--- a/workflow-ui/compose/build.gradle.kts
+++ b/workflow-ui/compose/build.gradle.kts
@@ -38,11 +38,10 @@ dependencies {
   api(project(":workflow-ui:backstack-android"))
   api(project(":workflow-ui:core-android"))
 
-  api(Dependencies.Kotlin.Stdlib.jdk8)
+  api(Dependencies.AndroidX.Compose.foundation)
 
   androidTestImplementation(project(":workflow-runtime"))
   androidTestImplementation(Dependencies.AndroidX.activity)
-  androidTestImplementation(Dependencies.AndroidX.Compose.foundation)
   androidTestImplementation(Dependencies.AndroidX.Compose.ui)
   androidTestImplementation(Dependencies.Test.AndroidX.core)
   androidTestImplementation(Dependencies.Test.AndroidX.truthExt)

--- a/workflow-ui/compose/src/androidTest/AndroidManifest.xml
+++ b/workflow-ui/compose/src/androidTest/AndroidManifest.xml
@@ -1,1 +1,7 @@
-<manifest package="com.squareup.workflow1.ui.compose.test"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.squareup.workflow1.ui.compose.test">
+
+  <application>
+    <activity android:name="androidx.activity.ComponentActivity"/>
+  </application>
+</manifest>

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewFactoryTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewFactoryTest.kt
@@ -1,0 +1,139 @@
+package com.squareup.workflow1.ui.compose
+
+import android.content.Context
+import android.widget.FrameLayout
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewEnvironmentKey
+import com.squareup.workflow1.ui.ViewRegistry
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.WorkflowViewStub
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(WorkflowUiExperimentalApi::class)
+@RunWith(AndroidJUnit4::class)
+class ComposeViewFactoryTest {
+
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test fun showsComposeContent() {
+    val viewFactory = composeViewFactory<Unit> { _, _ ->
+      BasicText("Hello, world!")
+    }
+    val viewRegistry = ViewRegistry(viewFactory)
+    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+
+    composeRule.setContent {
+      AndroidView(::RootView) {
+        it.stub.update(Unit, viewEnvironment)
+      }
+    }
+
+    composeRule.onNodeWithText("Hello, world!").assertIsDisplayed()
+  }
+
+  @Test fun getsRenderingUpdates() {
+    val viewFactory = composeViewFactory<String> { rendering, _ ->
+      BasicText(rendering, Modifier.testTag("text"))
+    }
+    val viewRegistry = ViewRegistry(viewFactory)
+    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+    var rendering by mutableStateOf("hello")
+
+    composeRule.setContent {
+      AndroidView(::RootView) {
+        it.stub.update(rendering, viewEnvironment)
+      }
+    }
+    composeRule.onNodeWithTag("text").assertTextEquals("hello")
+
+    rendering = "world"
+
+    composeRule.onNodeWithTag("text").assertTextEquals("world")
+  }
+
+  @Test fun getsViewEnvironmentUpdates() {
+    val testEnvironmentKey = object : ViewEnvironmentKey<String>(String::class) {
+      override val default: String get() = error("No default")
+    }
+
+    val viewFactory = composeViewFactory<Unit> { _, environment ->
+      val text = environment[testEnvironmentKey]
+      BasicText(text, Modifier.testTag("text"))
+    }
+    val viewRegistry = ViewRegistry(viewFactory)
+    var viewEnvironment by mutableStateOf(
+      ViewEnvironment(
+        mapOf(
+          ViewRegistry to viewRegistry,
+          testEnvironmentKey to "hello"
+        )
+      )
+    )
+
+    composeRule.setContent {
+      AndroidView(::RootView) {
+        it.stub.update(Unit, viewEnvironment)
+      }
+    }
+    composeRule.onNodeWithTag("text").assertTextEquals("hello")
+
+    viewEnvironment = viewEnvironment + (testEnvironmentKey to "world")
+
+    composeRule.onNodeWithTag("text").assertTextEquals("world")
+  }
+
+  // TODO(#458) Add test back in once composition root is imported.
+  // @Test fun wrapsFactoryWithRoot() {
+  //   val wrapperText = mutableStateOf("one")
+  //   val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to ViewRegistry(TestFactory)))
+  //     .withCompositionRoot { content ->
+  //       Column {
+  //         BasicText(wrapperText.value)
+  //         content()
+  //       }
+  //     }
+  //
+  //   setViewEnvironment(viewEnvironment)
+  //
+  //   // Compose bug doesn't let us use assertIsDisplayed on older devices.
+  //   // See https://issuetracker.google.com/issues/157728188.
+  //   composeRule.onNodeWithText("one").assertExists()
+  //   composeRule.onNodeWithText("two").assertExists()
+  //
+  //   wrapperText.value = "ENO"
+  //
+  //   composeRule.onNodeWithText("ENO").assertExists()
+  //   composeRule.onNodeWithText("two").assertExists()
+  // }
+
+  private class RootView(context: Context) : FrameLayout(context) {
+    val stub = WorkflowViewStub(context).also(::addView)
+
+    fun setViewEnvironment(viewEnvironment: ViewEnvironment) {
+      stub.update(TestRendering("two"), viewEnvironment)
+    }
+  }
+
+  private data class TestRendering(val text: String)
+
+  private companion object {
+    val TestFactory = composeViewFactory<TestRendering> { rendering, _ ->
+      BasicText(rendering.text)
+    }
+  }
+}

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeViewFactory.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeViewFactory.kt
@@ -1,0 +1,142 @@
+// See https://youtrack.jetbrains.com/issue/KT-31734
+@file:Suppress("RemoveEmptyParenthesesFromAnnotationEntry")
+
+package com.squareup.workflow1.ui.compose
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.ComposeView
+import com.squareup.workflow1.ui.LayoutRunner
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewFactory
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.bindShowRendering
+import kotlin.reflect.KClass
+
+/**
+ * Creates a [ViewFactory] that uses a [Composable] function to display the rendering.
+ *
+ * Simple usage:
+ *
+ * ```
+ * val FooViewFactory = composeViewFactory { rendering, _ ->
+ *   Text(rendering.message)
+ * }
+ *
+ * …
+ *
+ * val viewRegistry = ViewRegistry(FooViewFactory, …)
+ * ```
+ *
+ * If you need to write a class instead of a function, for example to support dependency injection,
+ * see [ComposeViewFactory].
+ *
+ * For more details about how to write composable view factories, see [ComposeViewFactory].
+ */
+@WorkflowUiExperimentalApi
+public inline fun <reified RenderingT : Any> composeViewFactory(
+  noinline content: @Composable (
+    rendering: RenderingT,
+    environment: ViewEnvironment
+  ) -> Unit
+): ViewFactory<RenderingT> = composeViewFactory(RenderingT::class, content)
+
+@PublishedApi
+@WorkflowUiExperimentalApi
+internal fun <RenderingT : Any> composeViewFactory(
+  type: KClass<RenderingT>,
+  content: @Composable (
+    rendering: RenderingT,
+    environment: ViewEnvironment
+  ) -> Unit
+): ViewFactory<RenderingT> = object : ComposeViewFactory<RenderingT>() {
+  override val type: KClass<in RenderingT> = type
+  @Composable override fun Content(
+    rendering: RenderingT,
+    viewEnvironment: ViewEnvironment
+  ) {
+    content(rendering, viewEnvironment)
+  }
+}
+
+/**
+ * A [ViewFactory] that uses a [Composable] function to display the rendering. It is the
+ * Compose-based analogue of [LayoutRunner].
+ *
+ * Simple usage:
+ *
+ * ```
+ * class FooViewFactory : ComposeViewFactory<Foo>() {
+ *   override val type = Foo::class
+ *
+ *   @Composable override fun Content(
+ *     rendering: Foo,
+ *     viewEnvironment: ViewEnvironment
+ *   ) {
+ *     Text(rendering.message)
+ *   }
+ * }
+ *
+ * …
+ *
+ * val viewRegistry = ViewRegistry(FooViewFactory, …)
+ * ```
+ *
+ * ## Nesting child renderings
+ *
+ * Workflows can render other workflows, and renderings from one workflow can contain renderings
+ * from other workflows. These renderings may all be bound to their own [ViewFactory]s. Regular
+ * [ViewFactory]s and [LayoutRunner]s use
+ * [WorkflowViewStub][com.squareup.workflow1.ui.WorkflowViewStub] to recursively show nested
+ * renderings using the [ViewRegistry][com.squareup.workflow1.ui.ViewRegistry].
+ *
+ * View factories defined using this function may also show nested renderings. Doing so is as simple
+ * as calling [WorkflowRendering] and passing in the nested rendering. See the kdoc on that function
+ * for an example.
+ *
+ * Nested renderings will have access to any
+ * [composition locals][androidx.compose.runtime.CompositionLocal] defined in outer composable, even
+ * if there are legacy views in between them, as long as the [ViewEnvironment] is propagated
+ * continuously between the two factories.
+ *
+ * ## Initializing Compose context
+ *
+ * Often all the [composeViewFactory] factories in an app need to share some context – for example,
+ * certain composition locals need to be provided, such as `MaterialTheme`. To configure this shared
+ * context, call [withCompositionRoot] on your top-level [ViewEnvironment]. The first time a
+ * [composeViewFactory] is used to show a rendering, its [Content] function will be wrapped
+ * with the [CompositionRoot]. See the documentation on [CompositionRoot] for more information.
+ */
+@WorkflowUiExperimentalApi
+public abstract class ComposeViewFactory<RenderingT : Any> : ViewFactory<RenderingT> {
+
+  /**
+   * The composable content of this [ViewFactory]. This method will be called any time [rendering]
+   * or [viewEnvironment] change. It is the Compose-based analogue of [LayoutRunner.showRendering].
+   */
+  @Composable public abstract fun Content(
+    rendering: RenderingT,
+    viewEnvironment: ViewEnvironment
+  )
+
+  final override fun buildView(
+    initialRendering: RenderingT,
+    initialViewEnvironment: ViewEnvironment,
+    contextForNewView: Context,
+    container: ViewGroup?
+  ): View = ComposeView(contextForNewView).also { composeView ->
+    // Update the state whenever a new rendering is emitted.
+    // This lambda will be executed synchronously before bindShowRendering returns.
+    composeView.bindShowRendering(
+      initialRendering,
+      initialViewEnvironment
+    ) { rendering, environment ->
+      // Entry point to the world of Compose.
+      composeView.setContent {
+        Content(rendering, environment)
+      }
+    }
+  }
+}


### PR DESCRIPTION
First part of #458.

This code was mostly copy/pasted from the compose sub-project, with some additional polish. Some of the docs refer to things that don't exist yet, but will be coming in immediate follow-ups.

I'll bring in the samples once more pieces are merged, so I don't have to edit them to work with a more limited set of primitives.

Archeology: The first version of this was introduced in https://github.com/square/workflow/pull/703.