### PR TITLE
Fixes leak in WorkflowLifecycleOwner.installOn

### DIFF
--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -176,8 +176,8 @@ public abstract interface class com/squareup/workflow1/ui/WorkflowLifecycleOwner
 
 public final class com/squareup/workflow1/ui/WorkflowLifecycleOwner$Companion {
 	public final fun get (Landroid/view/View;)Lcom/squareup/workflow1/ui/WorkflowLifecycleOwner;
-	public final fun installOn (Landroid/view/View;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun installOn$default (Lcom/squareup/workflow1/ui/WorkflowLifecycleOwner$Companion;Landroid/view/View;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun installOn (Landroid/view/View;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun installOn$default (Lcom/squareup/workflow1/ui/WorkflowLifecycleOwner$Companion;Landroid/view/View;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public abstract interface class com/squareup/workflow1/ui/WorkflowRunner {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLifecycleOwner.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLifecycleOwner.kt
@@ -72,7 +72,7 @@ public interface WorkflowLifecycleOwner : LifecycleOwner {
      */
     public fun installOn(
       view: View,
-      findParentLifecycle: () -> Lifecycle? = { findParentViewTreeLifecycle(view) }
+      findParentLifecycle: (View) -> Lifecycle? = { v -> findParentViewTreeLifecycle(v) }
     ) {
       RealWorkflowLifecycleOwner(findParentLifecycle).also {
         ViewTreeLifecycleOwner.set(view, it)
@@ -103,7 +103,7 @@ public interface WorkflowLifecycleOwner : LifecycleOwner {
 @OptIn(WorkflowUiExperimentalApi::class)
 @VisibleForTesting(otherwise = PRIVATE)
 internal class RealWorkflowLifecycleOwner(
-  private var findParentLifecycle: () -> Lifecycle?,
+  private var findParentLifecycle: (View) -> Lifecycle?,
   enforceMainThread: Boolean = true,
 ) : WorkflowLifecycleOwner,
   LifecycleOwner,
@@ -144,7 +144,7 @@ internal class RealWorkflowLifecycleOwner(
 
     // Always check for a new parent, in case we're attached to different part of the view tree.
     val oldLifecycle = parentLifecycle
-    parentLifecycle = checkNotNull(findParentLifecycle()) {
+    parentLifecycle = checkNotNull(findParentLifecycle(v)) {
       "Expected to find either a ViewTreeLifecycleOwner in the view tree, or for the view's" +
         " context to be a LifecycleOwner."
     }

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/RealWorkflowLifecycleOwnerTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/RealWorkflowLifecycleOwnerTest.kt
@@ -19,7 +19,7 @@ import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Test
 import kotlin.test.assertFailsWith
 
-class RealWorkflowLifecycleOwnerTest {
+internal class RealWorkflowLifecycleOwnerTest {
 
   private val rootContext = mock<Context>()
   private val view = mock<View> {


### PR DESCRIPTION
The lambda created by `WorkflowLifecycleOwner.installOn` was needlessly
holding a reference to the given view. The fix is to change the
`findParentLifecycle` function to expect a `View` argument, to be passed at
attach time.