### PR TITLE
View.launchWhenAttached tolerates strange ids

### DIFF
--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewLaunchWhenAttached.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewLaunchWhenAttached.kt
@@ -1,5 +1,6 @@
 package com.squareup.workflow1.ui
 
+import android.content.res.Resources.NotFoundException
 import android.view.View
 import android.view.View.NO_ID
 import androidx.lifecycle.ViewTreeLifecycleOwner
@@ -95,8 +96,13 @@ private fun View.ensureAttachedScope(): AttachedScope {
       val coroutineName = buildString {
         append("${view::class.java.name}@${view.hashCode()}")
         if (view.id != NO_ID) {
-          append('-')
-          append(resources.getResourceEntryName(view.id))
+          try {
+            val name = resources.getResourceEntryName(view.id)
+            append('-')
+            append(name)
+          } catch (e: NotFoundException) {
+            // Ignore. It's just a debugging name, who cares.
+          }
         }
       }.let(::CoroutineName)
 

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ViewLaunchWhenAttachedTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ViewLaunchWhenAttachedTest.kt
@@ -1,5 +1,6 @@
 package com.squareup.workflow1.ui
 
+import android.content.res.Resources.NotFoundException
 import android.view.View
 import android.view.View.OnAttachStateChangeListener
 import androidx.lifecycle.Lifecycle.Event.ON_DESTROY
@@ -166,6 +167,34 @@ internal class ViewLaunchWhenAttachedTest {
   @Test fun `launchWhenAttached includes view classname in coroutine name`() {
     var coroutineName: String? = null
     mockAttachedToWindow(view, true)
+
+    // Action: launch coroutine!
+    view.launchWhenAttached {
+      coroutineName = coroutineContext[CoroutineName]?.name
+    }
+
+    assertThat(coroutineName).isNotNull()
+    assertThat(coroutineName).contains("android.view.View")
+    assertThat(coroutineName).contains("${view.hashCode()}")
+  }
+
+  @Test fun `launchWhenAttached includes view id name in coroutine name`() {
+    var coroutineName: String? = null
+    mockAttachedToWindow(view, true)
+    whenever(view.resources.getResourceEntryName(anyInt())).thenReturn("fnord")
+
+    // Action: launch coroutine!
+    view.launchWhenAttached {
+      coroutineName = coroutineContext[CoroutineName]?.name
+    }
+
+    assertThat(coroutineName).contains("fnord")
+  }
+
+  @Test fun `launchWhenAttached tolerates garbage ids`() {
+    var coroutineName: String? = null
+    mockAttachedToWindow(view, true)
+    whenever(view.resources.getResourceEntryName(anyInt())).thenThrow(NotFoundException())
 
     // Action: launch coroutine!
     view.launchWhenAttached {


### PR DESCRIPTION
Fixes a problem where `launchWhenAttached` would crash if it failed to fetch a
resource name when trying to make a cute scope name. I happen to know of some
view systems that break our assumption that every id is named.