### PR TITLE
Adding a dependency step prior to references to AndroidX ViewModel on Tutorial step 1

### DIFF
--- a/samples/tutorial/Tutorial1.md
+++ b/samples/tutorial/Tutorial1.md
@@ -154,6 +154,17 @@ object WelcomeWorkflow : StatefulWorkflow<Unit, State, Output, WelcomeScreen>() 
 
 Now we have our `WelcomeWorkflow` rendering a `WelcomeScreen`, and have a layout runner that knows how to display with a `WelcomeScreen`. It's time to bind this all together and actually show it on the screen!
 
+Since we're about to include functionality related to AndroidX `ViewModel`s, `build.gradle` should be updated with the following dependencies:
+
+```groovy
+dependencies {
+  // ...
+  implementation deps.activityktx
+  implementation deps.viewmodelktx
+  implementation deps.viewmodelsavedstate
+}
+```
+
 We'll update the `TutorialActivity` to set its content using a `ViewRegistry` that points to our `LayoutRunner`'s `ViewFactory`:
 
 ```kotlin


### PR DESCRIPTION
Since the following lines reference ViewModels from AndroidX, and the referenced dependencies didn't exist in build.gradle, the tutorial would not compile during this step. Because Tutorial2.md includes a step to add the dependencies to build.gradle, that convention will be followed to add lines to include the necessary dependencies during step 1.