### PR TITLE
Daisy-chaining support for `testRender`

### DIFF
--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -8,8 +8,10 @@ public final class com/squareup/workflow1/testing/RenderIdempotencyChecker : com
 }
 
 public abstract interface class com/squareup/workflow1/testing/RenderTestResult {
-	public abstract fun verifyAction (Lkotlin/jvm/functions/Function1;)V
-	public abstract fun verifyActionResult (Lkotlin/jvm/functions/Function2;)V
+	public abstract fun testNextRender ()Lcom/squareup/workflow1/testing/RenderTester;
+	public abstract fun testNextRenderWithProps (Ljava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTester;
+	public abstract fun verifyAction (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/testing/RenderTestResult;
+	public abstract fun verifyActionResult (Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow1/testing/RenderTestResult;
 }
 
 public abstract class com/squareup/workflow1/testing/RenderTester {

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderTestResult.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderTestResult.kt
@@ -1,5 +1,6 @@
 package com.squareup.workflow1.testing
 
+import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction
 import com.squareup.workflow1.WorkflowOutput
 
@@ -10,7 +11,7 @@ import com.squareup.workflow1.WorkflowOutput
  * @see verifyAction
  * @see verifyActionResult
  */
-public interface RenderTestResult<PropsT, StateT, OutputT> {
+public interface RenderTestResult<PropsT, StateT, OutputT, RenderingT> {
 
   /**
    * Asserts that the render pass handled either a workflow/worker output or a rendering event, and
@@ -21,7 +22,9 @@ public interface RenderTestResult<PropsT, StateT, OutputT> {
    * This is useful if your actions are a sealed class or enum. If you need to test an anonymous
    * action, use [verifyActionResult].
    */
-  public fun verifyAction(block: (WorkflowAction<PropsT, StateT, OutputT>) -> Unit)
+  public fun verifyAction(
+    block: (WorkflowAction<PropsT, StateT, OutputT>) -> Unit
+  ): RenderTestResult<PropsT, StateT, OutputT, RenderingT>
 
   /**
    * Asserts that the render pass handled either a workflow/worker output or a rendering event,
@@ -35,5 +38,32 @@ public interface RenderTestResult<PropsT, StateT, OutputT> {
    * be useful if your actions are anonymous. If they are a sealed class or enum, use [verifyAction]
    * instead and write separate unit tests for your action implementations.
    */
-  public fun verifyActionResult(block: (newState: StateT, output: WorkflowOutput<OutputT>?) -> Unit)
+  public fun verifyActionResult(
+    block: (newState: StateT, output: WorkflowOutput<OutputT>?) -> Unit
+  ): RenderTestResult<PropsT, StateT, OutputT, RenderingT>
+
+  /**
+   * Starts a new [RenderTester] session using the same props as the previous session started by
+   * [testRender] or [testNextRenderWithProps], and the state that is a result of the latest render
+   * pass (the same one you could run assertions on in [verifyActionResult]).
+   *
+   * This method is useful for daisy-chaining of [RenderTester] sessions, when you want to assert
+   * different state transitions without [WorkflowTestRuntime] overhead.
+   */
+  public fun testNextRender(): RenderTester<PropsT, StateT, OutputT, RenderingT>
+
+  /**
+   * Starts a new [RenderTester] session using [newProps] props, and the state that is a result
+   * of the latest render pass (the same one you could run assertions on in [verifyActionResult]).
+   *
+   * This method is useful for daisy-chaining of [RenderTester] sessions, when you want to assert
+   * different state transitions without [WorkflowTestRuntime] overhead.
+   *
+   * Note that if you're overriding [StatefulWorkflow.onPropsChanged] method, it'll be ran before
+   * the next [RenderTester.render] pass, and [RenderTester] returned by this method will use
+   * the updated `state` value.
+   */
+  public fun testNextRenderWithProps(
+    newProps: PropsT
+  ): RenderTester<PropsT, StateT, OutputT, RenderingT>
 }

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderTester.kt
@@ -239,7 +239,7 @@ public abstract class RenderTester<PropsT, StateT, OutputT, RenderingT> {
    */
   public abstract fun render(
     block: (rendering: RenderingT) -> Unit = {}
-  ): RenderTestResult<PropsT, StateT, OutputT>
+  ): RenderTestResult<PropsT, StateT, OutputT, RenderingT>
 
   public abstract fun requireExplicitWorkerExpectations():
     RenderTester<PropsT, StateT, OutputT, RenderingT>


### PR DESCRIPTION
Resolves #580 .