### PR TITLE
Fix a leak in RealWorkflowLifecycleOwner.

### DIFF
--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/RealWorkflowLifecycleOwnerTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/RealWorkflowLifecycleOwnerTest.kt
@@ -76,7 +76,11 @@ class RealWorkflowLifecycleOwnerTest {
     owner.destroyOnDetach()
     assertThat(owner.lifecycle.currentState).isEqualTo(DESTROYED)
 
-    makeViewAttached()
+    val error = assertFailsWith<IllegalStateException> {
+      makeViewAttached()
+    }
+    assertThat(error).hasMessageThat()
+      .isEqualTo("Expected to not be attached after being destroyed.")
     assertThat(owner.lifecycle.currentState).isEqualTo(DESTROYED)
   }
 


### PR DESCRIPTION
We were capturing views in lambdas, and not nulling them out when the lifecycle was destroyed.

cc @rjrjr