### PR TITLE
Fixes memory leak in WorkflowLifecycleOwner.

### DIFF
--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -175,8 +175,8 @@ public abstract interface class com/squareup/workflow1/ui/WorkflowLifecycleOwner
 
 public final class com/squareup/workflow1/ui/WorkflowLifecycleOwner$Companion {
 	public final fun get (Landroid/view/View;)Lcom/squareup/workflow1/ui/WorkflowLifecycleOwner;
-	public final fun installOn (Landroid/view/View;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun installOn$default (Lcom/squareup/workflow1/ui/WorkflowLifecycleOwner$Companion;Landroid/view/View;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun installOn (Landroid/view/View;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun installOn$default (Lcom/squareup/workflow1/ui/WorkflowLifecycleOwner$Companion;Landroid/view/View;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public abstract interface class com/squareup/workflow1/ui/WorkflowRunner {

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/RealWorkflowLifecycleOwnerTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/RealWorkflowLifecycleOwnerTest.kt
@@ -17,7 +17,7 @@ import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Test
 import kotlin.test.assertFailsWith
 
-class RealWorkflowLifecycleOwnerTest {
+internal class RealWorkflowLifecycleOwnerTest {
 
   private val rootContext = mock<Context>()
   private val view = mock<View> {
@@ -25,7 +25,6 @@ class RealWorkflowLifecycleOwnerTest {
   }
   private var parentLifecycle: LifecycleRegistry? = null
   private val owner = RealWorkflowLifecycleOwner(
-    view,
     enforceMainThread = false,
     findParentLifecycle = { parentLifecycle }
   )


### PR DESCRIPTION
Hold a pointer to the `View` only while it is attached. Pass a `View` param to
the `findParentLifecycle` function to ensure it doesn't need to hold a
leak-prone ref either.

These fixes are a more focussed distillation of the handful that landed on
`main` in the last few days. There are no changes related to lifecycle, and
we no longer worry about nulling out the lambda.

Note that this PR will merge into a new `v1.0.0-alpha19` branch, which was cut from the `v1.0.0-alpha18` tag.