### PR TITLE
Exposes ViewEnvironment.withDefaults, makes WorkflowRendering() use it.

### DIFF
--- a/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
+++ b/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
@@ -21,18 +21,15 @@ import com.squareup.sample.gameworkflow.Player
 import com.squareup.sample.gameworkflow.symbol
 import com.squareup.sample.mainactivity.TicTacToeActivity
 import com.squareup.sample.tictactoe.R
-import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.environment
 import com.squareup.workflow1.ui.getRendering
-import com.squareup.workflow1.ui.internal.test.inAnyView
 import com.squareup.workflow1.ui.internal.test.actuallyPressBack
+import com.squareup.workflow1.ui.internal.test.inAnyView
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.concurrent.atomic.AtomicReference
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -68,8 +65,6 @@ class TicTacToeEspressoTest {
 
     inAnyView(withId(R.id.start_game)).perform(click())
 
-    val environment = AtomicReference<ViewEnvironment>()
-
     // Why should I learn how to write a matcher when I can just grab the activity
     // and work with it directly?
     scenario.onActivity { activity ->
@@ -77,9 +72,6 @@ class TicTacToeEspressoTest {
       val parent = button.parent as View
       val rendering = parent.getRendering<GamePlayScreen>()!!
       assertThat(rendering.gameState.playing).isSameInstanceAs(Player.X)
-      val firstEnv = parent.environment
-      assertThat(firstEnv).isNotNull()
-      environment.set(firstEnv)
 
       // Make a move.
       rendering.onClick(0, 0)
@@ -100,7 +92,6 @@ class TicTacToeEspressoTest {
       val parent = button.parent as View
       val rendering = parent.getRendering<GamePlayScreen>()!!
       assertThat(rendering.gameState.playing).isSameInstanceAs(Player.O)
-      assertThat(parent.environment).isEqualTo(environment.get())
     }
   }
 

--- a/workflow-ui/compose-tooling/src/androidTest/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewFactoryTest.kt
+++ b/workflow-ui/compose-tooling/src/androidTest/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewFactoryTest.kt
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @RunWith(AndroidJUnit4::class)
-class PreviewViewFactoryTest {
+internal class PreviewViewFactoryTest {
 
   @get:Rule val composeRule = createComposeRule()
 

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewFactoryTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewFactoryTest.kt
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @RunWith(AndroidJUnit4::class)
-class ComposeViewFactoryTest {
+internal class ComposeViewFactoryTest {
 
   @get:Rule val composeRule = createComposeRule()
 

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/WorkflowRenderingTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/WorkflowRenderingTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TestFunctionName")
+
 package com.squareup.workflow1.ui.compose
 
 import android.content.Context
@@ -59,6 +61,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.workflow1.ui.AndroidViewRendering
 import com.squareup.workflow1.ui.BuilderViewFactory
 import com.squareup.workflow1.ui.Compatible
+import com.squareup.workflow1.ui.Named
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewRegistry
@@ -73,7 +76,7 @@ import kotlin.reflect.KClass
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @RunWith(AndroidJUnit4::class)
-class WorkflowRenderingTest {
+internal class WorkflowRenderingTest {
 
   @Rule @JvmField val composeRule = createComposeRule()
 
@@ -142,28 +145,24 @@ class WorkflowRenderingTest {
   }
 
   @Test fun legacyAndroidViewRendersUpdates() {
-    data class LegacyViewRendering(val text: String) : AndroidViewRendering<LegacyViewRendering> {
-      override val viewFactory: ViewFactory<LegacyViewRendering> =
-        object : ViewFactory<LegacyViewRendering> {
-          override val type = LegacyViewRendering::class
-
-          override fun buildView(
-            initialRendering: LegacyViewRendering,
-            initialViewEnvironment: ViewEnvironment,
-            contextForNewView: Context,
-            container: ViewGroup?
-          ): View = TextView(contextForNewView).apply {
-            bindShowRendering(initialRendering, initialViewEnvironment) { rendering, _ ->
-              text = rendering.text
-            }
-          }
-        }
-    }
-
     val wrapperText = mutableStateOf("two")
 
     composeRule.setContent {
       WorkflowRendering(LegacyViewRendering(wrapperText.value), ViewEnvironment())
+    }
+
+    onView(withText("two")).check(matches(isDisplayed()))
+    wrapperText.value = "OWT"
+    onView(withText("OWT")).check(matches(isDisplayed()))
+  }
+
+  // https://github.com/square/workflow-kotlin/issues/538
+  @Test fun includesDefaultEnvironment() {
+    val wrapperText = mutableStateOf("two")
+
+    composeRule.setContent {
+      val rendering = Named(LegacyViewRendering(wrapperText.value), "fnord")
+      WorkflowRendering(rendering, ViewEnvironment())
     }
 
     onView(withText("two")).check(matches(isDisplayed()))
@@ -537,5 +536,25 @@ class WorkflowRenderingTest {
       }
 
     @Composable fun Content(viewEnvironment: ViewEnvironment)
+  }
+
+  private data class LegacyViewRendering(
+    val text: String
+    ) : AndroidViewRendering<LegacyViewRendering> {
+    override val viewFactory: ViewFactory<LegacyViewRendering> =
+      object : ViewFactory<LegacyViewRendering> {
+        override val type = LegacyViewRendering::class
+
+        override fun buildView(
+          initialRendering: LegacyViewRendering,
+          initialViewEnvironment: ViewEnvironment,
+          contextForNewView: Context,
+          container: ViewGroup?
+        ): View = TextView(contextForNewView).apply {
+          bindShowRendering(initialRendering, initialViewEnvironment) { rendering, _ ->
+            text = rendering.text
+          }
+        }
+      }
   }
 }

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/WorkflowRendering.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/WorkflowRendering.kt
@@ -1,3 +1,5 @@
+@file:Suppress("FunctionName")
+
 package com.squareup.workflow1.ui.compose
 
 import android.view.View
@@ -27,6 +29,7 @@ import com.squareup.workflow1.ui.WorkflowViewStub
 import com.squareup.workflow1.ui.getFactoryForRendering
 import com.squareup.workflow1.ui.getShowRendering
 import com.squareup.workflow1.ui.showRendering
+import com.squareup.workflow1.ui.withDefaults
 import kotlin.reflect.KClass
 
 /**
@@ -65,6 +68,8 @@ import kotlin.reflect.KClass
   viewEnvironment: ViewEnvironment,
   modifier: Modifier = Modifier
 ) {
+  val enhancedViewEnvironment = viewEnvironment.withDefaults()
+
   // This will fetch a new view factory any time the new rendering is incompatible with the previous
   // one, as determined by Compatible. This corresponds to WorkflowViewStub's canShowRendering
   // check.
@@ -82,7 +87,7 @@ import kotlin.reflect.KClass
       // intentionally don't ask it for a new instance every time to match the behavior of
       // WorkflowViewStub and other containers, which only ask for a new factory when the rendering is
       // incompatible.
-      viewEnvironment[ViewRegistry]
+      enhancedViewEnvironment[ViewRegistry]
         // Can't use ViewRegistry.buildView here since we need the factory to convert it to a
         // compose one.
         .getFactoryForRendering(rendering)
@@ -100,7 +105,7 @@ import kotlin.reflect.KClass
       // into this function is to directly control the layout of the child view – which means
       // minimum constraints are likely to be significant.
       Box(modifier, propagateMinConstraints = true) {
-        viewFactory.Content(rendering, viewEnvironment)
+        viewFactory.Content(rendering, enhancedViewEnvironment)
       }
     }
   }
@@ -132,7 +137,7 @@ import kotlin.reflect.KClass
 
       // If we're leaving the composition it means the WorkflowRendering is either going away itself
       // or about to switch to an incompatible rendering – either way, this lifecycle is dead. Note
-      // that we can't transition from INITIALIZED to DESTROYED – the LifecycelRegistry will throw.
+      // that we can't transition from INITIALIZED to DESTROYED – the LifecycleRegistry will throw.
       // WorkflowLifecycleOwner has this same check.
       if (lifecycleOwner.registry.currentState != INITIALIZED) {
         lifecycleOwner.registry.currentState = DESTROYED

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -104,6 +104,10 @@ public abstract class com/squareup/workflow1/ui/ViewEnvironmentKey {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/squareup/workflow1/ui/ViewEnvironmentKt {
+	public static final fun withDefaults (Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/ViewEnvironment;
+}
+
 public abstract interface class com/squareup/workflow1/ui/ViewFactory {
 	public abstract fun buildView (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public abstract fun getType ()Lkotlin/reflect/KClass;

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewEnvironment.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewEnvironment.kt
@@ -51,3 +51,17 @@ public abstract class ViewEnvironmentKey<T : Any>(
     return "ViewEnvironmentKey($type)-${super.toString()}"
   }
 }
+
+/**
+ * Meant for use by root containers, returns a [ViewEnvironment] that includes everything
+ * from the receiver, plus requirements for the workflow UI runtime. The standard containers
+ * have this call built in, it is unlikely to be needed in application code.
+ */
+@WorkflowUiExperimentalApi
+public fun ViewEnvironment.withDefaults(): ViewEnvironment {
+  return if (Named::class in this[ViewRegistry].keys) {
+    this
+  } else {
+    this + (ViewRegistry to (this[ViewRegistry] + ViewRegistry(NamedViewFactory)))
+  }
+}

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
@@ -8,12 +8,6 @@ import android.view.ViewGroup
 import kotlin.reflect.KClass
 
 /**
- * [ViewFactory]s that are always available.
- */
-@WorkflowUiExperimentalApi
-internal val defaultViewFactories = ViewRegistry(NamedViewFactory)
-
-/**
  * The [ViewEnvironment] service that can be used to display the stream of renderings
  * from a workflow tree as [View] instances. This is the engine behind [AndroidViewRendering],
  * [WorkflowViewStub] and [ViewFactory]. Most apps can ignore [ViewRegistry] as an implementation

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
@@ -64,12 +64,8 @@ public class WorkflowLayout(
     renderings: Flow<Any>,
     environment: ViewEnvironment = ViewEnvironment()
   ) {
-    val envWithDefaults = environment.withDefaultViewFactories()
-    takeWhileAttached(renderings) { show(it, envWithDefaults) }
+    takeWhileAttached(renderings) { show(it, environment) }
   }
-
-  private fun ViewEnvironment.withDefaultViewFactories(): ViewEnvironment =
-    this + (ViewRegistry to (this[ViewRegistry] + defaultViewFactories))
 
   private fun show(
     newRendering: Any,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
@@ -196,9 +196,10 @@ public class WorkflowViewStub @JvmOverloads constructor(
     rendering: Any,
     viewEnvironment: ViewEnvironment
   ): View {
+    val enrichedViewEnvironment = viewEnvironment.withDefaults()
     actual.takeIf { it.canShowRendering(rendering) }
       ?.let {
-        it.showRendering(rendering, viewEnvironment)
+        it.showRendering(rendering, enrichedViewEnvironment)
         return it
       }
 
@@ -219,10 +220,10 @@ public class WorkflowViewStub @JvmOverloads constructor(
       WorkflowLifecycleOwner.get(actual)?.destroyOnDetach()
     }
 
-    return viewEnvironment[ViewRegistry]
+    return enrichedViewEnvironment[ViewRegistry]
       .buildView(
         rendering,
-        viewEnvironment,
+        enrichedViewEnvironment,
         parent.context,
         parent,
         initializeView = {

--- a/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity.kt
+++ b/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity.kt
@@ -10,14 +10,12 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewTreeLifecycleOwner
 import com.squareup.workflow1.ui.BuilderViewFactory
-import com.squareup.workflow1.ui.NamedViewFactory
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.WorkflowViewStub
 import com.squareup.workflow1.ui.bindShowRendering
-import com.squareup.workflow1.ui.plus
 import kotlin.reflect.KClass
 
 /**
@@ -56,7 +54,7 @@ public abstract class AbstractLifecycleTestActivity : WorkflowUiTestActivity() {
     // This will override WorkflowUiTestActivity's retention of the environment across config
     // changes. This is intentional, since our ViewRegistry probably contains a leafBinding which
     // captures the events list.
-    viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry + NamedViewFactory))
+    viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
   }
 
   override fun onStart() {


### PR DESCRIPTION
Ensures that `Named` works in compose based apps, and makes the need for
containers to do this kind of thing a bit more explicit.

Also moves the existing defaults swizzle from `WorkflowLayout` to
`WorkflowViewStub`, one step closer to getting rid of the former.

Fixes #538