### PR TITLE
Replaces *.initializeView with *.viewStarter

### DIFF
--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/WorkflowRendering.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/WorkflowRendering.kt
@@ -27,6 +27,7 @@ import com.squareup.workflow1.ui.WorkflowViewStub
 import com.squareup.workflow1.ui.getFactoryForRendering
 import com.squareup.workflow1.ui.getShowRendering
 import com.squareup.workflow1.ui.showRendering
+import com.squareup.workflow1.ui.start
 import kotlin.reflect.KClass
 
 /**
@@ -184,6 +185,8 @@ private fun <R : Any> ViewFactory<R>.asComposeViewFactory() =
           // we don't have access to that.
           originalFactory.buildView(rendering, viewEnvironment, context, container = null)
             .also { view ->
+              view.start()
+
               // Mirrors the check done in ViewRegistry.buildView.
               checkNotNull(view.getShowRendering<Any>()) {
                 "View.bindShowRendering should have been called for $view, typically by the " +

--- a/workflow-ui/container-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
+++ b/workflow-ui/container-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
@@ -32,8 +32,8 @@ import com.squareup.workflow1.ui.canShowRendering
 import com.squareup.workflow1.ui.compatible
 import com.squareup.workflow1.ui.container.R
 import com.squareup.workflow1.ui.getRendering
-import com.squareup.workflow1.ui.showFirstRendering
 import com.squareup.workflow1.ui.showRendering
+import com.squareup.workflow1.ui.start
 
 /**
  * A container view that can display a stream of [BackStackScreen] instances.
@@ -103,11 +103,12 @@ public open class BackStackContainer @JvmOverloads constructor(
       initialViewEnvironment = environment,
       contextForNewView = this.context,
       container = this,
-      initializeView = {
-        WorkflowLifecycleOwner.installOn(this)
-        showFirstRendering()
+      viewStarter = { view, doStart ->
+        WorkflowLifecycleOwner.installOn(view)
+        doStart()
       }
     )
+    newView.start()
     viewStateCache.update(named.backStack, oldViewMaybe, newView)
 
     val popped = currentRendering?.backStack?.any { compatible(it, named.top) } == true

--- a/workflow-ui/container-android/src/main/java/com/squareup/workflow1/ui/modal/ModalViewContainer.kt
+++ b/workflow-ui/container-android/src/main/java/com/squareup/workflow1/ui/modal/ModalViewContainer.kt
@@ -20,6 +20,7 @@ import com.squareup.workflow1.ui.buildView
 import com.squareup.workflow1.ui.modal.ModalViewContainer.Companion.binding
 import com.squareup.workflow1.ui.onBackPressedDispatcherOwnerOrNull
 import com.squareup.workflow1.ui.showRendering
+import com.squareup.workflow1.ui.start
 import kotlin.reflect.KClass
 
 /**
@@ -72,6 +73,7 @@ public open class ModalViewContainer @JvmOverloads constructor(
         container = this
       )
         .apply {
+          start()
           // If the modal's root view has no backPressedHandler, add a no-op one to
           // ensure that the `onBackPressed` call below will not leak up to handlers
           // that should be blocked by this modal session.

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -24,10 +24,10 @@ public final class com/squareup/workflow1/ui/BuilderViewFactory : com/squareup/w
 }
 
 public final class com/squareup/workflow1/ui/DecorativeViewFactory : com/squareup/workflow1/ui/ViewFactory {
-	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;)V
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;)V
-	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/ui/ViewStarter;Lkotlin/jvm/functions/Function4;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/ui/ViewStarter;Lkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/ui/ViewStarter;Lkotlin/jvm/functions/Function4;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/ui/ViewStarter;Lkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public fun getType ()Lkotlin/reflect/KClass;
 }
@@ -49,21 +49,6 @@ public final class com/squareup/workflow1/ui/LayoutRunnerViewFactory : com/squar
 	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/jvm/functions/Function1;)V
 	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public fun getType ()Lkotlin/reflect/KClass;
-}
-
-public final class com/squareup/workflow1/ui/ShowRenderingTag {
-	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)V
-	public final fun component1 ()Ljava/lang/Object;
-	public final fun component2 ()Lcom/squareup/workflow1/ui/ViewEnvironment;
-	public final fun component3 ()Lkotlin/jvm/functions/Function2;
-	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow1/ui/ShowRenderingTag;
-	public static synthetic fun copy$default (Lcom/squareup/workflow1/ui/ShowRenderingTag;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/ShowRenderingTag;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getEnvironment ()Lcom/squareup/workflow1/ui/ViewEnvironment;
-	public final fun getShowRendering ()Lkotlin/jvm/functions/Function2;
-	public final fun getShowing ()Ljava/lang/Object;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/squareup/workflow1/ui/SnapshotParcelsKt {
@@ -124,21 +109,24 @@ public final class com/squareup/workflow1/ui/ViewRegistry$Companion : com/square
 public final class com/squareup/workflow1/ui/ViewRegistryKt {
 	public static final fun ViewRegistry ()Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun ViewRegistry ([Lcom/squareup/workflow1/ui/ViewFactory;)Lcom/squareup/workflow1/ui/ViewRegistry;
-	public static final fun buildView (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;Lkotlin/jvm/functions/Function1;)Landroid/view/View;
-	public static synthetic fun buildView$default (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroid/view/View;
+	public static final fun buildView (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;Lcom/squareup/workflow1/ui/ViewStarter;)Landroid/view/View;
+	public static synthetic fun buildView$default (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;Lcom/squareup/workflow1/ui/ViewStarter;ILjava/lang/Object;)Landroid/view/View;
 	public static final fun getFactoryForRendering (Lcom/squareup/workflow1/ui/ViewRegistry;Ljava/lang/Object;)Lcom/squareup/workflow1/ui/ViewFactory;
 	public static final fun plus (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewFactory;)Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun plus (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewRegistry;
-	public static final fun showFirstRendering (Landroid/view/View;)V
 }
 
 public final class com/squareup/workflow1/ui/ViewShowRenderingKt {
 	public static final fun bindShowRendering (Landroid/view/View;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)V
 	public static final fun canShowRendering (Landroid/view/View;Ljava/lang/Object;)Z
 	public static final fun getEnvironment (Landroid/view/View;)Lcom/squareup/workflow1/ui/ViewEnvironment;
-	public static final fun getRendering (Landroid/view/View;)Ljava/lang/Object;
 	public static final fun getShowRendering (Landroid/view/View;)Lkotlin/jvm/functions/Function2;
 	public static final fun showRendering (Landroid/view/View;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
+	public static final fun start (Landroid/view/View;)V
+}
+
+public abstract interface class com/squareup/workflow1/ui/ViewStarter {
+	public abstract fun startView (Landroid/view/View;Lkotlin/jvm/functions/Function0;)V
 }
 
 public final class com/squareup/workflow1/ui/WorkflowLayout : android/widget/FrameLayout {
@@ -147,6 +135,42 @@ public final class com/squareup/workflow1/ui/WorkflowLayout : android/widget/Fra
 	public final fun start (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
 	public final fun start (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewRegistry;)V
 	public static synthetic fun start$default (Lcom/squareup/workflow1/ui/WorkflowLayout;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewEnvironment;ILjava/lang/Object;)V
+}
+
+public abstract class com/squareup/workflow1/ui/WorkflowViewState {
+	public abstract fun getEnvironment ()Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public abstract fun getShowRendering ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/squareup/workflow1/ui/WorkflowViewState$New : com/squareup/workflow1/ui/WorkflowViewState {
+	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component2 ()Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public final fun component3 ()Lkotlin/jvm/functions/Function2;
+	public final fun component4 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/WorkflowViewState$New;
+	public static synthetic fun copy$default (Lcom/squareup/workflow1/ui/WorkflowViewState$New;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/WorkflowViewState$New;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEnvironment ()Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public fun getShowRendering ()Lkotlin/jvm/functions/Function2;
+	public synthetic fun getShowing ()Ljava/lang/Object;
+	public final fun getStarter ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow1/ui/WorkflowViewState$Started : com/squareup/workflow1/ui/WorkflowViewState {
+	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)V
+	public final fun component2 ()Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public final fun component3 ()Lkotlin/jvm/functions/Function2;
+	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow1/ui/WorkflowViewState$Started;
+	public static synthetic fun copy$default (Lcom/squareup/workflow1/ui/WorkflowViewState$Started;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/WorkflowViewState$Started;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEnvironment ()Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public fun getShowRendering ()Lkotlin/jvm/functions/Function2;
+	public synthetic fun getShowing ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/squareup/workflow1/ui/WorkflowViewStub : android/view/View {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
@@ -1,6 +1,8 @@
 package com.squareup.workflow1.ui
 
 import android.view.View
+import com.squareup.workflow1.ui.WorkflowViewState.New
+import com.squareup.workflow1.ui.WorkflowViewState.Started
 
 /**
  * Function attached to a view created by [ViewFactory], to allow it
@@ -8,29 +10,22 @@ import android.view.View
  */
 @WorkflowUiExperimentalApi
 public typealias ViewShowRendering<RenderingT> =
-  (@UnsafeVariance RenderingT, ViewEnvironment) -> Unit
+    (@UnsafeVariance RenderingT, ViewEnvironment) -> Unit
+// Unsafe because typealias ViewShowRendering<in RenderingT> is not supported, can't
+// declare variance on a typealias. If I recall correctly.
 
 /**
-` * View tag that holds the function to make the view show instances of [RenderingT], and
- * the [current rendering][showing].
+ * For use by implementations of [ViewFactory.buildView]. Establishes [showRendering]
+ * as the implementation of [View.showRendering] for the receiver, possibly replacing
+ * the existing one.
  *
- * @param showing the current rendering. Used by [canShowRendering] to decide if the
- * view can be updated with the next rendering.
- */
-@WorkflowUiExperimentalApi
-public data class ShowRenderingTag<out RenderingT : Any>(
-  val showing: RenderingT,
-  val environment: ViewEnvironment,
-  val showRendering: ViewShowRendering<RenderingT>
-)
-
-/**
- * Establishes [showRendering] as the implementation of [View.showRendering]
- * for the receiver, possibly replacing the existing one. Likewise sets / updates
- * the values returned by [View.getRendering] and [View.environment].
+ * - After this method is called, [View.start] must be called exactly
+ *   once before [View.showRendering] can be called.
+ * - If this method is called again _after_ [View.start] (e.g. if a [View] is reused),
+ *   the receiver is reset to its initialized state, and [View.start] must
+ *   be called again.
  *
- * Intended for use by implementations of [ViewFactory.buildView].
- *
+ * @see ViewFactory
  * @see DecorativeViewFactory
  */
 @WorkflowUiExperimentalApi
@@ -39,31 +34,56 @@ public fun <RenderingT : Any> View.bindShowRendering(
   initialViewEnvironment: ViewEnvironment,
   showRendering: ViewShowRendering<RenderingT>
 ) {
-  setTag(
-    R.id.view_show_rendering_function,
-    ShowRenderingTag(initialRendering, initialViewEnvironment, showRendering)
-  )
+  workflowViewState = when (workflowViewStateOrNull) {
+    is New<*> -> New(initialRendering, initialViewEnvironment, showRendering, starter)
+    else -> New(initialRendering, initialViewEnvironment, showRendering)
+  }
+
+  // Note that if there is already a `New<*>` tag, we have to take care to propagate
+  // the starter. Repeated calls happen whenever one ViewFactory delegates to another.
+  //
+  //  - We render `NamedScreen(FooScreen())`
+  //  - The view is built by `FooScreenFactory`, which calls `bindShowRendering<FooScreen>()`
+  //  - `NamedScreenFactory` invokes `FooScreenFactory.buildView`, and calls
+  //    `bindShowRendering<NamedScreen<*>>()` on the view that `FooScreenFactory` built.
 }
 
 /**
- * It is usually more convenient to use [WorkflowViewStub] than to call this method directly.
+ * Note that [WorkflowViewStub] calls this method for you.
+ *
+ * Makes the initial call to [View.showRendering], along with any wrappers that have been
+ * added via [ViewRegistry.buildView], or [DecorativeViewFactory.viewStarter].
+ *
+ * - It is an error to call this method more than once.
+ * - It is an error to call [View.showRendering] without having called this method first.
+ */
+@WorkflowUiExperimentalApi
+public fun View.start() {
+  val current = workflowViewStateAsNew
+  workflowViewState = Started(current.showing, current.environment, current.showRendering)
+  current.starter(this)
+}
+
+/**
+ * Note that [WorkflowViewStub.showRendering] makes this check for you.
  *
  * True if this view is able to show [rendering].
  *
- * Returns `false` if [bindShowRendering] has not been called, so it is always safe to
- * call this method. Otherwise returns the [compatibility][compatible] of the initial
- * [rendering] and the new one.
+ * Returns `false` if [View.bindShowRendering] has not been called, so it is always safe to
+ * call this method. Otherwise returns the [compatibility][compatible] of the current
+ * [View.getRendering] and the new one.
  */
 @WorkflowUiExperimentalApi
 public fun View.canShowRendering(rendering: Any): Boolean {
-  return getRendering<Any>()?.matches(rendering) == true
+  return getRendering<Any>()?.let { compatible(it, rendering) } == true
 }
 
 /**
- * It is usually more convenient to use [WorkflowViewStub] than to call this method directly.
+ * It is usually more convenient to call [WorkflowViewStub.showRendering]
+ * than to call this method directly.
  *
- * Sets the workflow rendering associated with this view, and displays it by
- * invoking the [ViewShowRendering] function previously set by [bindShowRendering].
+ * Shows [rendering] in this View by invoking the [ViewShowRendering] function
+ * previously set by [bindShowRendering].
  *
  * @throws IllegalStateException if [bindShowRendering] has not been called.
  */
@@ -72,47 +92,42 @@ public fun <RenderingT : Any> View.showRendering(
   rendering: RenderingT,
   viewEnvironment: ViewEnvironment
 ) {
-  showRenderingTag
-    ?.let { tag ->
-      check(tag.showing.matches(rendering)) {
-        "Expected $this to be able to show rendering $rendering, but that did not match " +
-          "previous rendering ${tag.showing}. " +
-          "Consider using ${WorkflowViewStub::class.java.simpleName} to display arbitrary types."
-      }
-
-      // Update the tag's rendering and viewEnvironment.
-      bindShowRendering(rendering, viewEnvironment, tag.showRendering)
-      // And do the actual showRendering work.
-      tag.showRendering.invoke(rendering, viewEnvironment)
+  workflowViewStateAsStarted.let { viewState ->
+    check(compatible(viewState.showing, rendering)) {
+      "Expected $this to be able to show rendering $rendering, but that did not match " +
+        "previous rendering ${viewState.showing}. " +
+        "Consider using WorkflowViewStub to display arbitrary types."
     }
-    ?: error(
-      "Expected $this to have a showRendering function to show $rendering. " +
-        "Perhaps it was not built by a ${ViewFactory::class.java.simpleName}, " +
-        "or perhaps the factory did not call View.bindShowRendering."
-    )
+
+    // Update the tag's rendering and viewEnvironment before calling
+    // the actual showRendering function.
+    workflowViewState = Started(rendering, viewEnvironment, viewState.showRendering)
+    viewState.showRendering.invoke(rendering, viewEnvironment)
+  }
 }
 
 /**
- * Returns the most recent rendering shown by this view, or null if [bindShowRendering]
- * has never been called.
+ * Returns the most recent rendering shown by this view cast to [RenderingT],
+ * or null if [bindShowRendering] has never been called.
+ *
+ * @throws ClassCastException if the current rendering is not of type [RenderingT]
  */
 @WorkflowUiExperimentalApi
-public fun <RenderingT : Any> View.getRendering(): RenderingT? {
+public inline fun <reified RenderingT : Any> View.getRendering(): RenderingT? {
   // Can't use a val because of the parameter type.
-  @Suppress("UNCHECKED_CAST")
-  return when (val showing = showRenderingTag?.showing) {
+  return when (val showing = workflowViewStateOrNull?.showing) {
     null -> null
     else -> showing as RenderingT
   }
 }
 
 /**
- * Returns the most recent [ViewEnvironment] that apply to this view, or null if [bindShowRendering]
+ * Returns the most recent [ViewEnvironment] applied to this view, or null if [bindShowRendering]
  * has never been called.
  */
 @WorkflowUiExperimentalApi
 public val View.environment: ViewEnvironment?
-  get() = showRenderingTag?.environment
+  get() = workflowViewStateOrNull?.environment
 
 /**
  * Returns the function set by the most recent call to [bindShowRendering], or null
@@ -120,17 +135,12 @@ public val View.environment: ViewEnvironment?
  */
 @WorkflowUiExperimentalApi
 public fun <RenderingT : Any> View.getShowRendering(): ViewShowRendering<RenderingT>? {
-  return showRenderingTag?.showRendering
+  return workflowViewStateOrNull?.showRendering
 }
 
-/**
- * Returns the [ShowRenderingTag] established by the last call to [View.bindShowRendering],
- * or null if that method has never been called.
- */
 @WorkflowUiExperimentalApi
-@PublishedApi
-internal val View.showRenderingTag: ShowRenderingTag<*>?
-  get() = getTag(R.id.view_show_rendering_function) as? ShowRenderingTag<*>
-
-@WorkflowUiExperimentalApi
-private fun Any.matches(other: Any) = compatible(this, other)
+internal var View.starter: (View) -> Unit
+  get() = workflowViewStateAsNew.starter
+  set(value) {
+    workflowViewState = workflowViewStateAsNew.copy(starter = value)
+  }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewState.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewState.kt
@@ -1,0 +1,58 @@
+package com.squareup.workflow1.ui
+
+import android.view.View
+import com.squareup.workflow1.ui.WorkflowViewState.New
+import com.squareup.workflow1.ui.WorkflowViewState.Started
+
+/**
+ * [View tag][View.setTag] that holds the functions and state backing [View.showRendering], etc.
+ */
+@WorkflowUiExperimentalApi
+@PublishedApi
+internal sealed class WorkflowViewState<out RenderingT : Any> {
+  @PublishedApi
+  internal abstract val showing: RenderingT
+  abstract val environment: ViewEnvironment
+  abstract val showRendering: ViewShowRendering<RenderingT>
+
+  /** [bindShowRendering] has been called, [start] has not. */
+  data class New<out RenderingT : Any>(
+    override val showing: RenderingT,
+    override val environment: ViewEnvironment,
+    override val showRendering: ViewShowRendering<RenderingT>,
+
+    val starter: (View) -> Unit = { view ->
+      view.showRendering(view.getRendering()!!, view.environment!!)
+    }
+  ) : WorkflowViewState<RenderingT>()
+
+  /** [start] has been called. It's safe to call [showRendering] now. */
+  data class Started<out RenderingT : Any>(
+    override val showing: RenderingT,
+    override val environment: ViewEnvironment,
+    override val showRendering: ViewShowRendering<RenderingT>
+  ) : WorkflowViewState<RenderingT>()
+}
+
+@WorkflowUiExperimentalApi
+@PublishedApi
+internal val View.workflowViewStateOrNull: WorkflowViewState<*>?
+  get() = getTag(R.id.workflow_ui_view_state) as? WorkflowViewState<*>
+
+@WorkflowUiExperimentalApi
+internal var View.workflowViewState: WorkflowViewState<*>
+  get() = workflowViewStateOrNull ?: error(
+    "Expected $this to have been built by a ViewFactory. " +
+      "Perhaps the factory did not call View.bindShowRendering."
+  )
+  set(value) = setTag(R.id.workflow_ui_view_state, value)
+
+@WorkflowUiExperimentalApi internal val View.workflowViewStateAsNew: New<*>
+  get() = workflowViewState as? New<*> ?: error(
+    "Expected $this to be un-started, but View.start() has been called"
+  )
+
+@WorkflowUiExperimentalApi internal val View.workflowViewStateAsStarted: Started<*>
+  get() = workflowViewState as? Started<*> ?: error(
+    "Expected $this to have been started, but View.start() has not been called"
+  )

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
@@ -225,12 +225,14 @@ public class WorkflowViewStub @JvmOverloads constructor(
         viewEnvironment,
         parent.context,
         parent,
-        initializeView = {
-          WorkflowLifecycleOwner.installOn(this)
-          showFirstRendering()
+        viewStarter = { view, doStart ->
+          WorkflowLifecycleOwner.installOn(view)
+          doStart()
         }
       )
       .also { newView ->
+        newView.start()
+
         if (inflatedId != NO_ID) newView.id = inflatedId
         if (updatesVisibility) newView.visibility = visibility
         background?.let { newView.background = it }

--- a/workflow-ui/core-android/src/main/res/values/ids.xml
+++ b/workflow-ui/core-android/src/main/res/values/ids.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <!-- View Tag that holds the function to update a view created via ViewRegistry. -->
-  <item name="view_show_rendering_function" type="id"/>
+  <item name="workflow_ui_view_state" type="id"/>
   <!-- View Tag used for back button handlers. -->
   <item name="view_back_handler" type="id"/>
   <!-- View Tag used for EditText textChangedListener. -->

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/CompositeViewRegistryTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/CompositeViewRegistryTest.kt
@@ -6,7 +6,7 @@ import kotlin.reflect.KClass
 import kotlin.test.assertFailsWith
 
 @OptIn(WorkflowUiExperimentalApi::class)
-class CompositeViewRegistryTest {
+internal class CompositeViewRegistryTest {
 
   @Test fun `constructor throws on duplicates`() {
     val fooBarRegistry = TestRegistry(setOf(FooRendering::class, BarRendering::class))

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/TestViewFactory.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/TestViewFactory.kt
@@ -25,8 +25,8 @@ internal class TestViewFactory<R : Any>(override val type: KClass<R>) : ViewFact
     called = true
     return mock {
       on {
-        getTag(eq(com.squareup.workflow1.ui.R.id.view_show_rendering_function))
-      } doReturn (ShowRenderingTag(initialRendering, initialViewEnvironment, { _, _ -> }))
+        getTag(eq(com.squareup.workflow1.ui.R.id.workflow_ui_view_state))
+      } doReturn (WorkflowViewState.New(initialRendering, initialViewEnvironment, { _, _ -> }))
     }
   }
 }


### PR DESCRIPTION
Fixes #597.

It used to be the case that every `DecorativeViewFactory` called
`showRendering()` twice (#397). We fixed that (we thought) by introducing the
`initializeView` lambda to `ViewRegistry.buildView` and
`DecorativeViewFactory` (#408).

Unfortunately, that fix botched recursion. Individual `DecorativeViewFactory`
instances work fine, but if you wrap them you still get one `showRendering`
call from each. Worse, upstream `initializeView` lambdas are clobbered by
immediately downstream ones. e.g., when a `WorkflowViewStub` shows a
`DecorativeViewFactory`, the `WorkflowLifecycleRunner.installOn` call in the
former is clobbered.

The fix is to completely decouple building a view from from this kind of
initialization. `ViewRegistry.buildView` and its wrappers no longer try to
call `showRendering` at all.

Instead the caller of `buildView` (mostly `WorkflowViewStub`) is reponsible
for immediately calling `View.start` on the new `View`. `View.start` makes
the initial `showRendering` call that formerly was the job of
`ViewFactory.buildView` -- the factory builds the view, and the container
turns the key. Since `View.start` is called only after all wrapped
`ViewFactory.buildView` functions have executed, we're certain it will only
happen once.

Of course we still need the ability to customize view initialization via
wrapping, especially to invoke `WorkflowLifecycleOwner.installOn`. To
accomodate that, the function that `View.start` executes can be wrapped via
the new `viewStarter` argument to `ViewRegistry.buildView` and
`DecorativeViewFactory`, which replaces `initializeView`.

This required a pretty thorough overhaul of `ViewShowRendering.kt`
The `ViewShowRenderingTag` that it hangs off of a view tag is renamed
`WorkflowViewState`, and extracted to a separate file.

`WorkflowViewState` is a sealed class with two implementations (`New` and
`Started`) to help us enforce the order of the `ViewRegistry.buildView`,
`View.bindShowRendering`, `View.start` and `View.showRendering` calls.
