### PR TITLE
Make ModalContainer provide individual SavedStateRegistries to each of its layers.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.squareup.workflow1
-VERSION_NAME=1.1.0-SNAPSHOT
+VERSION_NAME=1.1.0-rjrjr2-SNAPSHOT
 
 POM_DESCRIPTION=Reactive workflows
 

--- a/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/ViewStateCacheTest.kt
+++ b/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/ViewStateCacheTest.kt
@@ -9,9 +9,9 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import com.squareup.workflow1.ui.Named
 import com.squareup.workflow1.ui.ViewEnvironment
-import com.squareup.workflow1.ui.androidx.WorkflowLifecycleOwner
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.backstack.KeyedStateRegistryOwner
+import com.squareup.workflow1.ui.androidx.KeyedStateRegistryOwner
+import com.squareup.workflow1.ui.androidx.WorkflowLifecycleOwner
 import com.squareup.workflow1.ui.backstack.ViewStateCache
 import com.squareup.workflow1.ui.backstack.ViewStateFrame
 import com.squareup.workflow1.ui.backstack.test.fixtures.ViewStateTestView

--- a/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/ViewStateCache.kt
+++ b/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/ViewStateCache.kt
@@ -12,6 +12,8 @@ import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.ViewTreeSavedStateRegistryOwner
 import com.squareup.workflow1.ui.Named
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.androidx.KeyedStateRegistryOwner
+import com.squareup.workflow1.ui.androidx.StateRegistryAggregator
 import com.squareup.workflow1.ui.backstack.ViewStateCache.SavedState
 import com.squareup.workflow1.ui.getRendering
 

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
 import com.squareup.workflow1.ui.AndroidViewRendering
 import com.squareup.workflow1.ui.Compatible
-import com.squareup.workflow1.ui.Named
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewRegistry
@@ -385,7 +384,7 @@ internal class ComposeViewTreeIntegrationTest {
   }
 
   @Test fun composition_is_restored_in_multiple_modals_after_config_change() {
-    val firstScreen = ComposeRendering(compatibilityKey = "first") {
+    val firstScreen = ComposeRendering(compatibilityKey = "key") {
       var counter by rememberSaveable { mutableStateOf(0) }
       BasicText(
         "Counter: $counter",
@@ -394,7 +393,9 @@ internal class ComposeViewTreeIntegrationTest {
           .testTag(CounterTag)
       )
     }
-    val secondScreen = ComposeRendering(compatibilityKey = "second") {
+    // Use the same compatibility key – these screens are in different modals, so they won't
+    // conflict.
+    val secondScreen = ComposeRendering(compatibilityKey = "key") {
       var counter by rememberSaveable { mutableStateOf(0) }
       BasicText(
         "Counter2: $counter",
@@ -403,17 +404,26 @@ internal class ComposeViewTreeIntegrationTest {
           .testTag(CounterTag2)
       )
     }
+    // Use the same compatibility key – these screens are in different modals, so they won't
+    // conflict.
+    val thirdScreen = ComposeRendering(compatibilityKey = "key") {
+      var counter by rememberSaveable { mutableStateOf(0) }
+      BasicText(
+        "Counter3: $counter",
+        Modifier
+          .clickable { counter++ }
+          .testTag(CounterTag3)
+      )
+    }
 
     // Show first screen to initialize state.
     scenario.onActivity {
       it.setRendering(
         TestModalScreen(
           listOf(
-            // Name each BackStackScreen to give them unique state registry keys.
-            // TODO(https://github.com/square/workflow-kotlin/issues/469) Should this naming be
-            //  done automatically in ModalContainer?
-            Named(BackStackScreen(EmptyRendering, firstScreen), "modal1"),
-            Named(BackStackScreen(EmptyRendering, secondScreen), "modal2")
+            firstScreen,
+            secondScreen,
+            thirdScreen
           )
         )
       )
@@ -429,6 +439,11 @@ internal class ComposeViewTreeIntegrationTest {
       .performClick()
       .assertTextEquals("Counter2: 1")
 
+    composeRule.onNodeWithTag(CounterTag3)
+      .assertTextEquals("Counter3: 0")
+      .performClick()
+      .assertTextEquals("Counter3: 1")
+
     scenario.recreate()
 
     composeRule.onNodeWithTag(CounterTag)
@@ -436,6 +451,105 @@ internal class ComposeViewTreeIntegrationTest {
 
     composeRule.onNodeWithTag(CounterTag2)
       .assertTextEquals("Counter2: 1")
+
+    composeRule.onNodeWithTag(CounterTag3)
+      .assertTextEquals("Counter3: 1")
+  }
+
+  @Test fun composition_is_restored_in_multiple_modals_backstacks_after_config_change() {
+    fun createRendering(
+      layer: Int,
+      screen: Int
+    ) = ComposeRendering(
+      // Use the same compatibility key across layers – these screens are in different modals, so
+      // they won't conflict.
+      compatibilityKey = screen.toString()
+    ) {
+      var counter by rememberSaveable { mutableStateOf(0) }
+      BasicText(
+        "Counter[$layer][$screen]: $counter",
+        Modifier
+          .clickable { counter++ }
+          .testTag("[$layer][$screen]")
+      )
+    }
+
+    val layer0Screen0 = createRendering(0, 0)
+    val layer0Screen1 = createRendering(0, 1)
+    val layer1Screen0 = createRendering(1, 0)
+    val layer1Screen1 = createRendering(1, 1)
+
+    // Show first screen to initialize state.
+    scenario.onActivity {
+      it.setRendering(
+        TestModalScreen(
+          listOf(
+            BackStackScreen(EmptyRendering, layer0Screen0),
+            BackStackScreen(EmptyRendering, layer1Screen0)
+          )
+        )
+      )
+    }
+
+    composeRule.onNodeWithText("Counter[0][0]: 0")
+      .assertIsDisplayed()
+      .performClick()
+      .assertTextEquals("Counter[0][0]: 1")
+    composeRule.onNodeWithText("Counter[1][0]: 0")
+      .assertIsDisplayed()
+      .performClick()
+      .assertTextEquals("Counter[1][0]: 1")
+
+    // Push some screens onto the backstack.
+    scenario.onActivity {
+      it.setRendering(
+        TestModalScreen(
+          listOf(
+            BackStackScreen(EmptyRendering, layer0Screen0, layer0Screen1),
+            BackStackScreen(EmptyRendering, layer1Screen0, layer1Screen1)
+          )
+        )
+      )
+    }
+
+    composeRule.onNodeWithText("Counter[0][0]", substring = true)
+      .assertDoesNotExist()
+    composeRule.onNodeWithText("Counter[1][0]", substring = true)
+      .assertDoesNotExist()
+    composeRule.onNodeWithText("Counter[0][1]: 0")
+      .assertIsDisplayed()
+      .performClick()
+      .assertTextEquals("Counter[0][1]: 1")
+    composeRule.onNodeWithText("Counter[1][1]: 0")
+      .assertIsDisplayed()
+      .performClick()
+      .assertTextEquals("Counter[1][1]: 1")
+
+    // Simulate config change.
+    scenario.recreate()
+
+    // Check that the last-shown screens were restored.
+    composeRule.onNodeWithText("Counter[0][1]: 1")
+      .assertIsDisplayed()
+    composeRule.onNodeWithText("Counter[1][1]: 1")
+      .assertIsDisplayed()
+
+    // Pop both backstacks and check that screens were restored.
+    scenario.onActivity {
+      it.setRendering(
+        TestModalScreen(
+          listOf(
+            BackStackScreen(EmptyRendering, layer0Screen0),
+            BackStackScreen(EmptyRendering, layer1Screen0)
+          )
+        )
+      )
+    }
+
+    composeRule.onNodeWithText("Counter[0][0]: 1")
+      .assertIsDisplayed()
+    composeRule.onNodeWithText("Counter[1][0]: 1")
+      .assertIsDisplayed()
   }
 
   private fun WorkflowUiTestActivity.setBackstack(vararg backstack: ComposeRendering) {
@@ -486,5 +600,6 @@ internal class ComposeViewTreeIntegrationTest {
 
     const val CounterTag = "counter"
     const val CounterTag2 = "counter2"
+    const val CounterTag3 = "counter3"
   }
 }

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -165,10 +165,33 @@ public final class com/squareup/workflow1/ui/WorkflowViewStub : android/view/Vie
 	public final fun update (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;)Landroid/view/View;
 }
 
+public final class com/squareup/workflow1/ui/androidx/KeyedStateRegistryOwner : androidx/lifecycle/LifecycleOwner, androidx/savedstate/SavedStateRegistryOwner {
+	public static final field Companion Lcom/squareup/workflow1/ui/androidx/KeyedStateRegistryOwner$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Landroidx/lifecycle/LifecycleOwner;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getController ()Landroidx/savedstate/SavedStateRegistryController;
+	public final fun getKey ()Ljava/lang/String;
+	public fun getLifecycle ()Landroidx/lifecycle/Lifecycle;
+	public fun getSavedStateRegistry ()Landroidx/savedstate/SavedStateRegistry;
+}
+
+public final class com/squareup/workflow1/ui/androidx/KeyedStateRegistryOwner$Companion {
+	public final fun installAsSavedStateRegistryOwnerOn (Landroid/view/View;Ljava/lang/String;)Lcom/squareup/workflow1/ui/androidx/KeyedStateRegistryOwner;
+}
+
+public final class com/squareup/workflow1/ui/androidx/StateRegistryAggregator {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public final fun attachToParentRegistry (Ljava/lang/String;Landroidx/savedstate/SavedStateRegistryOwner;)V
+	public final fun detachFromParentRegistry ()V
+	public final fun pruneKeys (Ljava/util/Collection;)V
+	public final fun restoreRegistryControllerIfReady (Ljava/lang/String;Landroidx/savedstate/SavedStateRegistryController;)V
+	public final fun saveRegistryController (Ljava/lang/String;Landroidx/savedstate/SavedStateRegistryController;)V
+}
+
 public final class com/squareup/workflow1/ui/androidx/WorkflowAndroidXSupport {
 	public static final field INSTANCE Lcom/squareup/workflow1/ui/androidx/WorkflowAndroidXSupport;
+	public final fun createStateRegistryKeyForContainer (Landroid/view/View;)Ljava/lang/String;
 	public final fun lifecycleOwnerFromViewTreeOrContext (Landroid/view/View;)Landroidx/lifecycle/LifecycleOwner;
-	public final fun stateRegistryOwnerFromViewTreeOrContext (Landroid/view/View;)Landroidx/savedstate/SavedStateRegistryOwner;
+	public final fun requireStateRegistryOwnerFromViewTreeOrContext (Landroid/view/View;)Landroidx/savedstate/SavedStateRegistryOwner;
 }
 
 public abstract interface class com/squareup/workflow1/ui/androidx/WorkflowLifecycleOwner : androidx/lifecycle/LifecycleOwner {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/KeyedStateRegistryOwner.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/KeyedStateRegistryOwner.kt
@@ -1,4 +1,4 @@
-package com.squareup.workflow1.ui.backstack
+package com.squareup.workflow1.ui.androidx
 
 import android.view.View
 import androidx.lifecycle.LifecycleOwner
@@ -6,17 +6,16 @@ import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.ViewTreeSavedStateRegistryOwner
-import com.squareup.workflow1.ui.androidx.WorkflowLifecycleOwner
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.backstack.KeyedStateRegistryOwner.Companion.installAsSavedStateRegistryOwnerOn
+import com.squareup.workflow1.ui.androidx.KeyedStateRegistryOwner.Companion.installAsSavedStateRegistryOwnerOn
 
 /**
- * The implementation of [SavedStateRegistryOwner] that is installed on every immediate child view
- * of a [BackStackContainer]. In other words, when a view inside a [BackStackContainer] calls
+ * The implementation of [SavedStateRegistryOwner] that should be installed on every immediate child
+ * view of container views so that when a view inside a container calls
  * [ViewTreeSavedStateRegistryOwner.get] on itself, one of these is returned.
  *
- * Internally, this class exposes a [controller] to allow the [ViewStateCache] to save and restore
- * any state registered by child views.
+ * Internally, this class exposes a [controller] to allow saving and restoring the child view's
+ * state, e.g. to/from a [StateRegistryAggregator].
  *
  * To create an instance, call [installAsSavedStateRegistryOwnerOn].
  *
@@ -24,14 +23,15 @@ import com.squareup.workflow1.ui.backstack.KeyedStateRegistryOwner.Companion.ins
  * @param lifecycleOwner The [LifecycleOwner] that will be delegated to by this instance. Note that
  * [SavedStateRegistryOwner] extends [LifecycleOwner].
  */
-internal class KeyedStateRegistryOwner private constructor(
-  val key: String,
+@WorkflowUiExperimentalApi
+public class KeyedStateRegistryOwner private constructor(
+  public val key: String,
   lifecycleOwner: LifecycleOwner
 ) : SavedStateRegistryOwner, LifecycleOwner by lifecycleOwner {
-  val controller = SavedStateRegistryController.create(this)
+  public val controller: SavedStateRegistryController = SavedStateRegistryController.create(this)
   override fun getSavedStateRegistry(): SavedStateRegistry = controller.savedStateRegistry
 
-  companion object {
+  public companion object {
     /**
      * Creates a new [KeyedStateRegistryOwner] that is bound to [view]'s [WorkflowLifecycleOwner]
      * and sets it as the [ViewTreeSavedStateRegistryOwner] on [view].
@@ -39,8 +39,8 @@ internal class KeyedStateRegistryOwner private constructor(
      * Note that, once installed, the owner does not need to be "uninstalled". It can live on the
      * view instance as long as it exists, and just be garbage-collected with the view.
      */
-    @OptIn(WorkflowUiExperimentalApi::class)
-    fun installAsSavedStateRegistryOwnerOn(
+    @WorkflowUiExperimentalApi
+    public fun installAsSavedStateRegistryOwnerOn(
       view: View,
       key: String
     ): KeyedStateRegistryOwner {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/StateRegistryAggregator.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/StateRegistryAggregator.kt
@@ -1,4 +1,4 @@
-package com.squareup.workflow1.ui.backstack
+package com.squareup.workflow1.ui.androidx
 
 import android.os.Bundle
 import androidx.lifecycle.Lifecycle.Event
@@ -27,6 +27,9 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
  * previously hidden is being shown again, and from the [onRestored] callback. See the kdoc on these
  * methods and callbacks for more information.
  *
+ * For container views that have multiple children and need to provide a registry to each of them,
+ * consider using [KeyedStateRegistryOwner].
+ *
  * [attachToParentRegistry] should be called when the owning view is attached to a window, and
  * passed the parent registry. [detachFromParentRegistry] should be called when the view is
  * detached. See the kdoc on those methods for more information about what they do.
@@ -37,7 +40,7 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
  * [attachToParentRegistry] and the parent registry's lifecycle is in the `CREATED` state.
  */
 @OptIn(WorkflowUiExperimentalApi::class)
-internal class StateRegistryAggregator(
+public class StateRegistryAggregator(
   private val onWillSave: (StateRegistryAggregator) -> Unit,
   private val onRestored: (StateRegistryAggregator) -> Unit,
 ) {
@@ -96,14 +99,15 @@ internal class StateRegistryAggregator(
    * object for [detachment][detachFromParentRegistry] later.
    *
    * This method will register on the parent registry to save any child registries registered with
-   * [saveRegistryController].
+   * [saveRegistryController]. To get the parent registry for a view, consider using
+   * [WorkflowAndroidXSupport.requireStateRegistryOwnerFromViewTreeOrContext].
    *
    * If this object has not been restored yet, this method will start listening to the parent
    * lifecycle to know when to restore.
    *
    * Must be accompanied by a call to [detachFromParentRegistry] when the view is detached.
    */
-  fun attachToParentRegistry(
+  public fun attachToParentRegistry(
     key: String,
     parentOwner: SavedStateRegistryOwner
   ) {
@@ -146,7 +150,7 @@ internal class StateRegistryAggregator(
    *
    * Stops listening to the parent lifecycle and unregisters from the parent registry.
    */
-  fun detachFromParentRegistry() {
+  public fun detachFromParentRegistry() {
     // parentKey will only be null if parentRegistryOwner is also null.
     parentRegistryOwner?.savedStateRegistry?.unregisterSavedStateProvider(parentKey!!)
     parentRegistryOwner?.lifecycle?.removeObserver(lifecycleObserver)
@@ -163,7 +167,7 @@ internal class StateRegistryAggregator(
    * object. Must be the same key used to [restore][restoreRegistryControllerIfReady] the controller
    * later.
    */
-  fun saveRegistryController(
+  public fun saveRegistryController(
     key: String,
     controller: SavedStateRegistryController
   ) {
@@ -186,7 +190,7 @@ internal class StateRegistryAggregator(
    * @param key The key used to distinguish [controller] from other controllers saved to this
    * object. Must be the same key used to [save][saveRegistryController] the controller earlier.
    */
-  fun restoreRegistryControllerIfReady(
+  public fun restoreRegistryControllerIfReady(
     key: String,
     controller: SavedStateRegistryController
   ) {
@@ -197,11 +201,11 @@ internal class StateRegistryAggregator(
   }
 
   /**
-   * Removes all entries from [states] that don't have keys in [retaining].
+   * Removes all entries from [states] that don't have keys in [keysToKeep].
    */
-  fun pruneKeys(retaining: Collection<String>) {
+  public fun pruneKeys(keysToKeep: Collection<String>) {
     doIfRestored { states ->
-      val deadKeys = states.keys - retaining
+      val deadKeys = states.keys - keysToKeep
       states -= deadKeys
     }
   }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/WorkflowAndroidXSupport.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/WorkflowAndroidXSupport.kt
@@ -3,11 +3,15 @@ package com.squareup.workflow1.ui.androidx
 import android.content.Context
 import android.content.ContextWrapper
 import android.view.View
+import android.widget.FrameLayout
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.ViewTreeSavedStateRegistryOwner
+import com.squareup.workflow1.ui.Named
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.getRendering
 import kotlin.reflect.KClass
 import kotlin.reflect.cast
 
@@ -34,9 +38,53 @@ public object WorkflowAndroidXSupport {
    * is found in the view tree.
    */
   @WorkflowUiExperimentalApi
-  public fun stateRegistryOwnerFromViewTreeOrContext(view: View): SavedStateRegistryOwner? =
+  public fun requireStateRegistryOwnerFromViewTreeOrContext(view: View): SavedStateRegistryOwner =
+    checkNotNull(stateRegistryOwnerFromViewTreeOrContext(view)) {
+      "Expected to find a SavedStateRegistryOwner either in a parent view or the Context of this " +
+        javaClass.name
+    }
+
+  /**
+   * Tries to get the parent [SavedStateRegistryOwner] from the current view via
+   * [ViewTreeSavedStateRegistryOwner], if that fails it looks up the context chain for a registry
+   * owner, and if that fails it just returns null. This differs from
+   * [ViewTreeSavedStateRegistryOwner.get] because it will check the [View.getContext] if no owner
+   * is found in the view tree.
+   */
+  @WorkflowUiExperimentalApi
+  private fun stateRegistryOwnerFromViewTreeOrContext(view: View): SavedStateRegistryOwner? =
     ViewTreeSavedStateRegistryOwner.get(view)
       ?: view.context.ownerOrNull(SavedStateRegistryOwner::class)
+
+  /**
+   * Attempts to generate a unique key for the given [containerView] for registering the view on
+   * a [SavedStateRegistry].
+   *
+   * The [SavedStateRegistry] API involves defining string keys to associate with state bundles.
+   * These keys must be unique relative to the instance of the registry they are saved in. This
+   * function tries to satisfy that requirement by combining [containerView]'s fully-qualified class
+   * name with both its [view ID][View.getId] and the
+   * [compatibility key][com.squareup.workflow1.ui.Compatible.compatibilityKey] of its rendering.
+   * This method isn't guaranteed to give a unique key, but it should be good enough: If you need to
+   * nest multiple containers of the same type under the same [SavedStateRegistry], just wrap each
+   * container's rendering with a [Named] or give each container view a unique view ID.
+   *
+   * There's a potential issue here where if [containerView]'s ID is changed to something else, then
+   * another container is added with the old ID, the new container will overwrite the old one's
+   * state. Since they'd both be using the same key, [SavedStateRegistry] would throw an exception.
+   * However, as long as the first container is detached before its ID is changed this shouldn't be
+   * a problem.
+   */
+  @OptIn(WorkflowUiExperimentalApi::class)
+  public fun createStateRegistryKeyForContainer(containerView: View): String {
+    val namedKeyOrNull = run {
+      val rendering = containerView.getRendering<Any>() as? Named<*>
+      rendering?.compatibilityKey
+    }
+    val nameSuffix = namedKeyOrNull?.let { "-$it" } ?: ""
+    val idSuffix = if (containerView.id == FrameLayout.NO_ID) "" else "-${containerView.id}"
+    return containerView.javaClass.name + nameSuffix + idSuffix
+  }
 
   private tailrec fun <T : Any> Context.ownerOrNull(ownerClass: KClass<T>): T? =
     when {

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/androidx/StateRegistryAggregatorTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/androidx/StateRegistryAggregatorTest.kt
@@ -1,4 +1,4 @@
-package com.squareup.workflow1.ui.backstack
+package com.squareup.workflow1.ui.androidx
 
 import android.os.Bundle
 import androidx.lifecycle.Lifecycle
@@ -15,7 +15,7 @@ import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertFailsWith
 
 @RunWith(RobolectricTestRunner::class)
-class StateRegistryAggregatorTest {
+internal class StateRegistryAggregatorTest {
 
   @Test fun `attach stops observing previous parent when called multiple times without detach`() {
     val aggregator = StateRegistryAggregator(

--- a/workflow-ui/modal-android/api/modal-android.api
+++ b/workflow-ui/modal-android/api/modal-android.api
@@ -24,6 +24,8 @@ public abstract class com/squareup/workflow1/ui/modal/ModalContainer : android/w
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected abstract fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/modal/ModalContainer$DialogRef;
+	protected fun onAttachedToWindow ()V
+	protected fun onDetachedFromWindow ()V
 	protected fun onRestoreInstanceState (Landroid/os/Parcelable;)V
 	protected fun onSaveInstanceState ()Landroid/os/Parcelable;
 	protected final fun update (Lcom/squareup/workflow1/ui/modal/HasModals;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
@@ -33,19 +35,13 @@ public abstract class com/squareup/workflow1/ui/modal/ModalContainer : android/w
 protected final class com/squareup/workflow1/ui/modal/ModalContainer$DialogRef {
 	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/app/Dialog;Ljava/lang/Object;)V
 	public synthetic fun <init> (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/app/Dialog;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/Object;
-	public final fun component2 ()Lcom/squareup/workflow1/ui/ViewEnvironment;
-	public final fun component3 ()Landroid/app/Dialog;
-	public final fun component4 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/app/Dialog;Ljava/lang/Object;)Lcom/squareup/workflow1/ui/modal/ModalContainer$DialogRef;
-	public static synthetic fun copy$default (Lcom/squareup/workflow1/ui/modal/ModalContainer$DialogRef;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/app/Dialog;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/modal/ModalContainer$DialogRef;
+	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/modal/ModalContainer$DialogRef;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDialog ()Landroid/app/Dialog;
 	public final fun getExtra ()Ljava/lang/Object;
 	public final fun getModalRendering ()Ljava/lang/Object;
 	public final fun getViewEnvironment ()Lcom/squareup/workflow1/ui/ViewEnvironment;
 	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public class com/squareup/workflow1/ui/modal/ModalViewContainer : com/squareup/workflow1/ui/modal/ModalContainer {


### PR DESCRIPTION
This fixes #469, and also fixes #470.

TODO:
- [x] Tests
- [ ] Test internally
- [ ] New test for the `only after super.onCreate` crash called out below.