### PR TITLE
Add RxJava3 support for Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ your `repositories` block, and then add dependencies on the following artifacts:
     <td nowrap><code>com.squareup.workflow1:workflow-rx2:x.y.z</code></td>
     <td>You need to interact with RxJava2 from your Workflows.</td>
   </tr>
+<tr>
+    <td nowrap><code>com.squareup.workflow1:workflow-rx3:x.y.z</code></td>
+    <td>You need to interact with RxJava3 from your Workflows.</td>
+  </tr>
   <tr>
     <td nowrap><code>com.squareup.workflow1:workflow-testing-jvm:x.y.z</code></td>
     <td>You are writing tests. This should only be included as a test dependency.</td>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -80,6 +80,7 @@ object Dependencies {
       const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1"
       const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1"
       const val rx2 = "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:1.5.1"
+      const val rx3 = "org.jetbrains.kotlinx:kotlinx-coroutines-rx3:1.5.1"
 
       const val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.1"
     }
@@ -113,8 +114,9 @@ object Dependencies {
   const val lanterna = "com.googlecode.lanterna:lanterna:3.1.1"
   const val okio = "com.squareup.okio:okio:2.10.0"
 
-  object RxJava2 {
+  object RxJava {
     const val rxjava2 = "io.reactivex.rxjava2:rxjava:2.2.21"
+    const val rxjava3 = "io.reactivex.rxjava3:rxjava:3.1.2"
   }
 
   object Annotations {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ include(
     ":workflow-core",
     ":workflow-runtime",
     ":workflow-rx2",
+    ":workflow-rx3",
     ":workflow-testing",
     ":workflow-tracing",
     ":workflow-ui:compose",

--- a/workflow-rx3/README.md
+++ b/workflow-rx3/README.md
@@ -1,0 +1,3 @@
+# workflow-rx3
+
+This module contains adapters to use Workflows with RxJava3.

--- a/workflow-rx3/api/workflow-rx3.api
+++ b/workflow-rx3/api/workflow-rx3.api
@@ -1,0 +1,11 @@
+public abstract class com/squareup/workflow1/rx3/PublisherWorker : com/squareup/workflow1/Worker {
+	public fun <init> ()V
+	public fun doesSameWorkAs (Lcom/squareup/workflow1/Worker;)Z
+	public final fun run ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun runPublisher ()Lorg/reactivestreams/Publisher;
+}
+
+public final class com/squareup/workflow1/rx3/RxWorkersKt {
+	public static final fun asWorker (Lio/reactivex/rxjava3/core/Completable;)Lcom/squareup/workflow1/Worker;
+}
+

--- a/workflow-rx3/build.gradle.kts
+++ b/workflow-rx3/build.gradle.kts
@@ -17,9 +17,9 @@ dependencies {
   api(project(":workflow-core"))
   api(Dependencies.Kotlin.Stdlib.jdk6)
   api(Dependencies.Kotlin.Coroutines.core)
-  api(Dependencies.RxJava.rxjava2)
+  api(Dependencies.RxJava.rxjava3)
 
-  implementation(Dependencies.Kotlin.Coroutines.rx2)
+  implementation(Dependencies.Kotlin.Coroutines.rx3)
 
   testImplementation(project(":workflow-testing"))
   testImplementation(Dependencies.Kotlin.Test.jdk)

--- a/workflow-rx3/gradle.properties
+++ b/workflow-rx3/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=workflow-rx3
+POM_NAME=Workflow RxJava3
+POM_PACKAGING=jar

--- a/workflow-rx3/src/main/java/com/squareup/workflow1/rx3/PublisherWorker.kt
+++ b/workflow-rx3/src/main/java/com/squareup/workflow1/rx3/PublisherWorker.kt
@@ -1,0 +1,34 @@
+package com.squareup.workflow1.rx3
+
+import com.squareup.workflow1.Worker
+import com.squareup.workflow1.Workflow
+import io.reactivex.rxjava3.core.Flowable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.reactive.asFlow
+import org.reactivestreams.Publisher
+
+/**
+ * An convenience implementation of [Worker] that is expressed in terms of Reactive Streams'
+ * [Publisher] instead of [Flow].
+ *
+ * If you're using RxJava, [Flowable] is a [Publisher].
+ *
+ * Subclassing this is equivalent to just implementing [Worker.run] directly and calling [asFlow]
+ * on your [Publisher].
+ */
+public abstract class PublisherWorker<out OutputT : Any> : Worker<OutputT> {
+
+  /**
+   * Returns a [Flowable] to execute the work represented by this worker.
+   *
+   * If you have an [io.reactivex.rxjava3.core.Observable] instead, just call
+   * [toFlowable][io.reactivex.rxjava3.core.Observable.toFlowable] to convert it.
+   *
+   * The [Flowable] is subscribed to in the context of the workflow runtime. When this [Worker],
+   * its parent [Workflow], or any ancestor [Workflow]s are torn down, the subscription will be
+   * [disposed][io.reactivex.rxjava3.disposables.Disposable.dispose].
+   */
+  public abstract fun runPublisher(): Publisher<out OutputT>
+
+  final override fun run(): Flow<OutputT> = runPublisher().asFlow()
+}

--- a/workflow-rx3/src/main/java/com/squareup/workflow1/rx3/RxWorkers.kt
+++ b/workflow-rx3/src/main/java/com/squareup/workflow1/rx3/RxWorkers.kt
@@ -1,0 +1,85 @@
+package com.squareup.workflow1.rx3
+
+import com.squareup.workflow1.Worker
+import com.squareup.workflow1.asWorker
+import io.reactivex.rxjava3.core.BackpressureStrategy.BUFFER
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Single
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.rx3.await
+import kotlinx.coroutines.rx3.awaitSingleOrNull
+import org.reactivestreams.Publisher
+
+/**
+ * Creates a [Worker] from this [Observable].
+ *
+ * The [Observable] will be subscribed to when the [Worker] is started, and disposed when it is
+ * cancelled.
+ *
+ * RxJava doesn't allow nulls, but it can't express that in its types. The receiver type parameter
+ * is nullable so that the resulting [Worker] is non-nullable instead of having
+ * platform nullability.
+ */
+public inline fun <reified T : Any> Observable<out T?>.asWorker(): Worker<T> =
+  this.toFlowable(BUFFER).asWorker()
+
+/**
+ * Creates a [Worker] from this [Publisher] ([Flowable] is a [Publisher]).
+ *
+ * The [Publisher] will be subscribed to when the [Worker] is started, and cancelled when it is
+ * cancelled.
+ *
+ * RxJava doesn't allow nulls, but it can't express that in its types. The receiver type parameter
+ * is nullable so that the resulting [Worker] is non-nullable instead of having
+ * platform nullability.
+ */
+public inline fun <reified T : Any> Publisher<out T?>.asWorker(): Worker<T> =
+// This cast works because RxJava types don't actually allow nulls, it's just that they can't
+  // express that in their types because Java.
+  @Suppress("UNCHECKED_CAST")
+  (this as Publisher<T>).asFlow().asWorker()
+
+/**
+ * Creates a [Worker] from this [Maybe].
+ *
+ * The [Maybe] will be subscribed to when the [Worker] is started, and disposed when it is
+ * cancelled.
+ *
+ * RxJava doesn't allow nulls, but it can't express that in its types. The receiver type parameter
+ * is nullable so that the resulting [Worker] is non-nullable instead of having
+ * platform nullability.
+ */
+public inline fun <reified T : Any> Maybe<out T?>.asWorker(): Worker<T> =
+  Worker.fromNullable { awaitSingleOrNull() }
+
+/**
+ * Creates a [Worker] from this [Single].
+ *
+ * The [Single] will be subscribed to when the [Worker] is started, and disposed when it is
+ * cancelled.
+ *
+ * RxJava doesn't allow nulls, but it can't express that in its types. The receiver type parameter
+ * is nullable so that the resulting [Worker] is non-nullable instead of having
+ * platform nullability.
+ */
+public inline fun <reified T : Any> Single<out T?>.asWorker(): Worker<T> =
+// This !! works because RxJava types don't actually allow nulls, it's just that they can't
+  // express that in their types because Java.
+  Worker.from { await()!! }
+
+/**
+ * Creates a [Worker] from this [Completable].
+ *
+ * The [Completable] will be subscribed to when the [Worker] is started, and disposed when it is
+ * cancelled.
+ *
+ * The key is required for this operator because there is no type information available to
+ * distinguish workers.
+ *
+ * TODO: https://github.com/square/workflow-kotlin/issues/526 once this is removed.
+ */
+@Suppress("DEPRECATION")
+public fun Completable.asWorker(): Worker<Nothing> = Worker.createSideEffect { await() }

--- a/workflow-rx3/src/test/java/com/squareup/workflow1/rx3/PublisherWorkerTest.kt
+++ b/workflow-rx3/src/test/java/com/squareup/workflow1/rx3/PublisherWorkerTest.kt
@@ -1,0 +1,42 @@
+package com.squareup.workflow1.rx3
+
+import com.squareup.workflow1.Worker
+import com.squareup.workflow1.Workflow
+import com.squareup.workflow1.action
+import com.squareup.workflow1.runningWorker
+import com.squareup.workflow1.stateless
+import com.squareup.workflow1.testing.launchForTestingFromStartWith
+import io.reactivex.rxjava3.core.BackpressureStrategy.BUFFER
+import io.reactivex.rxjava3.subjects.PublishSubject
+import org.reactivestreams.Publisher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+internal class PublisherWorkerTest {
+
+  @Test fun works() {
+    val subject = PublishSubject.create<String>()
+    val worker = object : PublisherWorker<String>() {
+      override fun runPublisher(): Publisher<out String> = subject.toFlowable(BUFFER)
+      override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = otherWorker === this
+    }
+
+    fun action(value: String) = action<Unit, Nothing, String> { setOutput(value) }
+    val workflow = Workflow.stateless<Unit, String, Unit> {
+      runningWorker(worker) { action(it) }
+    }
+
+    workflow.launchForTestingFromStartWith {
+      assertFalse(hasOutput)
+
+      subject.onNext("one")
+      assertEquals("one", awaitNextOutput())
+
+      subject.onNext("two")
+      subject.onNext("three")
+      assertEquals("two", awaitNextOutput())
+      assertEquals("three", awaitNextOutput())
+    }
+  }
+}

--- a/workflow-rx3/src/test/java/com/squareup/workflow1/rx3/RxWorkersTest.kt
+++ b/workflow-rx3/src/test/java/com/squareup/workflow1/rx3/RxWorkersTest.kt
@@ -1,0 +1,351 @@
+package com.squareup.workflow1.rx3
+
+import com.squareup.workflow1.testing.test
+import io.reactivex.rxjava3.core.BackpressureStrategy.MISSING
+import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.subjects.CompletableSubject
+import io.reactivex.rxjava3.subjects.MaybeSubject
+import io.reactivex.rxjava3.subjects.PublishSubject
+import io.reactivex.rxjava3.subjects.SingleSubject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RxWorkersTest {
+
+  private class ExpectedException : RuntimeException()
+
+  // region Observable
+
+  @Test fun `observable emits`() {
+    val subject = PublishSubject.create<String>()
+    // Should support out-projected parameters.
+    val worker = (subject as Observable<out String?>).asWorker()
+
+    worker.test {
+      subject.onNext("foo")
+      assertEquals("foo", nextOutput())
+
+      subject.onNext("bar")
+      assertEquals("bar", nextOutput())
+    }
+  }
+
+  @Test fun `observable finishes`() {
+    val subject = PublishSubject.create<String>()
+    val worker = subject.asWorker()
+
+    worker.test {
+      subject.onComplete()
+      assertFinished()
+    }
+  }
+
+  @Test fun `observable finishes after emitting`() {
+    val subject = PublishSubject.create<String>()
+    val worker = subject.asWorker()
+
+    worker.test {
+      subject.onNext("foo")
+      assertEquals("foo", nextOutput())
+
+      subject.onComplete()
+      assertFinished()
+    }
+  }
+
+  @Test fun `observable throws`() {
+    val subject = PublishSubject.create<String>()
+    val worker = subject.asWorker()
+
+    worker.test {
+      subject.onError(ExpectedException())
+      assertTrue(getException() is ExpectedException)
+    }
+  }
+
+  @Test fun `observable is subscribed lazily`() {
+    var subscriptions = 0
+    val subject = PublishSubject.create<String>()
+    val worker = subject.doOnSubscribe { subscriptions++ }
+        .asWorker()
+
+    assertEquals(0, subscriptions)
+
+    worker.test {
+      assertEquals(1, subscriptions)
+    }
+  }
+
+  @Test fun `observable is disposed when worker cancelled`() {
+    var disposals = 0
+    val subject = PublishSubject.create<String>()
+    val worker = subject.doOnDispose { disposals++ }
+        .asWorker()
+
+    assertEquals(0, disposals)
+
+    worker.test {
+      assertEquals(0, disposals)
+      cancelWorker()
+      assertEquals(1, disposals)
+    }
+  }
+
+  // endregion
+
+  // region Flowable
+
+  @Test fun `flowable emits`() {
+    val subject = PublishSubject.create<String>()
+    val worker = (subject.toFlowable(MISSING) as Flowable<out String?>)
+        .asWorker()
+
+    worker.test {
+      subject.onNext("foo")
+      assertEquals("foo", nextOutput())
+
+      subject.onNext("bar")
+      assertEquals("bar", nextOutput())
+    }
+  }
+
+  @Test fun `flowable finishes`() {
+    val subject = PublishSubject.create<String>()
+    val worker = subject.toFlowable(MISSING)
+        .asWorker()
+
+    worker.test {
+      subject.onComplete()
+      assertFinished()
+    }
+  }
+
+  @Test fun `flowable finishes after emitting`() {
+    val subject = PublishSubject.create<String>()
+    val worker = subject.toFlowable(MISSING)
+        .asWorker()
+
+    worker.test {
+      subject.onNext("foo")
+      assertEquals("foo", nextOutput())
+
+      subject.onComplete()
+      assertFinished()
+    }
+  }
+
+  @Test fun `flowable throws`() {
+    val subject = PublishSubject.create<String>()
+    val worker = subject.toFlowable(MISSING)
+        .asWorker()
+
+    worker.test {
+      subject.onError(ExpectedException())
+      assertTrue(getException() is ExpectedException)
+    }
+  }
+
+  @Test fun `flowable is subscribed lazily`() {
+    var subscriptions = 0
+    val subject = PublishSubject.create<String>()
+    val worker = subject.toFlowable(MISSING)
+        .doOnSubscribe { subscriptions++ }
+        .asWorker()
+
+    assertEquals(0, subscriptions)
+
+    worker.test {
+      assertEquals(1, subscriptions)
+    }
+  }
+
+  @Test fun `flowable is cancelled when worker cancelled`() {
+    var cancels = 0
+    val subject = PublishSubject.create<String>()
+    val worker = subject.toFlowable(MISSING)
+        .doOnCancel { cancels++ }
+        .asWorker()
+
+    assertEquals(0, cancels)
+
+    worker.test {
+      assertEquals(0, cancels)
+      cancelWorker()
+      assertEquals(1, cancels)
+    }
+  }
+
+  // endregion
+
+  // region Maybe
+
+  @Test fun `maybe emits`() {
+    val subject = MaybeSubject.create<String>()
+    val worker = (subject as Maybe<out String?>).asWorker()
+
+    worker.test {
+      subject.onSuccess("foo")
+      assertEquals("foo", nextOutput())
+      assertFinished()
+    }
+  }
+
+  @Test fun `maybe finishes without emitting`() {
+    val subject = MaybeSubject.create<String>()
+    val worker = subject.asWorker()
+
+    worker.test {
+      subject.onComplete()
+      assertFinished()
+    }
+  }
+
+  @Test fun `maybe throws`() {
+    val subject = MaybeSubject.create<String>()
+    val worker = subject.asWorker()
+
+    worker.test {
+      subject.onError(ExpectedException())
+      assertTrue(getException() is ExpectedException)
+    }
+  }
+
+  @Test fun `maybe is subscribed lazily`() {
+    var subscriptions = 0
+    val subject = MaybeSubject.create<String>()
+    val worker = subject.doOnSubscribe { subscriptions++ }
+        .asWorker()
+
+    assertEquals(0, subscriptions)
+
+    worker.test {
+      assertEquals(1, subscriptions)
+    }
+  }
+
+  @Test fun `maybe is disposed when worker cancelled`() {
+    var cancels = 0
+    val subject = MaybeSubject.create<String>()
+    val worker = subject.doOnDispose { cancels++ }
+        .asWorker()
+
+    assertEquals(0, cancels)
+
+    worker.test {
+      assertEquals(0, cancels)
+      cancelWorker()
+      assertEquals(1, cancels)
+    }
+  }
+
+  // endregion
+
+  // region Single
+
+  @Test fun `single emits`() {
+    val subject = SingleSubject.create<String>()
+    val worker = (subject as Single<out String?>).asWorker()
+
+    worker.test {
+      subject.onSuccess("foo")
+      assertEquals("foo", nextOutput())
+      assertFinished()
+    }
+  }
+
+  @Test fun `single throws`() {
+    val subject = SingleSubject.create<String>()
+    val worker = subject.asWorker()
+
+    worker.test {
+      subject.onError(ExpectedException())
+      assertTrue(getException() is ExpectedException)
+    }
+  }
+
+  @Test fun `single is subscribed lazily`() {
+    var subscriptions = 0
+    val subject = SingleSubject.create<String>()
+    val worker = subject.doOnSubscribe { subscriptions++ }
+        .asWorker()
+
+    assertEquals(0, subscriptions)
+
+    worker.test {
+      assertEquals(1, subscriptions)
+    }
+  }
+
+  @Test fun `single is disposed when worker cancelled`() {
+    var cancels = 0
+    val subject = SingleSubject.create<String>()
+    val worker = subject.doOnDispose { cancels++ }
+        .asWorker()
+
+    assertEquals(0, cancels)
+
+    worker.test {
+      assertEquals(0, cancels)
+      cancelWorker()
+      assertEquals(1, cancels)
+    }
+  }
+
+  // endregion
+
+  // region Completable
+
+  @Test fun `completable emits`() {
+    val subject = CompletableSubject.create()
+    val worker = subject.asWorker()
+
+    worker.test {
+      subject.onComplete()
+      assertFinished()
+    }
+  }
+
+  @Test fun `completable throws`() {
+    val subject = CompletableSubject.create()
+    val worker = subject.asWorker()
+
+    worker.test {
+      subject.onError(ExpectedException())
+      assertTrue(getException() is ExpectedException)
+    }
+  }
+
+  @Test fun `completable is subscribed lazily`() {
+    var subscriptions = 0
+    val subject = CompletableSubject.create()
+    val worker = subject.doOnSubscribe { subscriptions++ }
+        .asWorker()
+
+    assertEquals(0, subscriptions)
+
+    worker.test {
+      assertEquals(1, subscriptions)
+    }
+  }
+
+  @Test fun `completable is disposed when worker cancelled`() {
+    var cancels = 0
+    val subject = CompletableSubject.create()
+    val worker = subject.doOnDispose { cancels++ }
+        .asWorker()
+
+    assertEquals(0, cancels)
+
+    worker.test {
+      assertEquals(0, cancels)
+      cancelWorker()
+      assertEquals(1, cancels)
+    }
+  }
+
+  // endregion
+}


### PR DESCRIPTION
I know, Kotlin Flows are the future.
I know, RxJava is the past.

But someone could want to have RxJava. And RxJava2 is [end-of-life](https://github.com/ReactiveX/RxJava#version-2x), so having RxJava3 bridge is a convenient thing.

And yes, I've just copied `workflow-rx2` and updated all imports. This is how migration works, right?