### PR TITLE
Introduce WorkflowRendering to show child renderings inside a composedViewFactory.

### DIFF
--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsTest.kt
@@ -1,0 +1,69 @@
+package com.squareup.sample.compose.nestedrenderings
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionCollection
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val ADD_BUTTON_TEXT = "Add Child"
+
+@RunWith(AndroidJUnit4::class)
+class NestedRenderingsTest {
+
+  @OptIn(WorkflowUiExperimentalApi::class)
+  @get:Rule val composeRule = createAndroidComposeRule<NestedRenderingsActivity>()
+
+  @Test fun childrenAreAddedAndRemoved() {
+    composeRule.onNodeWithText(ADD_BUTTON_TEXT)
+      .assertIsDisplayed()
+      .performClick()
+
+    composeRule.onAllNodesWithText(ADD_BUTTON_TEXT)
+      .assertCountEquals(2)
+      .forEach { it.performClick() }
+
+    composeRule.onAllNodesWithText(ADD_BUTTON_TEXT)
+      .assertCountEquals(4)
+
+    resetAll()
+    composeRule.onAllNodesWithText(ADD_BUTTON_TEXT).assertCountEquals(1)
+  }
+
+  /**
+   * We can't rely on the order of nodes returned by [onAllNodesWithText], and the contents of the
+   * collection will change as we remove nodes, so we have to double-loop over all reset buttons and
+   * click them all until there is only one left.
+   */
+  private fun resetAll() {
+    var foundNodes = Int.MAX_VALUE
+    while (foundNodes > 1) {
+      foundNodes = 0
+      composeRule.onAllNodesWithText("Reset").forEach {
+        try {
+          it.assertExists()
+        } catch (e: AssertionError) {
+          // No more reset buttons, we're done.
+          return@forEach
+        }
+        foundNodes++
+        it.performClick()
+      }
+    }
+  }
+
+  private fun SemanticsNodeInteractionCollection.forEach(
+    block: (SemanticsNodeInteraction) -> Unit
+  ) {
+    val count = fetchSemanticsNodes().size
+    for (i in 0 until count) block(get(i))
+  }
+}

--- a/samples/compose-samples/src/main/AndroidManifest.xml
+++ b/samples/compose-samples/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
     </activity>
 
     <activity android:name=".hellocomposebinding.HelloBindingActivity"/>
+    <activity android:name=".nestedrenderings.NestedRenderingsActivity"/>
 
   </application>
 </manifest>

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/launcher/Samples.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/launcher/Samples.kt
@@ -6,6 +6,8 @@ import androidx.activity.ComponentActivity
 import androidx.compose.runtime.Composable
 import com.squareup.sample.compose.hellocomposebinding.DrawHelloRenderingPreview
 import com.squareup.sample.compose.hellocomposebinding.HelloBindingActivity
+import com.squareup.sample.compose.nestedrenderings.NestedRenderingsActivity
+import com.squareup.sample.compose.nestedrenderings.RecursiveViewFactoryPreview
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import kotlin.reflect.KClass
 
@@ -15,6 +17,10 @@ val samples = listOf(
     "Hello Compose Binding", HelloBindingActivity::class,
     "Creates a ViewFactory using composeViewFactory."
   ) { DrawHelloRenderingPreview() },
+  Sample(
+    "Nested Renderings", NestedRenderingsActivity::class,
+    "Demonstrates recursive view factories using both Compose and legacy view factories."
+  ) { RecursiveViewFactoryPreview() },
 )
 
 data class Sample(

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/LegacyRunner.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/LegacyRunner.kt
@@ -1,0 +1,39 @@
+package com.squareup.sample.compose.nestedrenderings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.squareup.sample.compose.databinding.LegacyViewBinding
+import com.squareup.sample.compose.nestedrenderings.RecursiveWorkflow.LegacyRendering
+import com.squareup.workflow1.ui.LayoutRunner
+import com.squareup.workflow1.ui.LayoutRunner.Companion.bind
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewFactory
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+
+/**
+ * A [LayoutRunner] that renders [LegacyRendering]s using the legacy view framework.
+ */
+@OptIn(WorkflowUiExperimentalApi::class)
+class LegacyRunner(private val binding: LegacyViewBinding) : LayoutRunner<LegacyRendering> {
+
+  override fun showRendering(
+    rendering: LegacyRendering,
+    viewEnvironment: ViewEnvironment
+  ) {
+    binding.stub.update(rendering.rendering, viewEnvironment)
+  }
+
+  companion object : ViewFactory<LegacyRendering> by bind(
+    LegacyViewBinding::inflate, ::LegacyRunner
+  )
+}
+
+@OptIn(WorkflowUiExperimentalApi::class)
+@Preview(widthDp = 200, heightDp = 150, showBackground = true)
+@Composable private fun LegacyRunnerPreview() {
+  // TODO(#458) Uncomment once preview support is imported.
+  // LegacyRunner.preview(
+  //   rendering = LegacyRendering("child"),
+  //   placeholderModifier = Modifier.fillMaxSize()
+  // )
+}

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsActivity.kt
@@ -1,0 +1,59 @@
+package com.squareup.sample.compose.nestedrenderings
+
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewRegistry
+import com.squareup.workflow1.ui.WorkflowLayout
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.compose.withCompositionRoot
+import com.squareup.workflow1.ui.renderWorkflowIn
+import kotlinx.coroutines.flow.StateFlow
+
+@OptIn(WorkflowUiExperimentalApi::class)
+private val viewRegistry = ViewRegistry(
+  RecursiveViewFactory,
+  LegacyRunner
+)
+
+@OptIn(WorkflowUiExperimentalApi::class)
+private val viewEnvironment =
+  ViewEnvironment(mapOf(ViewRegistry to viewRegistry)).withCompositionRoot { content ->
+    CompositionLocalProvider(LocalBackgroundColor provides Color.Green) {
+      content()
+    }
+  }
+
+@WorkflowUiExperimentalApi
+class NestedRenderingsActivity : AppCompatActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    val model: NestedRenderingsModel by viewModels()
+    setContentView(
+      WorkflowLayout(this).apply {
+        start(
+          renderings = model.renderings,
+          environment = viewEnvironment
+        )
+      }
+    )
+  }
+
+  class NestedRenderingsModel(savedState: SavedStateHandle) : ViewModel() {
+    @OptIn(WorkflowUiExperimentalApi::class)
+    val renderings: StateFlow<Any> by lazy {
+      renderWorkflowIn(
+        workflow = RecursiveWorkflow,
+        scope = viewModelScope,
+        savedStateHandle = savedState
+      )
+    }
+  }
+}

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/RecursiveViewFactory.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/RecursiveViewFactory.kt
@@ -1,0 +1,128 @@
+@file:Suppress("RemoveEmptyParenthesesFromAnnotationEntry")
+
+package com.squareup.sample.compose.nestedrenderings
+
+import androidx.compose.foundation.layout.Arrangement.SpaceEvenly
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.Card
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.squareup.sample.compose.R
+import com.squareup.sample.compose.nestedrenderings.RecursiveWorkflow.Rendering
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.compose.WorkflowRendering
+import com.squareup.workflow1.ui.compose.composeViewFactory
+
+/**
+ * Composition local of [Color] to use as the background color for a [RecursiveViewFactory].
+ */
+val LocalBackgroundColor = compositionLocalOf<Color> { error("No background color specified") }
+
+/**
+ * A `ViewFactory` that renders [RecursiveWorkflow.Rendering]s.
+ */
+@OptIn(WorkflowUiExperimentalApi::class)
+val RecursiveViewFactory = composeViewFactory<Rendering> { rendering, viewEnvironment ->
+  // Every child should be drawn with a slightly-darker background color.
+  val color = LocalBackgroundColor.current
+  val childColor = remember(color) {
+    color.copy(alpha = .9f)
+      .compositeOver(Color.Black)
+  }
+
+  Card(backgroundColor = color) {
+    Column(
+      Modifier
+        .padding(dimensionResource(R.dimen.recursive_padding))
+        .fillMaxSize(),
+      horizontalAlignment = CenterHorizontally
+    ) {
+      CompositionLocalProvider(LocalBackgroundColor provides childColor) {
+        Children(
+          rendering.children, viewEnvironment,
+          // Pass a weight so that the column fills all the space not occupied by the buttons.
+          modifier = Modifier.weight(1f, fill = true)
+        )
+      }
+      Buttons(
+        onAdd = rendering.onAddChildClicked,
+        onReset = rendering.onResetClicked
+      )
+    }
+  }
+}
+
+@OptIn(WorkflowUiExperimentalApi::class)
+@Preview
+@Composable fun RecursiveViewFactoryPreview() {
+  CompositionLocalProvider(LocalBackgroundColor provides Color.Green) {
+    // TODO(#458) Uncomment once preview support is imported.
+    // RecursiveViewFactory.preview(
+    //   Rendering(
+    //     children = listOf(
+    //       "foo",
+    //       Rendering(
+    //         children = listOf("bar"),
+    //         onAddChildClicked = {}, onResetClicked = {}
+    //       )
+    //     ), onAddChildClicked = {}, onResetClicked = {}
+    //   ),
+    //   placeholderModifier = Modifier.fillMaxSize()
+    // )
+  }
+}
+
+@OptIn(WorkflowUiExperimentalApi::class)
+@Composable private fun Children(
+  children: List<Any>,
+  viewEnvironment: ViewEnvironment,
+  modifier: Modifier
+) {
+  Column(
+    modifier = modifier,
+    verticalArrangement = SpaceEvenly,
+    horizontalAlignment = CenterHorizontally
+  ) {
+    children.forEach { childRendering ->
+      WorkflowRendering(
+        childRendering,
+        // Pass a weight so all children are partitioned evenly within the total column space.
+        // Without the weight, each child is the full size of the parent.
+        viewEnvironment,
+        modifier = Modifier
+          .weight(1f, fill = true)
+          .fillMaxWidth()
+          .padding(dimensionResource(R.dimen.recursive_padding))
+      )
+    }
+  }
+}
+
+@Composable private fun Buttons(
+  onAdd: () -> Unit,
+  onReset: () -> Unit
+) {
+  Row {
+    Button(onClick = onAdd) {
+      Text("Add Child")
+    }
+    Button(onClick = onReset) {
+      Text("Reset")
+    }
+  }
+}

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/RecursiveWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/RecursiveWorkflow.kt
@@ -1,0 +1,70 @@
+package com.squareup.sample.compose.nestedrenderings
+
+import com.squareup.sample.compose.nestedrenderings.RecursiveWorkflow.LegacyRendering
+import com.squareup.sample.compose.nestedrenderings.RecursiveWorkflow.Rendering
+import com.squareup.sample.compose.nestedrenderings.RecursiveWorkflow.State
+import com.squareup.workflow1.Snapshot
+import com.squareup.workflow1.StatefulWorkflow
+import com.squareup.workflow1.action
+import com.squareup.workflow1.renderChild
+
+/**
+ * A simple workflow that produces [Rendering]s of zero or more children.
+ * The rendering provides event handlers for adding children and resetting child count to zero.
+ *
+ * Every other (odd) rendering in the [Rendering.children] will be wrapped with a [LegacyRendering]
+ * to force it to go through the legacy view layer. This way this sample both demonstrates pass-
+ * through Composable renderings as well as adapting in both directions.
+ */
+object RecursiveWorkflow : StatefulWorkflow<Unit, State, Nothing, Any>() {
+
+  data class State(val children: Int = 0)
+
+  /**
+   * A rendering from a [RecursiveWorkflow].
+   *
+   * @param children A list of renderings to display as children of this rendering.
+   * @param onAddChildClicked Adds a child to [children].
+   * @param onResetClicked Resets [children] to an empty list.
+   */
+  data class Rendering(
+    val children: List<Any>,
+    val onAddChildClicked: () -> Unit,
+    val onResetClicked: () -> Unit
+  )
+
+  /**
+   * Wrapper around a [Rendering] that will be implemented using a legacy view.
+   */
+  data class LegacyRendering(val rendering: Any)
+
+  override fun initialState(
+    props: Unit,
+    snapshot: Snapshot?
+  ): State = State()
+
+  override fun render(
+    renderProps: Unit,
+    renderState: State,
+    context: RenderContext
+  ): Rendering {
+    return Rendering(
+      children = List(renderState.children) { i ->
+        val child = context.renderChild(RecursiveWorkflow, key = i.toString())
+        if (i % 2 == 0) child else LegacyRendering(child)
+      },
+      onAddChildClicked = { context.actionSink.send(addChild()) },
+      onResetClicked = { context.actionSink.send(reset()) }
+    )
+  }
+
+  override fun snapshotState(state: State): Snapshot? = null
+
+  private fun addChild() = action {
+    state = state.copy(children = state.children + 1)
+  }
+
+  private fun reset() = action {
+    state = State()
+  }
+}

--- a/samples/compose-samples/src/main/res/values/dimens.xml
+++ b/samples/compose-samples/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <dimen name="recursive_padding">8dp</dimen>
+</resources>

--- a/workflow-ui/compose/api/compose.api
+++ b/workflow-ui/compose/api/compose.api
@@ -23,3 +23,7 @@ public final class com/squareup/workflow1/ui/compose/CompositionRootKt {
 	public static final fun withCompositionRoot (Lcom/squareup/workflow1/ui/ViewRegistry;Lkotlin/jvm/functions/Function3;)Lcom/squareup/workflow1/ui/ViewRegistry;
 }
 
+public final class com/squareup/workflow1/ui/compose/WorkflowRenderingKt {
+	public static final fun WorkflowRendering (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/workflow-ui/compose/build.gradle.kts
+++ b/workflow-ui/compose/build.gradle.kts
@@ -38,8 +38,9 @@ dependencies {
   api(project(":workflow-ui:backstack-android"))
   api(project(":workflow-ui:core-android"))
   api(project(":workflow-ui:modal-android"))
-
   api(Dependencies.AndroidX.Compose.foundation)
+
+  implementation(Dependencies.AndroidX.savedstate)
 
   androidTestImplementation(project(":workflow-runtime"))
   androidTestImplementation(Dependencies.AndroidX.activity)

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/WorkflowRenderingTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/WorkflowRenderingTest.kt
@@ -1,0 +1,541 @@
+package com.squareup.workflow1.ui.compose
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.Event
+import androidx.lifecycle.Lifecycle.Event.ON_CREATE
+import androidx.lifecycle.Lifecycle.Event.ON_DESTROY
+import androidx.lifecycle.Lifecycle.Event.ON_PAUSE
+import androidx.lifecycle.Lifecycle.Event.ON_RESUME
+import androidx.lifecycle.Lifecycle.Event.ON_START
+import androidx.lifecycle.Lifecycle.Event.ON_STOP
+import androidx.lifecycle.Lifecycle.State
+import androidx.lifecycle.Lifecycle.State.CREATED
+import androidx.lifecycle.Lifecycle.State.DESTROYED
+import androidx.lifecycle.Lifecycle.State.INITIALIZED
+import androidx.lifecycle.Lifecycle.State.RESUMED
+import androidx.lifecycle.Lifecycle.State.STARTED
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.squareup.workflow1.ui.AndroidViewRendering
+import com.squareup.workflow1.ui.BuilderViewFactory
+import com.squareup.workflow1.ui.Compatible
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewFactory
+import com.squareup.workflow1.ui.ViewRegistry
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.bindShowRendering
+import org.hamcrest.Description
+import org.hamcrest.TypeSafeMatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.reflect.KClass
+
+@OptIn(WorkflowUiExperimentalApi::class)
+@RunWith(AndroidJUnit4::class)
+class WorkflowRenderingTest {
+
+  @Rule @JvmField val composeRule = createComposeRule()
+
+  @Test fun doesNotRecompose_whenFactoryChanged() {
+    val registry1 = ViewRegistry(composeViewFactory<String> { rendering, _ ->
+      BasicText(rendering)
+    })
+    val registry2 = ViewRegistry(composeViewFactory<String> { rendering, _ ->
+      BasicText(rendering.reversed())
+    })
+    val registry = mutableStateOf(registry1)
+
+    composeRule.setContent {
+      WorkflowRendering("hello", ViewEnvironment(mapOf(ViewRegistry to registry.value)))
+    }
+
+    composeRule.onNodeWithText("hello").assertIsDisplayed()
+    registry.value = registry2
+    composeRule.onNodeWithText("hello").assertIsDisplayed()
+    composeRule.onNodeWithText("olleh").assertDoesNotExist()
+  }
+
+  /**
+   * Ensures we match the behavior of WorkflowViewStub and other containers, which only check for
+   * a new factory when a new rendering is incompatible with the current one.
+   */
+  @Test fun doesNotRecompose_whenAndroidViewRendering_factoryChanged() {
+    data class ShiftyRendering(val whichFactory: Boolean) : AndroidViewRendering<ShiftyRendering> {
+      override val viewFactory: ViewFactory<ShiftyRendering> = when (whichFactory) {
+        true -> composeViewFactory { _, _ -> BasicText("one") }
+        false -> composeViewFactory { _, _ -> BasicText("two") }
+      }
+    }
+
+    var rendering by mutableStateOf(ShiftyRendering(true))
+
+    composeRule.setContent {
+      WorkflowRendering(rendering, ViewEnvironment())
+    }
+
+    composeRule.onNodeWithText("one").assertIsDisplayed()
+    rendering = ShiftyRendering(false)
+    composeRule.onNodeWithText("one").assertIsDisplayed()
+  }
+
+  @Test fun wrapsFactoryWithRoot_whenAlreadyInComposition() {
+    data class TestRendering(val text: String)
+
+    val testFactory = composeViewFactory<TestRendering> { rendering, _ ->
+      BasicText(rendering.text)
+    }
+    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to ViewRegistry(testFactory)))
+      .withCompositionRoot { content ->
+        Column {
+          BasicText("one")
+          content()
+        }
+      }
+
+    composeRule.setContent {
+      WorkflowRendering(TestRendering("two"), viewEnvironment)
+    }
+
+    composeRule.onNodeWithText("one").assertIsDisplayed()
+    composeRule.onNodeWithText("two").assertIsDisplayed()
+  }
+
+  @Test fun legacyAndroidViewRendersUpdates() {
+    data class LegacyViewRendering(val text: String) : AndroidViewRendering<LegacyViewRendering> {
+      override val viewFactory: ViewFactory<LegacyViewRendering> =
+        object : ViewFactory<LegacyViewRendering> {
+          override val type = LegacyViewRendering::class
+
+          override fun buildView(
+            initialRendering: LegacyViewRendering,
+            initialViewEnvironment: ViewEnvironment,
+            contextForNewView: Context,
+            container: ViewGroup?
+          ): View = TextView(contextForNewView).apply {
+            bindShowRendering(initialRendering, initialViewEnvironment) { rendering, _ ->
+              text = rendering.text
+            }
+          }
+        }
+    }
+
+    val wrapperText = mutableStateOf("two")
+
+    composeRule.setContent {
+      WorkflowRendering(LegacyViewRendering(wrapperText.value), ViewEnvironment())
+    }
+
+    onView(withText("two")).check(matches(isDisplayed()))
+    wrapperText.value = "OWT"
+    onView(withText("OWT")).check(matches(isDisplayed()))
+  }
+
+  @Test fun destroysChildLifecycle_fromCompose_whenIncompatibleRendering() {
+    val lifecycleEvents = mutableListOf<Event>()
+
+    class LifecycleRecorder : ComposableRendering<LifecycleRecorder> {
+      @Composable override fun Content(viewEnvironment: ViewEnvironment) {
+        val lifecycle = LocalLifecycleOwner.current.lifecycle
+        DisposableEffect(lifecycle) {
+          lifecycle.addObserver(LifecycleEventObserver { _, event ->
+            lifecycleEvents += event
+          })
+          onDispose {
+            // Yes, we're leaking the observer. That's intentional: we need to make sure we see any
+            // lifecycle events that happen even after the composable is destroyed.
+          }
+        }
+      }
+    }
+
+    class EmptyRendering : ComposableRendering<EmptyRendering> {
+      @Composable override fun Content(viewEnvironment: ViewEnvironment) {}
+    }
+
+    var rendering: Any by mutableStateOf(LifecycleRecorder())
+    composeRule.setContent {
+      WorkflowRendering(rendering, ViewEnvironment())
+    }
+
+    composeRule.runOnIdle {
+      assertThat(lifecycleEvents).containsExactly(ON_CREATE, ON_START, ON_RESUME).inOrder()
+      lifecycleEvents.clear()
+    }
+
+    rendering = EmptyRendering()
+
+    composeRule.runOnIdle {
+      assertThat(lifecycleEvents).containsExactly(ON_PAUSE, ON_STOP, ON_DESTROY).inOrder()
+    }
+  }
+
+  @Test fun destroysChildLifecycle_fromLegacyView_whenIncompatibleRendering() {
+    val lifecycleEvents = mutableListOf<Event>()
+
+    class LifecycleRecorder : AndroidViewRendering<LifecycleRecorder> {
+      override val viewFactory: ViewFactory<LifecycleRecorder> = BuilderViewFactory(
+        LifecycleRecorder::class
+      ) { initialRendering, initialViewEnvironment, contextForNewView, _ ->
+        object : View(contextForNewView) {
+          init {
+            bindShowRendering(initialRendering, initialViewEnvironment) { _, _ -> }
+          }
+
+          override fun onAttachedToWindow() {
+            super.onAttachedToWindow()
+            val lifecycle = ViewTreeLifecycleOwner.get(this)!!.lifecycle
+            lifecycle.addObserver(LifecycleEventObserver { _, event ->
+              lifecycleEvents += event
+            })
+            // Yes, we're leaking the observer. That's intentional: we need to make sure we see
+            // any lifecycle events that happen even after the composable is destroyed.
+          }
+        }
+      }
+    }
+
+    class EmptyRendering : ComposableRendering<EmptyRendering> {
+      @Composable override fun Content(viewEnvironment: ViewEnvironment) {}
+    }
+
+    var rendering: Any by mutableStateOf(LifecycleRecorder())
+    composeRule.setContent {
+      WorkflowRendering(rendering, ViewEnvironment())
+    }
+
+    composeRule.runOnIdle {
+      assertThat(lifecycleEvents).containsExactly(ON_CREATE, ON_START, ON_RESUME).inOrder()
+      lifecycleEvents.clear()
+    }
+
+    rendering = EmptyRendering()
+
+    composeRule.runOnIdle {
+      assertThat(lifecycleEvents).containsExactly(ON_PAUSE, ON_STOP, ON_DESTROY).inOrder()
+    }
+  }
+
+  @Test fun followsParentLifecycle() {
+    val states = mutableListOf<State>()
+    val parentOwner = object : LifecycleOwner {
+      val registry = LifecycleRegistry(this)
+      override fun getLifecycle(): Lifecycle = registry
+    }
+
+    composeRule.setContent {
+      CompositionLocalProvider(LocalLifecycleOwner provides parentOwner) {
+        WorkflowRendering(LifecycleRecorder(states), ViewEnvironment())
+      }
+    }
+
+    composeRule.runOnIdle {
+      assertThat(states).containsExactly(INITIALIZED).inOrder()
+      states.clear()
+      parentOwner.registry.currentState = STARTED
+    }
+
+    composeRule.runOnIdle {
+      assertThat(states).containsExactly(CREATED, STARTED).inOrder()
+      states.clear()
+      parentOwner.registry.currentState = CREATED
+    }
+
+    composeRule.runOnIdle {
+      assertThat(states).containsExactly(CREATED).inOrder()
+      states.clear()
+      parentOwner.registry.currentState = RESUMED
+    }
+
+    composeRule.runOnIdle {
+      assertThat(states).containsExactly(STARTED, RESUMED).inOrder()
+      states.clear()
+      parentOwner.registry.currentState = DESTROYED
+    }
+
+    composeRule.runOnIdle {
+      assertThat(states).containsExactly(STARTED, CREATED, DESTROYED).inOrder()
+    }
+  }
+
+  @Test fun handlesParentInitiallyDestroyed() {
+    val states = mutableListOf<State>()
+    val parentOwner = object : LifecycleOwner {
+      val registry = LifecycleRegistry(this)
+      override fun getLifecycle(): Lifecycle = registry
+    }
+    composeRule.runOnIdle {
+      parentOwner.registry.currentState = DESTROYED
+    }
+
+    composeRule.setContent {
+      CompositionLocalProvider(LocalLifecycleOwner provides parentOwner) {
+        WorkflowRendering(LifecycleRecorder(states), ViewEnvironment())
+      }
+    }
+
+    composeRule.runOnIdle {
+      assertThat(states).containsExactly(INITIALIZED).inOrder()
+    }
+  }
+
+  @Test fun appliesModifierToComposableContent() {
+    class Rendering : ComposableRendering<Rendering> {
+      @Composable override fun Content(viewEnvironment: ViewEnvironment) {
+        Box(
+          Modifier
+            .testTag("box")
+            .fillMaxSize()
+        )
+      }
+    }
+
+    composeRule.setContent {
+      WorkflowRendering(
+        Rendering(), ViewEnvironment(),
+        Modifier.size(width = 42.dp, height = 43.dp)
+      )
+    }
+
+    composeRule.onNodeWithTag("box")
+      .assertWidthIsEqualTo(42.dp)
+      .assertHeightIsEqualTo(43.dp)
+  }
+
+  @Test fun propagatesMinConstraints() {
+    class Rendering : ComposableRendering<Rendering> {
+      @Composable override fun Content(viewEnvironment: ViewEnvironment) {
+        Box(Modifier.testTag("box"))
+      }
+    }
+
+    composeRule.setContent {
+      WorkflowRendering(
+        Rendering(), ViewEnvironment(),
+        Modifier.sizeIn(minWidth = 42.dp, minHeight = 43.dp)
+      )
+    }
+
+    composeRule.onNodeWithTag("box")
+      .assertWidthIsEqualTo(42.dp)
+      .assertHeightIsEqualTo(43.dp)
+  }
+
+  @Test fun appliesModifierToViewContent() {
+    val viewId = View.generateViewId()
+
+    class LegacyRendering(private val viewId: Int) : AndroidViewRendering<LegacyRendering> {
+      override val viewFactory: ViewFactory<LegacyRendering> = BuilderViewFactory(
+        LegacyRendering::class
+      ) { initialRendering, initialViewEnvironment, contextForNewView, _ ->
+        object : View(contextForNewView) {
+          init {
+            bindShowRendering(initialRendering, initialViewEnvironment) { r, _ ->
+              id = r.viewId
+            }
+          }
+        }
+      }
+    }
+
+    composeRule.setContent {
+      with(LocalDensity.current) {
+        WorkflowRendering(
+          LegacyRendering(viewId), ViewEnvironment(),
+          Modifier.size(42.toDp(), 43.toDp())
+        )
+      }
+    }
+
+    onView(withId(viewId)).check(matches(hasSize(42, 43)))
+  }
+
+  @Test fun skipsPreviousContentWhenIncompatible() {
+    var disposeCount = 0
+    class Rendering(
+      override val compatibilityKey: String
+    ) : ComposableRendering<Rendering>, Compatible {
+      @Composable override fun Content(viewEnvironment: ViewEnvironment) {
+        var counter by rememberSaveable { mutableStateOf(0) }
+        Column {
+          BasicText(
+            "$compatibilityKey: $counter",
+            Modifier
+              .testTag("tag")
+              .clickable { counter++ }
+          )
+          DisposableEffect(Unit) {
+            onDispose {
+              disposeCount++
+            }
+          }
+        }
+      }
+    }
+
+    var key by mutableStateOf("one")
+    composeRule.setContent {
+      WorkflowRendering(Rendering(key), ViewEnvironment())
+    }
+
+    composeRule.onNodeWithTag("tag")
+      .assertTextEquals("one: 0")
+      .performClick()
+      .assertTextEquals("one: 1")
+
+    key = "two"
+
+    composeRule.onNodeWithTag("tag")
+      .assertTextEquals("two: 0")
+    composeRule.runOnIdle {
+      assertThat(disposeCount).isEqualTo(1)
+    }
+
+    key = "one"
+
+    // State should not be restored.
+    composeRule.onNodeWithTag("tag")
+      .assertTextEquals("one: 0")
+    composeRule.runOnIdle {
+      assertThat(disposeCount).isEqualTo(2)
+    }
+  }
+
+  @Test fun doesNotSkipPreviousContentWhenCompatible() {
+    var disposeCount = 0
+
+    class Rendering(val text: String) : ComposableRendering<Rendering> {
+      @Composable override fun Content(viewEnvironment: ViewEnvironment) {
+        var counter by rememberSaveable { mutableStateOf(0) }
+        Column {
+          BasicText(
+            "$text: $counter",
+            Modifier
+              .testTag("tag")
+              .clickable { counter++ }
+          )
+          DisposableEffect(Unit) {
+            onDispose {
+              disposeCount++
+            }
+          }
+        }
+      }
+    }
+
+    var text by mutableStateOf("one")
+    composeRule.setContent {
+      WorkflowRendering(Rendering(text), ViewEnvironment())
+    }
+
+    composeRule.onNodeWithTag("tag")
+      .assertTextEquals("one: 0")
+      .performClick()
+      .assertTextEquals("one: 1")
+
+    text = "two"
+
+    // Counter state should be preserved.
+    composeRule.onNodeWithTag("tag")
+      .assertTextEquals("two: 1")
+    composeRule.runOnIdle {
+      assertThat(disposeCount).isEqualTo(0)
+    }
+  }
+
+  @Suppress("SameParameterValue")
+  private fun hasSize(
+    width: Int,
+    height: Int
+  ) = object : TypeSafeMatcher<View>() {
+    override fun describeTo(description: Description) {
+      description.appendText("has size ${width}x${height}px")
+    }
+
+    override fun matchesSafely(item: View): Boolean {
+      return item.width == width && item.height == height
+    }
+  }
+
+  private class LifecycleRecorder(
+    // For some reason, if we just capture the states val, it is null in the composable.
+    private val states: MutableList<State>
+  ) : ComposableRendering<LifecycleRecorder> {
+    @Composable override fun Content(viewEnvironment: ViewEnvironment) {
+      val lifecycle = LocalLifecycleOwner.current.lifecycle
+      DisposableEffect(lifecycle) {
+        this@LifecycleRecorder.states += lifecycle.currentState
+        lifecycle.addObserver(LifecycleEventObserver { _, _ ->
+          this@LifecycleRecorder.states += lifecycle.currentState
+        })
+        onDispose {
+          // Yes, we're leaking the observer. That's intentional: we need to make sure we see any
+          // lifecycle events that happen even after the composable is destroyed.
+        }
+      }
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private interface ComposableRendering<RenderingT : ComposableRendering<RenderingT>> :
+    AndroidViewRendering<RenderingT> {
+
+    /**
+     * It is significant that this returns a new instance on every call, since we can't rely on real
+     * implementations in the wild to reuse the same factory instance across rendering instances.
+     */
+    override val viewFactory: ViewFactory<RenderingT>
+      get() = object : ComposeViewFactory<ComposableRendering<*>>() {
+        override val type: KClass<in ComposableRendering<*>> = ComposableRendering::class
+
+        @Composable override fun Content(
+          rendering: ComposableRendering<*>,
+          viewEnvironment: ViewEnvironment
+        ) {
+          rendering.Content(viewEnvironment)
+        }
+      }
+
+    @Composable fun Content(viewEnvironment: ViewEnvironment)
+  }
+}

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/WorkflowRendering.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/WorkflowRendering.kt
@@ -1,0 +1,209 @@
+package com.squareup.workflow1.ui.compose
+
+import android.view.View
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.State.DESTROYED
+import androidx.lifecycle.Lifecycle.State.INITIALIZED
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewTreeLifecycleOwner
+import com.squareup.workflow1.ui.Compatible
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewFactory
+import com.squareup.workflow1.ui.ViewRegistry
+import com.squareup.workflow1.ui.WorkflowLifecycleOwner
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.WorkflowViewStub
+import com.squareup.workflow1.ui.getFactoryForRendering
+import com.squareup.workflow1.ui.getShowRendering
+import com.squareup.workflow1.ui.showRendering
+import kotlin.reflect.KClass
+
+/**
+ * Renders [rendering] into the composition using this [ViewEnvironment]'s [ViewRegistry] to
+ * generate the view.
+ *
+ * This function fulfills a similar role as [WorkflowViewStub], but is much more convenient to use
+ * from Composable functions. Note, however, that just like [WorkflowViewStub], it doesn't matter
+ * whether the factory registered for the rendering is using classic Android views or Compose.
+ *
+ * ## Example
+ *
+ * ```
+ * data class FramedRendering<R : Any>(
+ *   val borderColor: Color,
+ *   val child: R
+ * ) : ComposeRendering {
+ *
+ *   @Composable override fun Content(viewEnvironment: ViewEnvironment) {
+ *     Surface(border = Border(borderColor, 8.dp)) {
+ *       WorkflowRendering(child, viewEnvironment)
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @param rendering The workflow rendering to display. May be of any type for which a [ViewFactory]
+ * has been registered in [viewEnvironment]'s [ViewRegistry].
+ * @param modifier A [Modifier] that will be applied to composable used to show [rendering].
+ *
+ * @throws IllegalArgumentException if no factory can be found for [rendering]'s type.
+ */
+@WorkflowUiExperimentalApi
+@Composable public fun WorkflowRendering(
+  rendering: Any,
+  viewEnvironment: ViewEnvironment,
+  modifier: Modifier = Modifier
+) {
+  // This will fetch a new view factory any time the new rendering is incompatible with the previous
+  // one, as determined by Compatible. This corresponds to WorkflowViewStub's canShowRendering
+  // check.
+  val renderingCompatibilityKey = Compatible.keyFor(rendering)
+
+  // By surrounding the below code with this key function, any time the new rendering is not
+  // compatible with the previous rendering we'll tear down the previous subtree of the composition,
+  // including its lifecycle, which destroys the lifecycle and any remembered state. If the view
+  // factory created an Android view, this will also remove the old one from the view hierarchy
+  // before replacing it with the new one.
+  key(renderingCompatibilityKey) {
+    val viewFactory = remember {
+      // The view registry may return a new factory instance for a rendering every time we ask it, for
+      // example if an AndroidViewRendering doesn't share its factory between rendering instances. We
+      // intentionally don't ask it for a new instance every time to match the behavior of
+      // WorkflowViewStub and other containers, which only ask for a new factory when the rendering is
+      // incompatible.
+      viewEnvironment[ViewRegistry]
+        // Can't use ViewRegistry.buildView here since we need the factory to convert it to a
+        // compose one.
+        .getFactoryForRendering(rendering)
+        .asComposeViewFactory()
+    }
+
+    // Just like WorkflowViewStub, we need to manage a Lifecycle for the child view. We just provide
+    // a local here – ViewFactoryAndroidView will handle setting the appropriate view tree owners
+    // on the child view when necessary. Because this function is surrounded by a key() call, when
+    // the rendering is incompatible, the lifecycle for the old view will be destroyed.
+    val lifecycleOwner = rememberChildLifecycleOwner()
+
+    CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+      // We need to propagate min constraints because one of the likely uses for the modifier passed
+      // into this function is to directly control the layout of the child view – which means
+      // minimum constraints are likely to be significant.
+      Box(modifier, propagateMinConstraints = true) {
+        viewFactory.Content(rendering, viewEnvironment)
+      }
+    }
+  }
+}
+
+/**
+ * Returns a [LifecycleOwner] that is a mirror of the current [LocalLifecycleOwner] until this
+ * function leaves the composition. Similar to [WorkflowLifecycleOwner] for views, but a
+ * bit simpler since we don't need to worry about attachment state.
+ */
+@Composable private fun rememberChildLifecycleOwner(): LifecycleOwner {
+  val lifecycleOwner = remember {
+    object : LifecycleOwner {
+      val registry = LifecycleRegistry(this)
+      override fun getLifecycle(): Lifecycle = registry
+    }
+  }
+  val parentLifecycle = LocalLifecycleOwner.current.lifecycle
+
+  DisposableEffect(parentLifecycle) {
+    val parentObserver = LifecycleEventObserver { _, event ->
+      // Any time the parent lifecycle changes state, perform the same change on our lifecycle.
+      lifecycleOwner.registry.handleLifecycleEvent(event)
+    }
+
+    parentLifecycle.addObserver(parentObserver)
+    onDispose {
+      parentLifecycle.removeObserver(parentObserver)
+
+      // If we're leaving the composition it means the WorkflowRendering is either going away itself
+      // or about to switch to an incompatible rendering – either way, this lifecycle is dead. Note
+      // that we can't transition from INITIALIZED to DESTROYED – the LifecycelRegistry will throw.
+      // WorkflowLifecycleOwner has this same check.
+      if (lifecycleOwner.registry.currentState != INITIALIZED) {
+        lifecycleOwner.registry.currentState = DESTROYED
+      }
+    }
+  }
+
+  return lifecycleOwner
+}
+
+/**
+ * Returns a [ComposeViewFactory] that makes it convenient to display this [ViewFactory] as a
+ * composable. If this is a [ComposeViewFactory] already it just returns `this`, otherwise it wraps
+ * the factory in one that manages a classic Android view.
+ */
+@OptIn(WorkflowUiExperimentalApi::class)
+private fun <R : Any> ViewFactory<R>.asComposeViewFactory() =
+  (this as? ComposeViewFactory) ?: object : ComposeViewFactory<R>() {
+
+    private val originalFactory = this@asComposeViewFactory
+    override val type: KClass<in R> get() = originalFactory.type
+
+    /**
+     * This is effectively the logic of [WorkflowViewStub], but translated into Compose idioms.
+     * This approach has a few advantages:
+     *
+     *  - Avoids extra custom views required to host `WorkflowViewStub` inside a Composition. Its trick
+     *    of replacing itself in its parent doesn't play nicely with Compose.
+     *  - Allows us to pass the correct parent view for inflation (the root of the composition).
+     *  - Avoids `WorkflowViewStub` having to do its own lookup to find the correct [ViewFactory], since
+     *    we already have the correct one.
+     *  - Propagate the current [LifecycleOwner] from [LocalLifecycleOwner] by setting it as the
+     *    [ViewTreeLifecycleOwner] on the view.
+     *
+     * Like `WorkflowViewStub`, this function uses the [originalFactory] to create and memoize a
+     * [View] to display the [rendering], keeps it updated with the latest [rendering] and
+     * [viewEnvironment], and adds it to the composition.
+     */
+    @Composable override fun Content(
+      rendering: R,
+      viewEnvironment: ViewEnvironment
+    ) {
+      val lifecycleOwner = LocalLifecycleOwner.current
+
+      AndroidView(
+        factory = { context ->
+          // We pass in a null container because the container isn't a View, it's a composable. The
+          // compose machinery will generate an intermediate view that it ends up adding this to but
+          // we don't have access to that.
+          originalFactory.buildView(rendering, viewEnvironment, context, container = null)
+            .also { view ->
+              // Mirrors the check done in ViewRegistry.buildView.
+              checkNotNull(view.getShowRendering<Any>()) {
+                "View.bindShowRendering should have been called for $view, typically by the " +
+                  "${ViewFactory::class.java.name} that created it."
+              }
+
+              // Unfortunately AndroidView doesn't propagate this itself.
+              ViewTreeLifecycleOwner.set(view, lifecycleOwner)
+              // We don't propagate the (non-compose) SavedStateRegistryOwner, or the (compose)
+              // SaveableStateRegistry, because currently all our navigation is implemented as
+              // Android views, which ensures there is always an Android view between any state
+              // registry and any Android view shown as a child of it, even if there's a compose
+              // view in between.
+            }
+        },
+        // This function will be invoked every time this composable is recomposed, which means that
+        // any time a new rendering or view environment are passed in we'll send them to the view.
+        update = { view ->
+          view.showRendering(rendering, viewEnvironment)
+        }
+      )
+    }
+  }


### PR DESCRIPTION
`WorkflowRendering` is the compose analogue of `WorkflowViewStub`.

Part of #458.

Also introduces a sample of nesting legacy and compose renderings.

Archeology: Originally introduced in https://github.com/square/workflow-kotlin-compose/pull/7.

- Closes #374.
- Closes #375.
- Closes #478.

![Kapture 2021-08-18 at 19 34 07](https://user-images.githubusercontent.com/101754/129998320-5af3fa05-a91d-444c-950f-e96fb29e09b8.gif)
