### PR TITLE
Increase UI tests timeout from 30 to 40 mins.

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -57,7 +57,7 @@ jobs:
   instrumentation-tests:
     name: Instrumentation tests
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false


### PR DESCRIPTION
The ui tests have been timing out more recently, and I think it's because of all the new UI tests in the compose modules.