### PR TITLE
Undoes port of AlertContainerScreen to Screen

### DIFF
--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/TimeMachineAppWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/TimeMachineAppWorkflow.kt
@@ -7,7 +7,10 @@ import com.squareup.sample.timemachine.shakeable.ShakeableTimeMachineScreen
 import com.squareup.sample.timemachine.shakeable.ShakeableTimeMachineWorkflow
 import com.squareup.sample.timemachine.shakeable.ShakeableTimeMachineWorkflow.PropsFactory
 import com.squareup.workflow1.StatelessWorkflow
+import com.squareup.workflow1.mapRendering
 import com.squareup.workflow1.renderChild
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.asScreen
 import kotlin.time.ExperimentalTime
 import kotlin.time.TimeSource
 
@@ -15,15 +18,19 @@ import kotlin.time.TimeSource
  * A workflow that wraps [DungeonAppWorkflow] with a [ShakeableTimeMachineWorkflow] to enable
  * time travel debugging.
  */
-@OptIn(ExperimentalTime::class)
+@OptIn(ExperimentalTime::class, WorkflowUiExperimentalApi::class)
 class TimeMachineAppWorkflow(
   appWorkflow: DungeonAppWorkflow,
   clock: TimeSource,
   context: Context
 ) : StatelessWorkflow<BoardPath, Nothing, ShakeableTimeMachineScreen>() {
 
+  @Suppress("DEPRECATION")
   private val timeMachineWorkflow =
-    ShakeableTimeMachineWorkflow(TimeMachineWorkflow(appWorkflow, clock), context)
+    ShakeableTimeMachineWorkflow(
+      TimeMachineWorkflow(appWorkflow.mapRendering { asScreen(it) }, clock),
+      context
+    )
 
   override fun render(
     renderProps: BoardPath,

--- a/workflow-ui/container-android/api/container-android.api
+++ b/workflow-ui/container-android/api/container-android.api
@@ -20,11 +20,11 @@ public final class com/squareup/workflow1/ui/modal/AlertContainer : com/squareup
 	public synthetic fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/modal/ModalContainer$DialogRef;
 }
 
-public final class com/squareup/workflow1/ui/modal/AlertContainer$Companion : com/squareup/workflow1/ui/ScreenViewFactory {
-	public synthetic fun buildView (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+public final class com/squareup/workflow1/ui/modal/AlertContainer$Companion : com/squareup/workflow1/ui/ViewFactory {
 	public fun buildView (Lcom/squareup/workflow1/ui/modal/AlertContainerScreen;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
-	public final fun customThemeBinding (I)Lcom/squareup/workflow1/ui/ScreenViewFactory;
-	public static synthetic fun customThemeBinding$default (Lcom/squareup/workflow1/ui/modal/AlertContainer$Companion;IILjava/lang/Object;)Lcom/squareup/workflow1/ui/ScreenViewFactory;
+	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public final fun customThemeBinding (I)Lcom/squareup/workflow1/ui/ViewFactory;
+	public static synthetic fun customThemeBinding$default (Lcom/squareup/workflow1/ui/modal/AlertContainer$Companion;IILjava/lang/Object;)Lcom/squareup/workflow1/ui/ViewFactory;
 	public fun getType ()Lkotlin/reflect/KClass;
 }
 

--- a/workflow-ui/container-android/src/main/java/com/squareup/workflow1/ui/modal/AlertContainer.kt
+++ b/workflow-ui/container-android/src/main/java/com/squareup/workflow1/ui/modal/AlertContainer.kt
@@ -10,9 +10,9 @@ import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.annotation.StyleRes
 import androidx.appcompat.app.AlertDialog
-import com.squareup.workflow1.ui.ManualScreenViewFactory
-import com.squareup.workflow1.ui.ScreenViewFactory
+import com.squareup.workflow1.ui.BuilderViewFactory
 import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.bindShowRendering
 import com.squareup.workflow1.ui.container.R
@@ -83,22 +83,21 @@ public class AlertContainer @JvmOverloads constructor(
 
   private class AlertContainerViewFactory(
     @StyleRes private val dialogThemeResId: Int = 0
-  ) : ScreenViewFactory<AlertContainerScreen<*>> by ManualScreenViewFactory(
-    type = AlertContainerScreen::class,
-    viewConstructor = { initialRendering, initialEnv, context, _ ->
-      AlertContainer(context, dialogThemeResId = dialogThemeResId)
-        .apply {
-          id = R.id.workflow_alert_container
-          layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
-          bindShowRendering(initialRendering, initialEnv, ::update)
-        }
-    }
+  ) : ViewFactory<AlertContainerScreen<*>> by BuilderViewFactory(
+      type = AlertContainerScreen::class,
+      viewConstructor = { initialRendering, initialEnv, context, _ ->
+        AlertContainer(context, dialogThemeResId = dialogThemeResId)
+            .apply {
+              id = R.id.workflow_alert_container
+              layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+              bindShowRendering(initialRendering, initialEnv, ::update)
+            }
+      }
   )
 
-  public companion object : ScreenViewFactory<AlertContainerScreen<*>>
-  by AlertContainerViewFactory() {
+  public companion object : ViewFactory<AlertContainerScreen<*>> by AlertContainerViewFactory() {
     /**
-     * Creates a [ScreenViewFactory] to show the [AlertScreen]s of an [AlertContainerScreen]
+     * Creates a [ViewFactory] to show the [AlertScreen]s of an [AlertContainerScreen]
      * as Android `AlertDialog`s.
      *
      * @param dialogThemeResId the resource ID of the theme against which to inflate
@@ -106,6 +105,6 @@ public class AlertContainer @JvmOverloads constructor(
      */
     public fun customThemeBinding(
       @StyleRes dialogThemeResId: Int = 0
-    ): ScreenViewFactory<AlertContainerScreen<*>> = AlertContainerViewFactory(dialogThemeResId)
+    ): ViewFactory<AlertContainerScreen<*>> = AlertContainerViewFactory(dialogThemeResId)
   }
 }

--- a/workflow-ui/container-common/api/container-common.api
+++ b/workflow-ui/container-common/api/container-common.api
@@ -19,7 +19,7 @@ public final class com/squareup/workflow1/ui/backstack/BackStackScreenKt {
 	public static final fun toBackStackScreenOrNull (Ljava/util/List;)Lcom/squareup/workflow1/ui/backstack/BackStackScreen;
 }
 
-public final class com/squareup/workflow1/ui/modal/AlertContainerScreen : com/squareup/workflow1/ui/Screen, com/squareup/workflow1/ui/modal/HasModals {
+public final class com/squareup/workflow1/ui/modal/AlertContainerScreen : com/squareup/workflow1/ui/modal/HasModals {
 	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow1/ui/modal/AlertScreen;)V
 	public fun <init> (Ljava/lang/Object;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/lang/Object;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/modal/AlertContainerScreen.kt
+++ b/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/modal/AlertContainerScreen.kt
@@ -2,7 +2,6 @@
 
 package com.squareup.workflow1.ui.modal
 
-import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
 /**
@@ -21,7 +20,7 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 public data class AlertContainerScreen<B : Any>(
   override val beneathModals: B,
   override val modals: List<AlertScreen> = emptyList()
-) : Screen, HasModals<B, AlertScreen> {
+) : HasModals<B, AlertScreen> {
   public constructor(
     baseScreen: B,
     alert: AlertScreen


### PR DESCRIPTION
It is entirely legacy, with no direct counterpart in the new world. Giving it a foot in both worlds just makes it harder to adopt the workflow update.