### PR TITLE
Introduces Wrapper

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.squareup.workflow1
-VERSION_NAME=1.0.0-rc3-SNAPSHOT
+VERSION_NAME=1.0.0-rc3ray1-SNAPSHOT
 
 POM_DESCRIPTION=Reactive workflows
 

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/BackButtonScreen.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/BackButtonScreen.kt
@@ -7,7 +7,7 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
  * the wrapped rendering's own back button handler.
  *
  * @param override If `true`, [onBackPressed] is set as the
- * [backPressedHandler][android.view.View.backPressedHandler] after
+ * [backPressedHandler][com.squareup.workflow1.ui.backPressedHandler] after
  * the [wrapped] rendering's view is built / updated. If false, ours
  * is set afterward, to allow the wrapped rendering to take precedence.
  * Defaults to `false`.

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/panel/PanelContainer.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/panel/PanelContainer.kt
@@ -65,7 +65,7 @@ class PanelContainer @JvmOverloads constructor(
         PanelContainer(contextForNewView).apply {
           id = R.id.panel_container
           layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
-          bindShowRendering(initialRendering, initialEnv, ::update)
+          bindShowRendering(::update)
         }
       }
   )

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/panel/ScrimContainer.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/panel/ScrimContainer.kt
@@ -101,9 +101,7 @@ class ScrimContainer @JvmOverloads constructor(
               layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
               addView(stub)
 
-              bindShowRendering(
-                  initialRendering, initialViewEnvironment
-              ) { rendering, environment ->
+              bindShowRendering() { rendering, environment ->
                 stub.update(rendering.wrapped, environment)
                 isDimmed = rendering.dimmed
               }

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardView.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardView.kt
@@ -87,6 +87,6 @@ class BoardView(context: Context) : View(context) {
       type = Board::class,
       viewConstructor = { initialRendering, initialEnv, contextForNewView, _ ->
         BoardView(contextForNewView)
-            .apply { bindShowRendering(initialRendering, initialEnv) { r, _ -> update(r) } }
+            .apply { bindShowRendering() { r, _ -> update(r) } }
       })
 }

--- a/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/ClickyTextRendering.kt
+++ b/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/ClickyTextRendering.kt
@@ -26,7 +26,7 @@ data class ClickyTextRendering(
         textView.layoutParams = LayoutParams(MATCH_PARENT, MATCH_PARENT)
         textView.gravity = CENTER
 
-        textView.bindShowRendering(initialRendering, initialEnv) { clickyText, _ ->
+        textView.bindShowRendering() { clickyText, _ ->
           textView.text = clickyText.message
           textView.isVisible = clickyText.visible
           textView.setOnClickListener(

--- a/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/ViewStateCacheTest.kt
+++ b/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/ViewStateCacheTest.kt
@@ -105,7 +105,7 @@ internal class ViewStateCacheTest {
     val firstViewRestored = ViewStateTestView(instrumentation.context).apply {
       id = 2
       WorkflowLifecycleOwner.installOn(this)
-      bindShowRendering(firstRendering, viewEnvironment) { _, _ -> /* Noop */ }
+      bindShowRendering() { _, _ -> /* Noop */ }
     }
     cache.update(listOf(firstRendering), oldViewMaybe = secondView, newView = firstViewRestored)
 
@@ -171,7 +171,7 @@ internal class ViewStateCacheTest {
   ) = ViewStateTestView(instrumentation.context).also { view ->
     id?.let { view.id = id }
     WorkflowLifecycleOwner.installOn(view)
-    view.bindShowRendering(firstRendering, viewEnvironment) { _, _ -> /* Noop */ }
+    view.bindShowRendering() { _, _ -> /* Noop */ }
   }
 
   private fun ViewStateCache.equalsForTest(other: ViewStateCache): Boolean {

--- a/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/fixtures/BackStackContainerLifecycleActivity.kt
+++ b/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/fixtures/BackStackContainerLifecycleActivity.kt
@@ -39,7 +39,7 @@ internal class BackStackContainerLifecycleActivity : AbstractLifecycleTestActivi
       contextForNewView: Context,
       container: ViewGroup?
     ): View = View(contextForNewView).apply {
-      bindShowRendering(initialRendering, initialViewEnvironment) { _, _ -> /* Noop */ }
+      bindShowRendering() { _, _ -> /* Noop */ }
     }
   }
 
@@ -114,10 +114,7 @@ internal class BackStackContainerLifecycleActivity : AbstractLifecycleTestActivi
       FrameLayout(contextForNewView).also { container ->
         val stub = WorkflowViewStub(contextForNewView)
         container.addView(stub)
-        container.bindShowRendering(
-          initialRendering,
-          initialViewEnvironment
-        ) { rendering, env ->
+        container.bindShowRendering() { rendering, env ->
           stub.update(rendering.wrappedBackstack.toBackstackWithBase(), env)
         }
       }

--- a/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/fixtures/NoTransitionBackStackContainer.kt
+++ b/workflow-ui/backstack-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/fixtures/NoTransitionBackStackContainer.kt
@@ -31,7 +31,7 @@ internal class NoTransitionBackStackContainer(context: Context) : BackStackConta
         .apply {
           id = R.id.workflow_back_stack_container
           layoutParams = LayoutParams(MATCH_PARENT, MATCH_PARENT)
-          bindShowRendering(initialRendering, initialEnv, ::update)
+          bindShowRendering(::update)
         }
     }
   )

--- a/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
+++ b/workflow-ui/backstack-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
@@ -100,7 +100,7 @@ public open class BackStackContainer @JvmOverloads constructor(
       container = this,
       initializeView = {
         WorkflowLifecycleOwner.installOn(this)
-        showFirstRendering()
+        showRendering(named.top, environment)
       }
     )
     viewStateCache.update(named.backStack, oldViewMaybe, newView)
@@ -211,12 +211,12 @@ public open class BackStackContainer @JvmOverloads constructor(
   public companion object : ViewFactory<BackStackScreen<*>>
   by BuilderViewFactory(
     type = BackStackScreen::class,
-    viewConstructor = { initialRendering, initialEnv, context, _ ->
+    viewConstructor = { _, _, context, _ ->
       BackStackContainer(context)
         .apply {
           id = R.id.workflow_back_stack_container
           layoutParams = (ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
-          bindShowRendering(initialRendering, initialEnv, ::update)
+          bindShowRendering(::update)
         }
     }
   )

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -467,7 +467,7 @@ internal class ComposeViewTreeIntegrationTest {
       return ComposeView(contextForNewView).apply {
         lastCompositionStrategy?.let(::setViewCompositionStrategy)
 
-        bindShowRendering(initialRendering, initialViewEnvironment) { rendering, _ ->
+        bindShowRendering() { rendering, _ ->
           if (rendering.disposeStrategy != lastCompositionStrategy) {
             lastCompositionStrategy = rendering.disposeStrategy
             lastCompositionStrategy?.let(::setViewCompositionStrategy)

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/NoTransitionBackStackContainer.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/NoTransitionBackStackContainer.kt
@@ -33,7 +33,7 @@ internal class NoTransitionBackStackContainer(context: Context) : BackStackConta
         .apply {
           id = R.id.workflow_back_stack_container
           layoutParams = LayoutParams(MATCH_PARENT, MATCH_PARENT)
-          bindShowRendering(initialRendering, initialEnv, ::update)
+          bindShowRendering(::update)
         }
     }
   )

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/WorkflowRenderingTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/WorkflowRenderingTest.kt
@@ -218,7 +218,7 @@ internal class WorkflowRenderingTest {
       ) { initialRendering, initialViewEnvironment, contextForNewView, _ ->
         object : View(contextForNewView) {
           init {
-            bindShowRendering(initialRendering, initialViewEnvironment) { _, _ -> }
+            bindShowRendering() { _, _ -> }
           }
 
           override fun onAttachedToWindow() {
@@ -369,7 +369,7 @@ internal class WorkflowRenderingTest {
       ) { initialRendering, initialViewEnvironment, contextForNewView, _ ->
         object : View(contextForNewView) {
           init {
-            bindShowRendering(initialRendering, initialViewEnvironment) { r, _ ->
+            bindShowRendering() { r, _ ->
               id = r.viewId
             }
           }
@@ -551,7 +551,7 @@ internal class WorkflowRenderingTest {
           contextForNewView: Context,
           container: ViewGroup?
         ): View = TextView(contextForNewView).apply {
-          bindShowRendering(initialRendering, initialViewEnvironment) { rendering, _ ->
+          bindShowRendering() { rendering, _ ->
             text = rendering.text
           }
         }

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeViewFactory.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeViewFactory.kt
@@ -129,10 +129,7 @@ public abstract class ComposeViewFactory<RenderingT : Any> : ViewFactory<Renderi
   ): View = ComposeView(contextForNewView).also { composeView ->
     // Update the state whenever a new rendering is emitted.
     // This lambda will be executed synchronously before bindShowRendering returns.
-    composeView.bindShowRendering(
-      initialRendering,
-      initialViewEnvironment
-    ) { rendering, environment ->
+    composeView.bindShowRendering() { rendering, environment ->
       // Entry point to the world of Compose.
       composeView.setContent {
         Content(rendering, environment)

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/DecorativeViewFactoryTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/DecorativeViewFactoryTest.kt
@@ -22,7 +22,7 @@ internal class DecorativeViewFactoryTest {
         contextForNewView: Context,
         container: ViewGroup?
       ): View = InnerView(contextForNewView).apply {
-        bindShowRendering(initialRendering, initialViewEnvironment) { rendering, _ ->
+        bindShowRendering() { rendering, _ ->
           events += "inner showRendering $rendering"
         }
       }
@@ -73,7 +73,7 @@ internal class DecorativeViewFactoryTest {
         contextForNewView: Context,
         container: ViewGroup?
       ): View = InnerView(contextForNewView).apply {
-        bindShowRendering(initialRendering, initialViewEnvironment) { rendering, _ ->
+        bindShowRendering() { rendering, _ ->
           events += "inner showRendering $rendering"
         }
       }
@@ -112,7 +112,7 @@ internal class DecorativeViewFactoryTest {
         contextForNewView: Context,
         container: ViewGroup?
       ): View = InnerView(contextForNewView).apply {
-        bindShowRendering(initialRendering, initialViewEnvironment) { rendering, _ ->
+        bindShowRendering() { rendering, _ ->
           events += "inner showRendering $rendering"
         }
       }

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/WorkflowViewStubLifecycleActivity.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/WorkflowViewStubLifecycleActivity.kt
@@ -26,10 +26,7 @@ internal class WorkflowViewStubLifecycleActivity : AbstractLifecycleTestActivity
       FrameLayout(contextForNewView).also { container ->
         val stub = WorkflowViewStub(contextForNewView)
         container.addView(stub)
-        container.bindShowRendering(
-          initialRendering,
-          initialViewEnvironment
-        ) { rendering, env ->
+        container.bindShowRendering() { rendering, env ->
           stub.update(rendering.wrapped, env)
         }
       }

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/WorkflowViewStubLifecycleTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/WorkflowViewStubLifecycleTest.kt
@@ -264,7 +264,7 @@ internal class WorkflowViewStubLifecycleTest {
         FrameLayout(context).apply {
           addView(stub)
 
-          bindShowRendering(initialRendering, initialViewEnvironment) { r, e ->
+          bindShowRendering() { r, e ->
             stub.update(r.wrapped, e)
           }
         }
@@ -349,7 +349,7 @@ internal class WorkflowViewStubLifecycleTest {
           updateText()
         }
 
-        bindShowRendering(initialRendering, initialViewEnvironment) { _, _ ->
+        bindShowRendering() { _, _ ->
           // Noop
         }
       }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunnerViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunnerViewFactory.kt
@@ -28,7 +28,7 @@ internal class LayoutRunnerViewFactory<RenderingT : Any>(
       .inflate(layoutId, container, false)
       .also { view ->
         val runner = runnerConstructor(view)
-        view.bindShowRendering(initialRendering, initialViewEnvironment) { rendering, environment ->
+        view.bindShowRendering() { rendering, environment ->
           runner.showRendering(rendering, environment)
         }
       }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/NamedViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/NamedViewFactory.kt
@@ -1,9 +1,0 @@
-package com.squareup.workflow1.ui
-
-/**
- * [ViewFactory] that allows views to display instances of [Named]. Delegates
- * to the factory for [Named.wrapped].
- */
-@WorkflowUiExperimentalApi
-internal object NamedViewFactory : ViewFactory<Named<*>>
-by DecorativeViewFactory(Named::class, { named -> named.wrapped })

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewBindingViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewBindingViewFactory.kt
@@ -22,10 +22,7 @@ internal class ViewBindingViewFactory<BindingT : ViewBinding, RenderingT : Any>(
     bindingInflater(contextForNewView.viewBindingLayoutInflater(container), container, false)
       .also { binding ->
         val runner = runnerConstructor(binding)
-        binding.root.bindShowRendering(
-          initialRendering,
-          initialViewEnvironment
-        ) { rendering, environment ->
+        binding.root.bindShowRendering() { rendering, environment ->
           runner.showRendering(rendering, environment)
         }
       }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
@@ -128,10 +128,10 @@ public fun ViewRegistry(): ViewRegistry = TypedViewRegistry()
 @WorkflowUiExperimentalApi
 public fun <RenderingT : Any>
   ViewRegistry.getFactoryForRendering(rendering: RenderingT): ViewFactory<RenderingT> {
+  val unwrapped = unwrap(rendering)
   @Suppress("UNCHECKED_CAST")
-  return getFactoryFor(rendering::class)
-    ?: (rendering as? AndroidViewRendering<*>)?.viewFactory as? ViewFactory<RenderingT>
-    ?: (rendering as? Named<*>)?.let { NamedViewFactory as ViewFactory<RenderingT> }
+  return getFactoryFor(unwrapped::class)
+    ?: (unwrapped as? AndroidViewRendering<*>)?.viewFactory as? ViewFactory<RenderingT>
     ?: throw IllegalArgumentException(
       "A ${ViewFactory::class.qualifiedName} should have been registered to display " +
         "${rendering::class.qualifiedName} instances, or that class should implement " +

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
@@ -3,7 +3,7 @@ package com.squareup.workflow1.ui
 import android.view.View
 
 /**
- * Function attached to a view created by [ViewFactory], to allow it
+ * Function attached to a view created by [ViewRegistry.buildView], to allow the view
  * to respond to [View.showRendering].
  */
 @WorkflowUiExperimentalApi
@@ -11,17 +11,16 @@ public typealias ViewShowRendering<RenderingT> =
   (@UnsafeVariance RenderingT, ViewEnvironment) -> Unit
 
 /**
-` * View tag that holds the function to make the view show instances of [RenderingT], and
- * the [current rendering][showing].
+ * View tag that holds the [current rendering][showing] and [ViewEnvironment][environment].
  *
  * @param showing the current rendering. Used by [canShowRendering] to decide if the
  * view can be updated with the next rendering.
  */
 @WorkflowUiExperimentalApi
-public data class ShowRenderingTag<out RenderingT : Any>(
+@PublishedApi
+internal data class ShowingTag<out RenderingT : Any>(
   val showing: RenderingT,
-  val environment: ViewEnvironment,
-  val showRendering: ViewShowRendering<RenderingT>
+  val environment: ViewEnvironment
 )
 
 /**
@@ -34,14 +33,10 @@ public data class ShowRenderingTag<out RenderingT : Any>(
  * @see DecorativeViewFactory
  */
 @WorkflowUiExperimentalApi
-public fun <RenderingT : Any> View.bindShowRendering(
-  initialRendering: RenderingT,
-  initialViewEnvironment: ViewEnvironment,
-  showRendering: ViewShowRendering<RenderingT>
-) {
+public fun <RenderingT : Any> View.bindShowRendering(showRendering: ViewShowRendering<RenderingT>) {
   setTag(
     R.id.view_show_rendering_function,
-    ShowRenderingTag(initialRendering, initialViewEnvironment, showRendering)
+    showRendering
   )
 }
 
@@ -68,23 +63,23 @@ public fun View.canShowRendering(rendering: Any): Boolean {
  * @throws IllegalStateException if [bindShowRendering] has not been called.
  */
 @WorkflowUiExperimentalApi
-public fun <RenderingT : Any> View.showRendering(
-  rendering: RenderingT,
+public fun View.showRendering(
+  rendering: Any,
   viewEnvironment: ViewEnvironment
 ) {
-  showRenderingTag
-    ?.let { tag ->
-      check(tag.showing.matches(rendering)) {
-        "Expected $this to be able to show rendering $rendering, but that did not match " +
-          "previous rendering ${tag.showing}. " +
-          "Consider using ${WorkflowViewStub::class.java.simpleName} to display arbitrary types."
-      }
-
-      // Update the tag's rendering and viewEnvironment.
-      bindShowRendering(rendering, viewEnvironment, tag.showRendering)
-      // And do the actual showRendering work.
-      tag.showRendering.invoke(unwrap(rendering), viewEnvironment)
+  showingTag?.let { tag ->
+    check(unwrap(tag.showing).matches(unwrap(rendering))) {
+      "Expected $this to be able to show rendering $rendering, but that did not match " +
+        "previous rendering ${tag.showing}. " +
+        "Consider using ${WorkflowViewStub::class.java.simpleName} to display arbitrary types."
     }
+  }
+
+  // Update the tag's rendering and viewEnvironment.
+  setTag(R.id.view_showing, ShowingTag(rendering, viewEnvironment))
+
+  getShowRendering()
+    ?.invoke(unwrap(rendering), viewEnvironment)
     ?: error(
       "Expected $this to have a showRendering function to show $rendering. " +
         "Perhaps it was not built by a ${ViewFactory::class.java.simpleName}, " +
@@ -93,44 +88,43 @@ public fun <RenderingT : Any> View.showRendering(
 }
 
 /**
- * Returns the most recent rendering shown by this view, or null if [bindShowRendering]
+ * Returns the most recent rendering shown by this view, or null if [showRendering]
  * has never been called.
  */
 @WorkflowUiExperimentalApi
-public fun <RenderingT : Any> View.getRendering(): RenderingT? {
-  // Can't use a val because of the parameter type.
-  @Suppress("UNCHECKED_CAST")
-  return when (val showing = showRenderingTag?.showing) {
+public inline fun <reified RenderingT : Any> View.getRendering(): RenderingT? {
+  return when (val showing = showingTag?.showing) {
     null -> null
     else -> showing as RenderingT
   }
 }
 
 /**
- * Returns the most recent [ViewEnvironment] that apply to this view, or null if [bindShowRendering]
+ * Returns the most recent [ViewEnvironment] that applies to this view, or null if [showRendering]
  * has never been called.
  */
 @WorkflowUiExperimentalApi
 public val View.environment: ViewEnvironment?
-  get() = showRenderingTag?.environment
+  get() = showingTag?.environment
 
 /**
  * Returns the function set by the most recent call to [bindShowRendering], or null
  * if that method has never been called.
  */
 @WorkflowUiExperimentalApi
-public fun <RenderingT : Any> View.getShowRendering(): ViewShowRendering<RenderingT>? {
-  return showRenderingTag?.showRendering
+public fun View.getShowRendering(): ViewShowRendering<Any>? {
+  @Suppress("UNCHECKED_CAST")
+  return getTag(R.id.view_show_rendering_function) as? ViewShowRendering<Any>
 }
 
 /**
- * Returns the [ShowRenderingTag] established by the last call to [View.bindShowRendering],
+ * Returns the [ShowingTag] established by the last call to [View.showRendering],
  * or null if that method has never been called.
  */
 @WorkflowUiExperimentalApi
 @PublishedApi
-internal val View.showRenderingTag: ShowRenderingTag<*>?
-  get() = getTag(R.id.view_show_rendering_function) as? ShowRenderingTag<*>
+internal val View.showingTag: ShowingTag<*>?
+  get() = getTag(R.id.view_showing) as? ShowingTag<*>
 
 @WorkflowUiExperimentalApi
 private fun Any.matches(other: Any) = compatible(this, other)

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
@@ -83,7 +83,7 @@ public fun <RenderingT : Any> View.showRendering(
       // Update the tag's rendering and viewEnvironment.
       bindShowRendering(rendering, viewEnvironment, tag.showRendering)
       // And do the actual showRendering work.
-      tag.showRendering.invoke(rendering, viewEnvironment)
+      tag.showRendering.invoke(unwrap(rendering), viewEnvironment)
     }
     ?: error(
       "Expected $this to have a showRendering function to show $rendering. " +

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
@@ -227,7 +227,7 @@ public class WorkflowViewStub @JvmOverloads constructor(
         parent,
         initializeView = {
           WorkflowLifecycleOwner.installOn(this)
-          showFirstRendering()
+          showRendering(rendering, viewEnvironment)
         }
       )
       .also { newView ->

--- a/workflow-ui/core-android/src/main/res/values/ids.xml
+++ b/workflow-ui/core-android/src/main/res/values/ids.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <!--
+  View Tag that holds the the current rendering and ViewEnvironment in a view created
+  via ViewRegistry.
+  -->
+  <item type="id" name="view_showing"/>
   <!-- View Tag that holds the function to update a view created via ViewRegistry. -->
   <item type="id" name="view_show_rendering_function"/>
   <!-- View Tag used for back button handlers. -->

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/TestViewFactory.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/TestViewFactory.kt
@@ -9,11 +9,11 @@ import com.nhaarman.mockito_kotlin.mock
 import kotlin.reflect.KClass
 
 @OptIn(WorkflowUiExperimentalApi::class)
-fun <R : Any> ViewRegistry.buildView(rendering: R): View =
+internal fun <R : Any> ViewRegistry.buildView(rendering: R): View =
   buildView(rendering, ViewEnvironment(mapOf(ViewRegistry to this)), mock<Context>())
 
 @OptIn(WorkflowUiExperimentalApi::class)
-class TestViewFactory<R : Any>(override val type: KClass<R>) : ViewFactory<R> {
+internal class TestViewFactory<R : Any>(override val type: KClass<R>) : ViewFactory<R> {
   var called = false
 
   override fun buildView(

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/TestViewFactory.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/TestViewFactory.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KClass
 
 @OptIn(WorkflowUiExperimentalApi::class)
 internal fun <R : Any> ViewRegistry.buildView(rendering: R): View =
-  buildView(rendering, ViewEnvironment(mapOf(ViewRegistry to this)), mock<Context>())
+  buildView(rendering, ViewEnvironment(mapOf(ViewRegistry to this)), mock())
 
 @OptIn(WorkflowUiExperimentalApi::class)
 internal class TestViewFactory<R : Any>(override val type: KClass<R>) : ViewFactory<R> {
@@ -26,7 +26,11 @@ internal class TestViewFactory<R : Any>(override val type: KClass<R>) : ViewFact
     return mock {
       on {
         getTag(eq(com.squareup.workflow1.ui.R.id.view_show_rendering_function))
-      } doReturn (ShowRenderingTag(initialRendering, initialViewEnvironment, { _, _ -> }))
+      } doReturn ( { _: Any, _: ViewEnvironment -> })
+
+      on {
+        getTag(eq(com.squareup.workflow1.ui.R.id.view_showing))
+      } doReturn ShowingTag(initialRendering, initialViewEnvironment)
     }
   }
 }

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ViewRegistryTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ViewRegistryTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.assertFailsWith
 @OptIn(WorkflowUiExperimentalApi::class)
 internal class ViewRegistryTest {
 
-  @OptIn(WorkflowUiExperimentalApi::class)
   @Test fun missingBindingMessage_isUseful() {
     val emptyReg = object : ViewRegistry {
       override val keys: Set<KClass<*>> = emptySet()
@@ -22,6 +21,48 @@ internal class ViewRegistryTest {
     }
     assertThat(error.message).isEqualTo(
       "A com.squareup.workflow1.ui.ViewFactory should have been registered to display " +
-        "kotlin.String instances, or that class should implement AndroidViewRendering<String>.")
+        "kotlin.String instances, or that class should implement AndroidViewRendering<String>."
+    )
   }
+
+  @Test fun simpleGetWorks() {
+    val reg = ViewRegistry(fooFactory)
+    assertThat(reg.getFactoryForRendering(Foo)).isSameInstanceAs(fooFactory)
+  }
+
+  @Test fun androidViewRenderingWorks() {
+    assertThat(ViewRegistry().getFactoryForRendering(AndroidFoo))
+      .isSameInstanceAs(AndroidFooFactory)
+  }
+
+  @Test fun wrappingWorks() {
+    val reg = ViewRegistry(fooFactory)
+    val wrapped = SimplestWrapper(SimplestWrapper(SimplestWrapper(Foo)))
+    assertThat(reg.getFactoryForRendering(wrapped)).isSameInstanceAs(fooFactory)
+  }
+
+  @Test fun canWrapAndroidViewRendering() {
+    assertThat(ViewRegistry().getFactoryForRendering(Named(AndroidFoo, "Bar")))
+      .isSameInstanceAs(AndroidFooFactory)
+  }
+
+  private object Foo
+
+  private val fooFactory = BuilderViewFactory(
+    type = Foo::class,
+    viewConstructor = { _, _, _, _ -> error("nope") }
+  )
+
+  private object AndroidFoo : AndroidViewRendering<AndroidFoo> {
+    override val viewFactory = AndroidFooFactory
+  }
+
+  object AndroidFooFactory : ViewFactory<AndroidFoo> by BuilderViewFactory(
+    type = AndroidFoo::class,
+    viewConstructor = { _, _, _, _ -> error("still nope") }
+  )
+
+  private class SimplestWrapper<W : Any>(
+    override val wrapped: W
+  ) : Wrapper<W>
 }

--- a/workflow-ui/core-common/api/core-common.api
+++ b/workflow-ui/core-common/api/core-common.api
@@ -12,7 +12,7 @@ public final class com/squareup/workflow1/ui/CompatibleKt {
 	public static final fun compatible (Ljava/lang/Object;Ljava/lang/Object;)Z
 }
 
-public final class com/squareup/workflow1/ui/Named : com/squareup/workflow1/ui/Compatible {
+public final class com/squareup/workflow1/ui/Named : com/squareup/workflow1/ui/Wrapper {
 	public fun <init> (Ljava/lang/Object;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/Object;
 	public final fun component2 ()Ljava/lang/String;
@@ -21,11 +21,25 @@ public final class com/squareup/workflow1/ui/Named : com/squareup/workflow1/ui/C
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCompatibilityKey ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getWrapped ()Ljava/lang/Object;
+	public fun getWrapped ()Ljava/lang/Object;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface annotation class com/squareup/workflow1/ui/WorkflowUiExperimentalApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface class com/squareup/workflow1/ui/Wrapper : com/squareup/workflow1/ui/Compatible {
+	public abstract fun getCompatibilityKey ()Ljava/lang/String;
+	public abstract fun getWrapped ()Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow1/ui/Wrapper$DefaultImpls {
+	public static fun getCompatibilityKey (Lcom/squareup/workflow1/ui/Wrapper;)Ljava/lang/String;
+}
+
+public final class com/squareup/workflow1/ui/WrapperKt {
+	public static final fun unwrap (Lcom/squareup/workflow1/ui/Wrapper;)Ljava/lang/Object;
+	public static final fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
 }
 

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Named.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Named.kt
@@ -7,9 +7,9 @@ package com.squareup.workflow1.ui
  */
 @WorkflowUiExperimentalApi
 public data class Named<W : Any>(
-  val wrapped: W,
+  override val wrapped: W,
   val name: String
-) : Compatible {
+) : Wrapper<W> {
   init {
     require(name.isNotBlank()) { "name must not be blank." }
   }

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Wrapper.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Wrapper.kt
@@ -1,0 +1,28 @@
+package com.squareup.workflow1.ui
+
+/**
+ * A rendering that wraps another, to which it delegates for UI construction duties.
+ */
+@WorkflowUiExperimentalApi
+public interface Wrapper<W : Any> : Compatible {
+  public val wrapped: W
+
+  override val compatibilityKey: String
+    get() = Compatible.keyFor(unwrap())
+}
+
+@WorkflowUiExperimentalApi
+public tailrec fun Wrapper<*>.unwrap(): Any {
+  (wrapped as? Wrapper<*>)?.let { return it.unwrap() }
+  return wrapped
+}
+
+@WorkflowUiExperimentalApi
+public fun unwrap(rendering: Any): Any {
+  return if (rendering is Wrapper<*>) rendering.unwrap() else rendering
+}
+
+@WorkflowUiExperimentalApi
+public inline fun <reified T> unwrapOrNull(rendering: Any): T? {
+  return unwrap(rendering) as? T
+}

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/CompatibleTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/CompatibleTest.kt
@@ -3,10 +3,8 @@ package com.squareup.workflow1.ui
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
-// If you try to replace isTrue() with isTrue compilation fails.
 @OptIn(WorkflowUiExperimentalApi::class)
-@Suppress("UsePropertyAccessSyntax")
-class CompatibleTest {
+internal class CompatibleTest {
   @Test fun `Different types do not match`() {
     val able = object : Any() {}
     val baker = object : Any() {}

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/NamedTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/NamedTest.kt
@@ -3,9 +3,7 @@ package com.squareup.workflow1.ui
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
-// If you try to replace isTrue() with isTrue compilation fails.
 @OptIn(WorkflowUiExperimentalApi::class)
-@Suppress("UsePropertyAccessSyntax")
 internal class NamedTest {
   object Whut
   object Hey

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/WrapperTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/WrapperTest.kt
@@ -1,0 +1,38 @@
+package com.squareup.workflow1.ui
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+@OptIn(WorkflowUiExperimentalApi::class)
+internal class WrapperTest {
+  @Test fun isCompatible() {
+    assertThat(compatible(SimplestWrapper("able"), SimplestWrapper("baker"))).isTrue()
+    assertThat(compatible(SimplestWrapper("able"), SimplestWrapper(42))).isFalse()
+    assertThat(compatible(SimplestWrapper("able"), "able")).isFalse()
+  }
+
+  @Test fun unwrapShallow() {
+    val wrapped = "String"
+    assertThat(unwrap(wrapped)).isSameInstanceAs(wrapped)
+  }
+
+  @Test fun unwrapRecursive() {
+    val wrapped = "String"
+    val wrapping = SimplestWrapper(SimplestWrapper(SimplestWrapper(wrapped)))
+    assertThat(unwrap(wrapping)).isSameInstanceAs(wrapped)
+  }
+
+  @Test fun unwrapAs() {
+    val wrapped = "String"
+    val wrapping = SimplestWrapper(wrapped)
+    val stringMaybe: String? = unwrapOrNull(wrapping)
+    val intMaybe: Int? = unwrapOrNull(wrapping)
+
+    assertThat(stringMaybe).isSameInstanceAs(wrapped)
+    assertThat(intMaybe).isNull()
+  }
+
+  private class SimplestWrapper<W : Any>(
+    override val wrapped: W
+  ) : Wrapper<W>
+}

--- a/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity.kt
+++ b/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity.kt
@@ -96,7 +96,7 @@ public abstract class AbstractLifecycleTestActivity : WorkflowUiTestActivity() {
         this.viewObserver = viewObserver
         viewObserver.onViewCreated(this, initialRendering)
 
-        bindShowRendering(initialRendering, initialViewEnvironment) { rendering, _ ->
+        bindShowRendering() { rendering, _ ->
           this.rendering = rendering
           viewObserver.onShowRendering(this, rendering)
         }

--- a/workflow-ui/modal-android/src/androidTest/java/com/squareup/workflow1/ui/modal/test/ModalViewContainerLifecycleActivity.kt
+++ b/workflow-ui/modal-android/src/androidTest/java/com/squareup/workflow1/ui/modal/test/ModalViewContainerLifecycleActivity.kt
@@ -30,7 +30,7 @@ internal class ModalViewContainerLifecycleActivity : AbstractLifecycleTestActivi
       contextForNewView: Context,
       container: ViewGroup?
     ): View = View(contextForNewView).apply {
-      bindShowRendering(initialRendering, initialViewEnvironment) { _, _ -> /* Noop */ }
+      bindShowRendering() { _, _ -> /* Noop */ }
     }
   }
 
@@ -58,10 +58,7 @@ internal class ModalViewContainerLifecycleActivity : AbstractLifecycleTestActivi
       FrameLayout(contextForNewView).also { container ->
         val stub = WorkflowViewStub(contextForNewView)
         container.addView(stub)
-        container.bindShowRendering(
-          initialRendering,
-          initialViewEnvironment
-        ) { rendering, env ->
+        container.bindShowRendering() { rendering, env ->
           stub.update(TestModals(listOf(rendering.wrapped)), env)
         }
       }

--- a/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/AlertContainer.kt
+++ b/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/AlertContainer.kt
@@ -86,7 +86,7 @@ public class AlertContainer @JvmOverloads constructor(
             .apply {
               id = R.id.workflow_alert_container
               layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
-              bindShowRendering(initialRendering, initialEnv, ::update)
+              bindShowRendering(::update)
             }
       }
   )

--- a/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/ModalViewContainer.kt
+++ b/workflow-ui/modal-android/src/main/java/com/squareup/workflow1/ui/modal/ModalViewContainer.kt
@@ -117,11 +117,11 @@ public open class ModalViewContainer @JvmOverloads constructor(
   ) : com.squareup.workflow1.ui.ViewFactory<H>
   by BuilderViewFactory(
       type = type,
-      viewConstructor = { initialRendering, initialEnv, context, _ ->
+      viewConstructor = { _, _, context, _ ->
         ModalViewContainer(context).apply {
           this.id = id
           layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
-          bindShowRendering(initialRendering, initialEnv, ::update)
+          bindShowRendering(::update)
         }
       }
   )

--- a/workflow-ui/radiography/src/main/java/com/squareup/workflow1/ui/radiography/WorkflowViewRenderer.kt
+++ b/workflow-ui/radiography/src/main/java/com/squareup/workflow1/ui/radiography/WorkflowViewRenderer.kt
@@ -1,9 +1,9 @@
 package com.squareup.workflow1.ui.radiography
 
 import com.squareup.workflow1.ui.Compatible
-import com.squareup.workflow1.ui.Named
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.getRendering
+import com.squareup.workflow1.ui.unwrap
 import radiography.AttributeAppendable
 import radiography.ScannableView
 import radiography.ScannableView.AndroidView
@@ -28,7 +28,7 @@ private object WorkflowViewRendererImpl : ViewStateRenderer {
   }
 
   private fun AttributeAppendable.renderRendering(rendering: Any) {
-    val actualRendering = (rendering as? Named<*>)?.wrapped ?: rendering
+    val actualRendering = unwrap(rendering)
     append("workflow-rendering-type:${actualRendering::class.java.name}")
 
     if (rendering is Compatible) {


### PR DESCRIPTION
We make a lot of use of renderings that wrap others to add meta information or
behavior, but which need to delegate for UI construction. This is tricky.

* We frequently forget to implement `Compatible`
* Things like `NamedViewFactory` or tricky `DecorativeViewFactory` implementations
  have to be added to `ViewRegistry`. Besides being fussy, these are platform specific.
* Introspective tasks like logging wind up with fragile code to peek
  through known wrappers.

The Wrapper interface and supporting extension functions should provide a
platform neutral way around this, and I hope pave the way to move
`ViewRegistry`(or a replacement) from `core-android` to `core-common`.