### PR TITLE
Introduces ScreenViewFactoryFinder

### DIFF
--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -95,6 +95,20 @@ public final class com/squareup/workflow1/ui/ScreenViewFactory$DefaultImpls {
 	public static synthetic fun buildView$default (Lcom/squareup/workflow1/ui/ScreenViewFactory;Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;ILjava/lang/Object;)Landroid/view/View;
 }
 
+public abstract interface class com/squareup/workflow1/ui/ScreenViewFactoryFinder {
+	public static final field Companion Lcom/squareup/workflow1/ui/ScreenViewFactoryFinder$Companion;
+	public abstract fun getViewFactoryForRendering (Lcom/squareup/workflow1/ui/ViewEnvironment;Lcom/squareup/workflow1/ui/Screen;)Lcom/squareup/workflow1/ui/ScreenViewFactory;
+}
+
+public final class com/squareup/workflow1/ui/ScreenViewFactoryFinder$Companion : com/squareup/workflow1/ui/ViewEnvironmentKey {
+	public fun getDefault ()Lcom/squareup/workflow1/ui/ScreenViewFactoryFinder;
+	public synthetic fun getDefault ()Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow1/ui/ScreenViewFactoryFinder$DefaultImpls {
+	public static fun getViewFactoryForRendering (Lcom/squareup/workflow1/ui/ScreenViewFactoryFinder;Lcom/squareup/workflow1/ui/ViewEnvironment;Lcom/squareup/workflow1/ui/Screen;)Lcom/squareup/workflow1/ui/ScreenViewFactory;
+}
+
 public final class com/squareup/workflow1/ui/ScreenViewFactoryKt {
 	public static final fun buildView (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;Lcom/squareup/workflow1/ui/ViewStarter;)Landroid/view/View;
 	public static synthetic fun buildView$default (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;Lcom/squareup/workflow1/ui/ViewStarter;ILjava/lang/Object;)Landroid/view/View;

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
@@ -8,7 +8,7 @@ import android.view.ViewGroup
 import com.squareup.workflow1.ui.container.BackStackScreen
 import kotlin.reflect.KClass
 
-@Deprecated("Use ViewEnvironment.getViewFactoryForRendering()")
+@Deprecated("Use ScreenViewFactoryFinder.getViewFactoryForRendering()")
 @WorkflowUiExperimentalApi
 public fun <RenderingT : Any>
   ViewRegistry.getFactoryForRendering(rendering: RenderingT): ViewFactory<RenderingT> {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewFactoryFinder.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewFactoryFinder.kt
@@ -1,0 +1,85 @@
+package com.squareup.workflow1.ui
+
+import com.squareup.workflow1.ui.container.BackStackScreen
+import com.squareup.workflow1.ui.container.BackStackScreenViewFactory
+import com.squareup.workflow1.ui.container.BodyAndModalsContainer
+import com.squareup.workflow1.ui.container.BodyAndModalsScreen
+import com.squareup.workflow1.ui.container.EnvironmentScreen
+import com.squareup.workflow1.ui.container.EnvironmentScreenViewFactory
+
+/**
+ * [ViewEnvironment] service object used by [Screen.buildView] to find the right
+ * [ScreenViewFactory]. The default implementation makes [AndroidScreen] work
+ * and provides default bindings for [NamedScreen], [EnvironmentScreen], [BackStackScreen],
+ * etc.
+ *
+ * Here is how this hook could be used to provide a custom view to handle [BackStackScreen]:
+ *
+ *    object MyViewFactory : ScreenViewFactory<BackStackScreen<*>>
+ *    by ManualScreenViewFactory(
+ *      type = BackStackScreen::class,
+ *      viewConstructor = { initialRendering, initialEnv, context, _ ->
+ *        MyBackStackContainer(context)
+ *          .apply {
+ *            layoutParams = (LayoutParams(MATCH_PARENT, MATCH_PARENT))
+ *            bindShowRendering(initialRendering, initialEnv, ::update)
+ *          }
+ *      }
+ *    )
+ *
+ *    object MyFinder : ScreenViewFactoryFinder {
+ *      @Suppress("UNCHECKED_CAST")
+ *      if (rendering is BackStackScreen<*>)
+ *        return MyViewFactory as ScreenViewFactory<ScreenT>
+ *      return super.getViewFactoryForRendering(environment, rendering)
+ *    }
+ *
+ *    class MyViewModel(savedState: SavedStateHandle) : ViewModel() {
+ *      val renderings: StateFlow<MyRootRendering> by lazy {
+ *        val customized = ViewEnvironment() + (ScreenViewFactoryFinder to MyFinder)
+ *        renderWorkflowIn(
+ *          workflow = MyRootWorkflow.withEnvironment(customized),
+ *          scope = viewModelScope,
+ *          savedStateHandle = savedState
+ *        )
+ *      }
+ *    }
+ */
+
+@WorkflowUiExperimentalApi
+public interface ScreenViewFactoryFinder {
+  public fun <ScreenT : Screen> getViewFactoryForRendering(
+    environment: ViewEnvironment,
+    rendering: ScreenT
+  ): ScreenViewFactory<ScreenT> {
+    val entry = environment[ViewRegistry].getEntryFor(rendering::class)
+
+    @Suppress("UNCHECKED_CAST", "DEPRECATION")
+    return (entry as? ScreenViewFactory<ScreenT>)
+      ?: (rendering as? AndroidScreen<*>)?.viewFactory as? ScreenViewFactory<ScreenT>
+      ?: (rendering as? AsScreen<*>)?.let { AsScreenViewFactory as ScreenViewFactory<ScreenT> }
+      ?: (rendering as? BackStackScreen<*>)?.let {
+        BackStackScreenViewFactory as ScreenViewFactory<ScreenT>
+      }
+      ?: (rendering as? BodyAndModalsScreen<*, *>)?.let {
+        BodyAndModalsContainer as ScreenViewFactory<ScreenT>
+      }
+      ?: (rendering as? NamedScreen<*>)?.let {
+        NamedScreenViewFactory as ScreenViewFactory<ScreenT>
+      }
+      ?: (rendering as? EnvironmentScreen<*>)?.let {
+        EnvironmentScreenViewFactory as ScreenViewFactory<ScreenT>
+      }
+      ?: throw IllegalArgumentException(
+        "A ScreenViewFactory should have been registered to display $rendering, " +
+          "or that class should implement AndroidScreen. Instead found $entry."
+      )
+  }
+
+  public companion object : ViewEnvironmentKey<ScreenViewFactoryFinder>(
+    ScreenViewFactoryFinder::class
+  ) {
+    override val default: ScreenViewFactoryFinder
+      get() = object : ScreenViewFactoryFinder {}
+  }
+}

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ScreenViewFactoryTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ScreenViewFactoryTest.kt
@@ -74,7 +74,7 @@ internal class ScreenViewFactoryTest {
 
       return mock {
         on {
-          getTag(eq(com.squareup.workflow1.ui.R.id.workflow_ui_view_state))
+          getTag(eq(R.id.workflow_ui_view_state))
         } doReturn (WorkflowViewState.New(initialRendering, initialViewEnvironment, { _, _ -> }))
       }
     }


### PR DESCRIPTION
Fixes #594, which was about how impractical it is to wrap the `ViewRegistry`
interface, by introducing a higher level interface that's easy to wrap.

The problem is that the fundamental method is `getFactoryFor(KClass)`, but
lots of crucial behavior (e.g. `AndroidViewRendering` /
`AndroidScreenRendering`) is in the `getFactoryForRendering` extension
method. But if we change the fundamental method to be instance based instead
of type based, we bring back a lot of potential complexity to `ViewRegistry`
that the original type-based choice very intentionally restricted.

To have our cake and eat it too, we move the extension method to a new
`ViewEnvironment` service interface, `ScreenViewFactoryFinder`. Ta da,
totally customizable, with the defaults totally built in.