### PR TITLE
Adopts AVD caching to speed up instrumentation tests.

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -72,12 +72,38 @@ jobs:
         with:
           java-version: 11.0.7
 
-      ## Actual task
-      - name: Instrumentation Tests
+      # AVD snapshot cache recipe from https://github.com/ReactiveCircus/android-emulator-runner#readme
+      #
+      - name: AVD cache
+        uses: actions/cache@v2
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          arch: x86_64
+          # @ychescale9 suspects Galaxy Nexus is the fastest one
+          profile: Galaxy Nexus
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          # @ychescale9 suspects Galaxy Nexus is the fastest one
+          profile: Galaxy Nexus
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
           script: ./gradlew connectedCheck --no-daemon --stacktrace
 
       - name: Upload results


### PR DESCRIPTION
See https://github.com/ReactiveCircus/android-emulator-runner#readme.