### PR TITLE
Introduce renderAsState, a handy way to run the workflow runtime from composables.

### DIFF
--- a/workflow-ui/compose/api/compose.api
+++ b/workflow-ui/compose/api/compose.api
@@ -23,6 +23,10 @@ public final class com/squareup/workflow1/ui/compose/CompositionRootKt {
 	public static final fun withCompositionRoot (Lcom/squareup/workflow1/ui/ViewRegistry;Lkotlin/jvm/functions/Function3;)Lcom/squareup/workflow1/ui/ViewRegistry;
 }
 
+public final class com/squareup/workflow1/ui/compose/RenderAsStateKt {
+	public static final fun renderAsState (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/util/List;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)Landroidx/compose/runtime/State;
+}
+
 public final class com/squareup/workflow1/ui/compose/WorkflowRenderingKt {
 	public static final fun WorkflowRendering (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/RenderAsStateTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/RenderAsStateTest.kt
@@ -1,0 +1,252 @@
+package com.squareup.workflow1.ui.compose
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
+import androidx.compose.runtime.saveable.SaveableStateRegistry
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.squareup.workflow1.Snapshot
+import com.squareup.workflow1.StatefulWorkflow
+import com.squareup.workflow1.Workflow
+import com.squareup.workflow1.action
+import com.squareup.workflow1.parse
+import com.squareup.workflow1.readUtf8WithLength
+import com.squareup.workflow1.stateless
+import com.squareup.workflow1.ui.compose.RenderAsStateTest.SnapshottingWorkflow.SnapshottedRendering
+import com.squareup.workflow1.writeUtf8WithLength
+import okio.ByteString
+import okio.ByteString.Companion.decodeBase64
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RenderAsStateTest {
+
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test fun passesPropsThrough() {
+    val workflow = Workflow.stateless<String, Nothing, String> { it }
+    lateinit var initialRendering: String
+
+    composeRule.setContent {
+      initialRendering = workflow.renderAsState(props = "foo", onOutput = {}).value
+    }
+
+    composeRule.runOnIdle {
+      assertThat(initialRendering).isEqualTo("foo")
+    }
+  }
+
+  @Test fun seesPropsAndRenderingUpdates() {
+    val workflow = Workflow.stateless<String, Nothing, String> { it }
+    val props = mutableStateOf("foo")
+    lateinit var rendering: String
+
+    composeRule.setContent {
+      rendering = workflow.renderAsState(props.value, onOutput = {}).value
+    }
+
+    composeRule.runOnIdle {
+      assertThat(rendering).isEqualTo("foo")
+      props.value = "bar"
+    }
+    composeRule.runOnIdle {
+      assertThat(rendering).isEqualTo("bar")
+    }
+  }
+
+  @Test fun invokesOutputCallback() {
+    val workflow = Workflow.stateless<Unit, String, (String) -> Unit> {
+      { string -> actionSink.send(action { setOutput(string) }) }
+    }
+    val receivedOutputs = mutableListOf<String>()
+    lateinit var rendering: (String) -> Unit
+
+    composeRule.setContent {
+      rendering = workflow.renderAsState(props = Unit, onOutput = { receivedOutputs += it }).value
+    }
+
+    composeRule.runOnIdle {
+      assertThat(receivedOutputs).isEmpty()
+      rendering("one")
+    }
+
+    composeRule.runOnIdle {
+      assertThat(receivedOutputs).isEqualTo(listOf("one"))
+      rendering("two")
+    }
+
+    composeRule.runOnIdle {
+      assertThat(receivedOutputs).isEqualTo(listOf("one", "two"))
+    }
+  }
+
+  @Test fun savesSnapshot() {
+    val workflow = SnapshottingWorkflow()
+    val savedStateRegistry = SaveableStateRegistry(emptyMap()) { true }
+    lateinit var rendering: SnapshottedRendering
+
+    composeRule.setContent {
+      CompositionLocalProvider(LocalSaveableStateRegistry provides savedStateRegistry) {
+        rendering = renderAsState(
+          workflow = workflow,
+          scope = rememberCoroutineScope(),
+          props = Unit,
+          interceptors = emptyList(),
+          onOutput = {},
+          snapshotKey = SNAPSHOT_KEY
+        ).value
+      }
+    }
+
+    composeRule.runOnIdle {
+      assertThat(rendering.string).isEmpty()
+      rendering.updateString("foo")
+    }
+
+    composeRule.runOnIdle {
+      val savedValues = savedStateRegistry.performSave()
+      println("saved keys: ${savedValues.keys}")
+      // Relying on the int key across all runtimes is brittle, so use an explicit key.
+      @Suppress("UNCHECKED_CAST")
+      val snapshot =
+        ByteString.of(*((savedValues.getValue(SNAPSHOT_KEY).single() as State<ByteArray>).value))
+      println("snapshot: ${snapshot.base64()}")
+      assertThat(snapshot).isEqualTo(EXPECTED_SNAPSHOT)
+    }
+  }
+
+  @Test fun restoresSnapshot() {
+    val workflow = SnapshottingWorkflow()
+    val restoreValues =
+      mapOf(SNAPSHOT_KEY to listOf(mutableStateOf(EXPECTED_SNAPSHOT.toByteArray())))
+    val savedStateRegistry = SaveableStateRegistry(restoreValues) { true }
+    lateinit var rendering: SnapshottedRendering
+
+    composeRule.setContent {
+      CompositionLocalProvider(LocalSaveableStateRegistry provides savedStateRegistry) {
+        rendering = renderAsState(
+          workflow = workflow,
+          scope = rememberCoroutineScope(),
+          props = Unit,
+          interceptors = emptyList(),
+          onOutput = {},
+          snapshotKey = "workflow-snapshot"
+        ).value
+      }
+    }
+
+    composeRule.runOnIdle {
+      assertThat(rendering.string).isEqualTo("foo")
+    }
+  }
+
+  @Test fun savesAndRestoresSnapshotOnConfigChange() {
+    val stateRestorationTester = StateRestorationTester(composeRule)
+    val workflow = SnapshottingWorkflow()
+    lateinit var rendering: SnapshottedRendering
+
+    stateRestorationTester.setContent {
+      rendering = workflow.renderAsState(
+        scope = rememberCoroutineScope(),
+        props = Unit,
+        interceptors = emptyList(),
+        onOutput = {},
+      ).value
+    }
+
+    composeRule.runOnIdle {
+      assertThat(rendering.string).isEmpty()
+      rendering.updateString("foo")
+    }
+
+    stateRestorationTester.emulateSavedInstanceStateRestore()
+
+    composeRule.runOnIdle {
+      assertThat(rendering.string).isEqualTo("foo")
+    }
+  }
+
+  @Test fun restoresFromSnapshotWhenWorkflowChanged() {
+    val workflow1 = SnapshottingWorkflow()
+    val workflow2 = SnapshottingWorkflow()
+    val currentWorkflow = mutableStateOf(workflow1)
+    lateinit var rendering: SnapshottedRendering
+
+    var compositionCount = 0
+    var lastCompositionCount = 0
+    fun assertWasRecomposed() {
+      assertThat(compositionCount).isGreaterThan(lastCompositionCount)
+      lastCompositionCount = compositionCount
+    }
+
+    composeRule.setContent {
+      compositionCount++
+      rendering = currentWorkflow.value.renderAsState(props = Unit, onOutput = {}).value
+    }
+
+    // Initialize the first workflow.
+    composeRule.runOnIdle {
+      assertThat(rendering.string).isEmpty()
+      assertWasRecomposed()
+      rendering.updateString("one")
+    }
+    composeRule.runOnIdle {
+      assertWasRecomposed()
+      assertThat(rendering.string).isEqualTo("one")
+    }
+
+    // Change the workflow instance being rendered. This should restart the runtime, but restore
+    // it from the snapshot.
+    currentWorkflow.value = workflow2
+
+    composeRule.runOnIdle {
+      assertWasRecomposed()
+      assertThat(rendering.string).isEqualTo("one")
+    }
+  }
+
+  private companion object {
+    const val SNAPSHOT_KEY = "workflow-snapshot"
+
+    /** Golden value from [savesSnapshot]. */
+    val EXPECTED_SNAPSHOT = "AAAABwAAAANmb28AAAAA".decodeBase64()!!
+  }
+
+  // Seems to be a problem accessing Workflow.stateful.
+  private class SnapshottingWorkflow :
+    StatefulWorkflow<Unit, String, Nothing, SnapshottedRendering>() {
+
+    data class SnapshottedRendering(
+      val string: String,
+      val updateString: (String) -> Unit
+    )
+
+    override fun initialState(
+      props: Unit,
+      snapshot: Snapshot?
+    ): String = snapshot?.bytes?.parse { it.readUtf8WithLength() } ?: ""
+
+    override fun render(
+      renderProps: Unit,
+      renderState: String,
+      context: RenderContext
+    ) = SnapshottedRendering(
+      string = renderState,
+      updateString = { newString -> context.actionSink.send(updateString(newString)) }
+    )
+
+    override fun snapshotState(state: String): Snapshot =
+      Snapshot.write { it.writeUtf8WithLength(state) }
+
+    private fun updateString(newString: String) = action {
+      state = newString
+    }
+  }
+}

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/RenderAsState.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/RenderAsState.kt
@@ -1,0 +1,215 @@
+@file:OptIn(ExperimentalWorkflowApi::class)
+
+package com.squareup.workflow1.ui.compose
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.RememberObserver
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.SaverScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import com.squareup.workflow1.ExperimentalWorkflowApi
+import com.squareup.workflow1.Snapshot
+import com.squareup.workflow1.TreeSnapshot
+import com.squareup.workflow1.Workflow
+import com.squareup.workflow1.WorkflowInterceptor
+import com.squareup.workflow1.renderWorkflowIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import okio.ByteString
+
+/**
+ * Runs this [Workflow] as long as this composable is part of the composition, and returns a
+ * [State] object that will be updated whenever the runtime emits a new [RenderingT]. Note that
+ * here, and in the rest of the documentation for this class, the "`State`" type refers to Compose's
+ * snapshot [State] type, _not_ the concept of the `StateT` type in a particular workflow.
+ *
+ * The workflow runtime will be started when this function is first added to the composition, and
+ * cancelled when it is removed or if the composition fails. The first rendering will be available
+ * immediately as soon as this function returns as [State.value]. Composables that read this value
+ * will automatically recompose whenever the runtime emits a new rendering. If you are driving UI
+ * from the Workflow tree managed by [renderAsState] then you will probably want to pass the
+ * returned [State]'s value (which is the Workflow rendering) to the [WorkflowRendering] composable.
+ *
+ * Note that the initial render pass will occur on whatever thread this function is called from.
+ * That may be a background thread, as Compose supports performing composition on background
+ * threads. Well-behaved workflows should have pure `initialState` and `render` functions, so this
+ * should not be a problem. Any side effects performed by workflows using the `runningSideEffect`
+ * method or Workers will be executed in [scope] as usual.
+ *
+ * [Snapshot]s from the runtime will automatically be saved and restored using Compose's
+ * [rememberSaveable].
+ *
+ * ## Example
+ *
+ * ```
+ * private val appViewRegistry = ViewRegistry(…)
+ *
+ * @Composable fun App(workflow: Workflow<…>, props: Props) {
+ *   val scaffoldState = …
+ *
+ *   // Run the workflow in the current composition's coroutine scope.
+ *   val rendering by workflow.renderAsState(props, onOutput = { output ->
+ *     // Note that onOutput is a suspend function, so you can run animations
+ *     // and call other suspend functions.
+ *     scaffoldState.snackbarHostState
+ *       .showSnackbar(output.toString())
+ *   })
+ *   val viewEnvironment = remember {
+ *     ViewEnvironment(mapOf(ViewRegistry to appViewRegistry))
+ *   }
+ *
+ *   Scaffold(…) { padding ->
+ *     // Display the root rendering using the view environment's ViewRegistry.
+ *     WorkflowRendering(rendering, viewEnvironment, Modifier.padding(padding))
+ *   }
+ * }
+ * ```
+ *
+ * @receiver The [Workflow] to run. If the value of the receiver changes to a different [Workflow]
+ * while this function is in the composition, the runtime will be restarted with the new workflow.
+ * @param props The [PropsT] for the root [Workflow]. Changes to this value across different
+ * compositions will cause the root workflow to re-render with the new props.
+ * @param interceptors
+ * An optional list of [WorkflowInterceptor]s that will wrap every workflow rendered by the runtime.
+ * Interceptors will be invoked in 0-to-`length` order: the interceptor at index 0 will process the
+ * workflow first, then the interceptor at index 1, etc.
+ * @param scope
+ * The [CoroutineScope] in which to launch the workflow runtime. If not specified, the value of
+ * [rememberCoroutineScope] will be used. Any exceptions thrown in any workflows, after the initial
+ * render pass, will be handled by this scope, and cancelling this scope will cancel the workflow
+ * runtime and any running workers. Note that any dispatcher in this scope will _not_ be used to
+ * execute the very first render pass.
+ * @param onOutput A function that will be executed whenever the root [Workflow] emits an output.
+ */
+@Composable
+public fun <PropsT, OutputT : Any, RenderingT> Workflow<PropsT, OutputT, RenderingT>.renderAsState(
+  props: PropsT,
+  interceptors: List<WorkflowInterceptor> = emptyList(),
+  scope: CoroutineScope = rememberCoroutineScope(),
+  onOutput: suspend (OutputT) -> Unit
+): State<RenderingT> = renderAsState(this, scope, props, interceptors, onOutput)
+
+/**
+ * @param snapshotKey Allows tests to pass in a custom key to use to save/restore the snapshot from
+ * the [LocalSaveableStateRegistry]. If null, will use the default key based on source location.
+ */
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+@Composable internal fun <PropsT, OutputT : Any, RenderingT> renderAsState(
+  workflow: Workflow<PropsT, OutputT, RenderingT>,
+  scope: CoroutineScope,
+  props: PropsT,
+  interceptors: List<WorkflowInterceptor>,
+  onOutput: suspend (OutputT) -> Unit,
+  snapshotKey: String? = null
+): State<RenderingT> {
+  val snapshotState = rememberSaveable(key = snapshotKey, stateSaver = TreeSnapshotSaver) {
+    mutableStateOf(null)
+  }
+  val updatedOnOutput by rememberUpdatedState(onOutput)
+
+  // We can't use DisposableEffect because it won't run until the composition is successfully
+  // committed, which will be after this function returns, and we need to run this immediately so we
+  // get the rendering synchronously. The thread running this composition might also not be the
+  // main thread or whatever thread the workflow context is configured to run on, but that should
+  // be fine as long as the workflows are correctly performing side effects in effects and not their
+  // render or related methods.
+  // The WorkflowState object remembered here is a RememberObserver – it will automatically cancel
+  // the workflow runtime when it leaves the composition or if the composition doesn't commit.
+  // The remember is keyed on any values that we can't update the runtime with dynamically, and
+  // therefore require completely restarting the runtime to take effect.
+  val state = remember(workflow, scope, interceptors) {
+    WorkflowRuntimeState<PropsT, OutputT, RenderingT>(
+      workflowScope = scope,
+      initialProps = props,
+      snapshotState = snapshotState,
+      onOutput = { updatedOnOutput(it) }
+    ).apply {
+      start(workflow, interceptors)
+    }
+  }
+
+  // Use a side effect to update props so that it waits for the composition to commit.
+  SideEffect {
+    state.setProps(props)
+  }
+
+  return state.rendering
+}
+
+/**
+ * State hoisted out of [renderAsState].
+ */
+private class WorkflowRuntimeState<PropsT, OutputT : Any, RenderingT>(
+  private val workflowScope: CoroutineScope,
+  initialProps: PropsT,
+  private val snapshotState: MutableState<TreeSnapshot?>,
+  private val onOutput: suspend (OutputT) -> Unit,
+) : RememberObserver {
+
+  private val renderingState = mutableStateOf<RenderingT?>(null)
+  private val propsFlow = MutableStateFlow(initialProps)
+
+  // The value is guaranteed to be set before returning, so this cast is fine.
+  @Suppress("UNCHECKED_CAST")
+  val rendering: State<RenderingT>
+    get() = renderingState as State<RenderingT>
+
+  fun start(
+    workflow: Workflow<PropsT, OutputT, RenderingT>,
+    interceptors: List<WorkflowInterceptor>
+  ) {
+    val renderings = renderWorkflowIn(
+      workflow = workflow,
+      scope = workflowScope,
+      props = propsFlow,
+      initialSnapshot = snapshotState.value,
+      interceptors = interceptors,
+      onOutput = onOutput
+    )
+
+    renderings
+      .onEach {
+        renderingState.value = it.rendering
+        snapshotState.value = it.snapshot
+      }
+      .launchIn(workflowScope)
+  }
+
+  fun setProps(props: PropsT) {
+    propsFlow.value = props
+  }
+
+  override fun onAbandoned() {
+    workflowScope.cancel()
+  }
+
+  override fun onRemembered() {}
+
+  override fun onForgotten() {
+    workflowScope.cancel()
+  }
+}
+
+private object TreeSnapshotSaver : Saver<TreeSnapshot?, ByteArray> {
+  override fun SaverScope.save(value: TreeSnapshot?): ByteArray {
+    return value?.toByteString()?.toByteArray() ?: ByteArray(0)
+  }
+
+  override fun restore(value: ByteArray): TreeSnapshot? {
+    return value.takeUnless { it.isEmpty() }
+      ?.let { bytes -> TreeSnapshot.parse(ByteString.of(*bytes)) }
+  }
+}


### PR DESCRIPTION
Part of #458.

`renderAsState` is a wrapper around the main workflow runtime entry point, `renderWorkflowIn`, that manages saving and restoring snapshot states as well as updating props and getting renderings and outputs from the workflow.

It's designed to follow the compose pattern for subscribing to reactive types: `Flow.collectAsState()`, `LiveData.observeAsState()`, `Observable.subscribeAsState()`.

Example:
```kotlin
@Composable fun App(workflow: Workflow<…>, props: Props) {
  val scaffoldState = …

  // Run the workflow in the current composition's coroutine scope.
  val rendering by workflow.renderAsState(props, onOutput = { output ->
    // Note that onOutput is a suspend function, so you can run animations
    // and call other suspend functions.
    scaffoldState.snackbarHostState
      .showSnackbar(output.toString())
  })
  val viewEnvironment = remember {
    ViewEnvironment(mapOf(ViewRegistry to appViewRegistry))
  }

  Scaffold(…) { padding ->
    // Display the root rendering using the view environment's ViewRegistry.
    WorkflowRendering(rendering, viewEnvironment, Modifier.padding(padding))
  }
}
```