### PR TITLE
Builds in NamedViewFactory properly.

### DIFF
--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -27,7 +27,6 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.workflow1.ui.AndroidViewRendering
 import com.squareup.workflow1.ui.Compatible
 import com.squareup.workflow1.ui.Named
-import com.squareup.workflow1.ui.NamedViewFactory
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewRegistry
@@ -55,7 +54,6 @@ internal class ComposeViewTreeIntegrationTest {
           ViewRegistry to ViewRegistry(
             ModalViewContainer.binding<TestModalScreen>(),
             NoTransitionBackStackContainer,
-            NamedViewFactory,
           )
         )
       )

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -51,13 +51,6 @@ public final class com/squareup/workflow1/ui/LayoutRunnerViewFactory : com/squar
 	public fun getType ()Lkotlin/reflect/KClass;
 }
 
-public final class com/squareup/workflow1/ui/NamedViewFactory : com/squareup/workflow1/ui/ViewFactory {
-	public static final field INSTANCE Lcom/squareup/workflow1/ui/NamedViewFactory;
-	public fun buildView (Lcom/squareup/workflow1/ui/Named;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
-	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
-	public fun getType ()Lkotlin/reflect/KClass;
-}
-
 public final class com/squareup/workflow1/ui/ShowRenderingTag {
 	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)V
 	public final fun component1 ()Ljava/lang/Object;

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/NamedViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/NamedViewFactory.kt
@@ -5,5 +5,5 @@ package com.squareup.workflow1.ui
  * to the factory for [Named.wrapped].
  */
 @WorkflowUiExperimentalApi
-public object NamedViewFactory : ViewFactory<Named<*>>
+internal object NamedViewFactory : ViewFactory<Named<*>>
 by DecorativeViewFactory(Named::class, { named -> named.wrapped })

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
@@ -8,12 +8,6 @@ import android.view.ViewGroup
 import kotlin.reflect.KClass
 
 /**
- * [ViewFactory]s that are always available.
- */
-@WorkflowUiExperimentalApi
-internal val defaultViewFactories = ViewRegistry(NamedViewFactory)
-
-/**
  * The [ViewEnvironment] service that can be used to display the stream of renderings
  * from a workflow tree as [View] instances. This is the engine behind [AndroidViewRendering],
  * [WorkflowViewStub] and [ViewFactory]. Most apps can ignore [ViewRegistry] as an implementation
@@ -137,6 +131,7 @@ public fun <RenderingT : Any>
   @Suppress("UNCHECKED_CAST")
   return getFactoryFor(rendering::class)
     ?: (rendering as? AndroidViewRendering<*>)?.viewFactory as? ViewFactory<RenderingT>
+    ?: (rendering as? Named<*>)?.let { NamedViewFactory as ViewFactory<RenderingT> }
     ?: throw IllegalArgumentException(
       "A ${ViewFactory::class.qualifiedName} should have been registered to display " +
         "${rendering::class.qualifiedName} instances, or that class should implement " +

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
@@ -64,12 +64,8 @@ public class WorkflowLayout(
     renderings: Flow<Any>,
     environment: ViewEnvironment = ViewEnvironment()
   ) {
-    val envWithDefaults = environment.withDefaultViewFactories()
-    takeWhileAttached(renderings) { show(it, envWithDefaults) }
+    takeWhileAttached(renderings) { show(it, environment) }
   }
-
-  private fun ViewEnvironment.withDefaultViewFactories(): ViewEnvironment =
-    this + (ViewRegistry to (this[ViewRegistry] + defaultViewFactories))
 
   private fun show(
     newRendering: Any,

--- a/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity.kt
+++ b/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity.kt
@@ -10,14 +10,12 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewTreeLifecycleOwner
 import com.squareup.workflow1.ui.BuilderViewFactory
-import com.squareup.workflow1.ui.NamedViewFactory
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.WorkflowViewStub
 import com.squareup.workflow1.ui.bindShowRendering
-import com.squareup.workflow1.ui.plus
 import kotlin.reflect.KClass
 
 /**
@@ -56,7 +54,7 @@ public abstract class AbstractLifecycleTestActivity : WorkflowUiTestActivity() {
     // This will override WorkflowUiTestActivity's retention of the environment across config
     // changes. This is intentional, since our ViewRegistry probably contains a leafBinding which
     // captures the events list.
-    viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry + NamedViewFactory))
+    viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
   }
 
   override fun onStart() {


### PR DESCRIPTION
`ViewRegistry.defaultViewFactories` has never worked very well, and it
completely failed `WorkflowRendering()`. We get rid of it, and instead ensure
that `NamedViewFactory` is always available via the same hook that makes
`AndroidViewRendering` work.

Fixes #538