### PR TITLE
Reference WelcomeWorkflow in the tutorial

### DIFF
--- a/samples/tutorial/Tutorial1.md
+++ b/samples/tutorial/Tutorial1.md
@@ -178,7 +178,7 @@ class TutorialActivity : AppCompatActivity() {
 class TutorialViewModel(savedState: SavedStateHandle) : ViewModel() {
   val renderings: StateFlow<WelcomeScreen> by lazy {
     renderWorkflowIn(
-        workflow = HelloWorkflow,
+        workflow = WelcomeWorkflow,
         scope = viewModelScope,
         savedStateHandle = savedState
     )


### PR DESCRIPTION
The example refers to a `HelloWorkflow` that doesn't exist in `samples/tutorial`. When using this reference, the code doesn't compile as the class doesn't exist.
I guess it existed previously and this reference was missed when changing the tutorial.

The reference is changed to the `WelcomeWorkflow` - the class that was created in this tutorial.