### PR TITLE
Remove API 29 emulators, since they seem to be hopelessly broken, and fix UI test result uploads.

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -67,7 +67,6 @@ jobs:
         api-level:
           - 21
           - 24
-          - 29
     steps:
       - uses: actions/checkout@v2
       - name: set up JDK 11.0.7
@@ -84,7 +83,8 @@ jobs:
           script: ./gradlew connectedCheck --no-daemon --stacktrace
 
       - name: Upload results
+        if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: insrumentation-test-results
+          name: instrumentation-test-results-${{ matrix.api-level }}
           path: ./**/build/reports/androidTests/connected/**


### PR DESCRIPTION
Seems like one of our UI tests is crashing the 29 emulator:

```
com.squareup.workflow1.ui.compose.ComposeViewTreeIntegrationTest > composition_is_restored_in_modal_after_config_change[test(AVD) - 10] FAILED 
Test failed to run to completion. Reason: 'Test run failed to complete. Expected 10 tests, received 7. onError: commandError=false message=INSTRUMENTATION_ABORTED: System has crashed.'. Check device logcat for details
Tests on test(AVD) - 10 failed: Test run failed to complete. Expected 10 tests, received 7. onError: commandError=false message=INSTRUMENTATION_ABORTED: System has crashed.
```

Afterwards, all the tests fail with this:
```
com.android.build.gradle.internal.testing.ConnectedDevice > runTests[test(AVD) - 10] FAILED 
	com.android.builder.testing.api.DeviceException: com.android.ddmlib.InstallException: Unknown failure: cmd: Can't find service: package
		at com.android.build.gradle.internal.testing.ConnectedDevice.installPackage(ConnectedDevice.java:133)
[no message defined]
java.util.concurrent.ExecutionException: java.lang.RuntimeException: com.android.builder.testing.api.DeviceException: com.android.ddmlib.InstallException: Unknown failure: cmd: Can't find service: package
	at java.base/java.util.concurrent.ForkJoinTask.get(ForkJoinTask.java:1006)
	at com.android.ide.common.workers.ExecutorServiceAdapter.await(ExecutorServiceAdapter.kt:53)
	at com.android.build.gradle.internal.testing.BaseTestRunner.runTests(BaseTestRunner.java:199)
	at com.android.build.gradle.internal.tasks.DeviceProviderInstrumentTestTask.lambda$doTaskAction$2(DeviceProviderInstrumentTestTask.java:340)
	at com.android.builder.testing.api.DeviceProvider.use(DeviceProvider.java:53)
	at com.android.build.gradle.internal.tasks.DeviceProviderInstrumentTestTask.doTaskAction(DeviceProviderInstrumentTestTask.java:329)

```