### PR TITLE
Simpler, safer ViewEnvironment and ViewRegistry management.

### DIFF
--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/App.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/App.kt
@@ -16,10 +16,9 @@ import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.WorkflowRendering
 import com.squareup.workflow1.ui.compose.renderAsState
+import com.squareup.workflow1.ui.plus
 
-private val viewRegistry = ViewRegistry(HelloBinding)
-
-private val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+private val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(HelloBinding)
 
 @Composable fun App() {
   MaterialTheme {

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloBindingActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloBindingActivity.kt
@@ -15,15 +15,13 @@ import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.composeViewFactory
 import com.squareup.workflow1.ui.compose.withCompositionRoot
+import com.squareup.workflow1.ui.plus
 import com.squareup.workflow1.ui.renderWorkflowIn
 import kotlinx.coroutines.flow.StateFlow
 
 @OptIn(WorkflowUiExperimentalApi::class)
-private val viewRegistry = ViewRegistry(HelloBinding)
-
-@OptIn(WorkflowUiExperimentalApi::class)
 private val viewEnvironment =
-  ViewEnvironment(mapOf(ViewRegistry to viewRegistry)).withCompositionRoot { content ->
+  (ViewEnvironment.EMPTY + ViewRegistry(HelloBinding)).withCompositionRoot { content ->
     MaterialTheme(content = content)
   }
 
@@ -37,12 +35,12 @@ class HelloBindingActivity : AppCompatActivity() {
 
     val model: HelloBindingModel by viewModels()
     setContentView(
-        WorkflowLayout(this).apply {
-          start(
-              renderings = model.renderings,
-              environment = viewEnvironment
-          )
-        }
+      WorkflowLayout(this).apply {
+        start(
+          renderings = model.renderings,
+          environment = viewEnvironment
+        )
+      }
     )
   }
 
@@ -50,9 +48,9 @@ class HelloBindingActivity : AppCompatActivity() {
     @OptIn(WorkflowUiExperimentalApi::class)
     val renderings: StateFlow<Any> by lazy {
       renderWorkflowIn(
-          workflow = HelloWorkflow,
-          scope = viewModelScope,
-          savedStateHandle = savedState
+        workflow = HelloWorkflow,
+        scope = viewModelScope,
+        savedStateHandle = savedState
       )
     }
   }

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/HelloComposeWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/HelloComposeWorkflow.kt
@@ -48,5 +48,5 @@ object HelloComposeWorkflow : ComposeWorkflow<String, Toggle>() {
 @Preview(showBackground = true)
 @Composable fun HelloComposeWorkflowPreview() {
   val rendering by HelloComposeWorkflow.renderAsState(props = "hello", onOutput = {})
-  WorkflowRendering(rendering, ViewEnvironment())
+  WorkflowRendering(rendering, ViewEnvironment.EMPTY)
 }

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
@@ -55,7 +55,7 @@ object InlineRenderingWorkflow : StatefulWorkflow<Unit, Int, Nothing, AndroidVie
 @Preview
 @Composable fun InlineRenderingWorkflowPreview() {
   val rendering by InlineRenderingWorkflow.renderAsState(props = Unit, onOutput = {})
-  WorkflowRendering(rendering, ViewEnvironment())
+  WorkflowRendering(rendering, ViewEnvironment.EMPTY)
 }
 
 @OptIn(ExperimentalAnimationApi::class)

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsActivity.kt
@@ -15,6 +15,7 @@ import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.withCompositionRoot
+import com.squareup.workflow1.ui.plus
 import com.squareup.workflow1.ui.renderWorkflowIn
 import kotlinx.coroutines.flow.StateFlow
 
@@ -26,7 +27,7 @@ private val viewRegistry = ViewRegistry(
 
 @OptIn(WorkflowUiExperimentalApi::class)
 private val viewEnvironment =
-  ViewEnvironment(mapOf(ViewRegistry to viewRegistry)).withCompositionRoot { content ->
+  (ViewEnvironment.EMPTY + viewRegistry).withCompositionRoot { content ->
     CompositionLocalProvider(LocalBackgroundColor provides Color.Green) {
       content()
     }

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/App.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/App.kt
@@ -1,4 +1,5 @@
 @file:OptIn(WorkflowUiExperimentalApi::class)
+@file:Suppress("FunctionName")
 
 package com.squareup.sample.compose.textinput
 
@@ -11,10 +12,9 @@ import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.WorkflowRendering
 import com.squareup.workflow1.ui.compose.renderAsState
+import com.squareup.workflow1.ui.plus
 
-private val viewRegistry = ViewRegistry(TextInputViewFactory)
-
-private val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+private val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(TextInputViewFactory)
 
 @Composable fun TextInputApp() {
   MaterialTheme {

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailConfig.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailConfig.kt
@@ -1,7 +1,8 @@
 package com.squareup.sample.container.overviewdetail
 
-import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewEnvironmentKey
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
 /**
  * [com.squareup.workflow1.ui.ViewEnvironment] value that informs views
@@ -34,3 +35,7 @@ enum class OverviewDetailConfig {
     override val default = None
   }
 }
+
+@WorkflowUiExperimentalApi
+operator fun ViewEnvironment.plus(config: OverviewDetailConfig): ViewEnvironment =
+  this + (OverviewDetailConfig to config)

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailContainer.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailContainer.kt
@@ -56,14 +56,14 @@ class OverviewDetailContainer(view: View) : ScreenViewRunner<OverviewDetailScree
       // Since we have two sibling back stacks, we need to give them each different
       // SavedStateRegistry key prefixes.
       val overviewViewEnvironment = viewEnvironment
-        .withBackStackStateKeyPrefix(OverviewBackStackKey) + (OverviewDetailConfig to Overview)
+        .withBackStackStateKeyPrefix(OverviewBackStackKey) + Overview
       overviewStub!!.show(rendering.overviewRendering, overviewViewEnvironment)
       rendering.detailRendering
         ?.let { detail ->
           detailStub!!.actual.visibility = VISIBLE
           detailStub.show(
             detail,
-            viewEnvironment + (OverviewDetailConfig to Detail)
+            viewEnvironment + Detail
           )
         }
         ?: run {
@@ -81,7 +81,7 @@ class OverviewDetailContainer(view: View) : ScreenViewRunner<OverviewDetailScree
       ?.let { rendering.overviewRendering + it }
       ?: rendering.overviewRendering
 
-    stub.show(combined, viewEnvironment + (OverviewDetailConfig to Single))
+    stub.show(combined, viewEnvironment + Single)
   }
 
   companion object : ScreenViewFactory<OverviewDetailScreen> by ScreenViewRunner.bind(

--- a/workflow-ui/compose-tooling/src/androidTest/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewFactoryTest.kt
+++ b/workflow-ui/compose-tooling/src/androidTest/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewFactoryTest.kt
@@ -79,7 +79,7 @@ internal class PreviewViewFactoryTest {
     composeRule.onNodeWithText("two").assertIsNotDisplayed()
   }
 
-  @Test fun customViewEnvironment() {
+  @Test fun customViewEnvironment.EMPTY {
     composeRule.setContent {
       ParentConsumesCustomKeyPreview()
     }

--- a/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewEnvironment.kt
+++ b/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewEnvironment.kt
@@ -11,6 +11,7 @@ import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.plus
 import kotlin.reflect.KClass
 
 /**
@@ -30,7 +31,7 @@ import kotlin.reflect.KClass
     PreviewViewRegistry(mainFactory, placeholderViewFactory(placeholderModifier))
   }
   return remember(viewRegistry, viewEnvironmentUpdater) {
-    ViewEnvironment(mapOf(ViewRegistry to viewRegistry)).let { environment ->
+    (ViewEnvironment.EMPTY + viewRegistry).let { environment ->
       // Give the preview a chance to add its own elements to the ViewEnvironment.
       viewEnvironmentUpdater?.let { it(environment) } ?: environment
     }

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewFactoryTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewFactoryTest.kt
@@ -24,6 +24,7 @@ import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.WorkflowViewStub
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
+import com.squareup.workflow1.ui.plus
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,8 +40,7 @@ internal class ComposeViewFactoryTest {
     val viewFactory = composeViewFactory<Unit> { _, _ ->
       BasicText("Hello, world!")
     }
-    val viewRegistry = ViewRegistry(viewFactory)
-    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+    val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(viewFactory)
 
     composeRule.setContent {
       AndroidView(::RootView) {
@@ -55,8 +55,7 @@ internal class ComposeViewFactoryTest {
     val viewFactory = composeViewFactory<String> { rendering, _ ->
       BasicText(rendering, Modifier.testTag("text"))
     }
-    val viewRegistry = ViewRegistry(viewFactory)
-    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+    val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(viewFactory)
     var rendering by mutableStateOf("hello")
 
     composeRule.setContent {
@@ -82,12 +81,7 @@ internal class ComposeViewFactoryTest {
     }
     val viewRegistry = ViewRegistry(viewFactory)
     var viewEnvironment by mutableStateOf(
-      ViewEnvironment(
-        mapOf(
-          ViewRegistry to viewRegistry,
-          testEnvironmentKey to "hello"
-        )
-      )
+      ViewEnvironment.EMPTY + viewRegistry + (testEnvironmentKey to "hello")
     )
 
     composeRule.setContent {
@@ -104,7 +98,7 @@ internal class ComposeViewFactoryTest {
 
   @Test fun wrapsFactoryWithRoot() {
     val wrapperText = mutableStateOf("one")
-    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to ViewRegistry(TestFactory)))
+    val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(TestFactory)
       .withCompositionRoot { content ->
         Column {
           BasicText(wrapperText.value)

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -27,19 +27,20 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
 import com.squareup.workflow1.ui.AndroidViewRendering
-import com.squareup.workflow1.ui.asScreen
 import com.squareup.workflow1.ui.Compatible
 import com.squareup.workflow1.ui.NamedScreen
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.asScreen
 import com.squareup.workflow1.ui.bindShowRendering
 import com.squareup.workflow1.ui.container.BackStackScreen
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
 import com.squareup.workflow1.ui.internal.test.WorkflowUiTestActivity
 import com.squareup.workflow1.ui.modal.HasModals
 import com.squareup.workflow1.ui.modal.ModalViewContainer
+import com.squareup.workflow1.ui.plus
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -55,14 +56,8 @@ internal class ComposeViewTreeIntegrationTest {
 
   @Before fun setUp() {
     scenario.onActivity {
-      it.viewEnvironment = ViewEnvironment(
-        mapOf(
-          ViewRegistry to ViewRegistry(
-            ModalViewContainer.binding<TestModalScreen>(),
-            NoTransitionBackStackContainer,
-          )
-        )
-      )
+      it.viewEnvironment = ViewEnvironment.EMPTY +
+        ViewRegistry(ModalViewContainer.binding<TestModalScreen>(), NoTransitionBackStackContainer)
     }
   }
 

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/WorkflowRenderingTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/WorkflowRenderingTest.kt
@@ -68,6 +68,7 @@ import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.bindShowRendering
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
+import com.squareup.workflow1.ui.plus
 import org.hamcrest.Description
 import org.hamcrest.TypeSafeMatcher
 import org.junit.Rule
@@ -92,7 +93,7 @@ internal class WorkflowRenderingTest {
     val registry = mutableStateOf(registry1)
 
     composeRule.setContent {
-      WorkflowRendering("hello", ViewEnvironment(mapOf(ViewRegistry to registry.value)))
+      WorkflowRendering("hello", ViewEnvironment.EMPTY + registry.value)
     }
 
     composeRule.onNodeWithText("hello").assertIsDisplayed()
@@ -116,7 +117,7 @@ internal class WorkflowRenderingTest {
     var rendering by mutableStateOf(ShiftyRendering(true))
 
     composeRule.setContent {
-      WorkflowRendering(rendering, ViewEnvironment())
+      WorkflowRendering(rendering, ViewEnvironment.EMPTY)
     }
 
     composeRule.onNodeWithText("one").assertIsDisplayed()
@@ -130,7 +131,7 @@ internal class WorkflowRenderingTest {
     val testFactory = composeViewFactory<TestRendering> { rendering, _ ->
       BasicText(rendering.text)
     }
-    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to ViewRegistry(testFactory)))
+    val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(testFactory)
       .withCompositionRoot { content ->
         Column {
           BasicText("one")
@@ -150,7 +151,7 @@ internal class WorkflowRenderingTest {
     val wrapperText = mutableStateOf("two")
 
     composeRule.setContent {
-      WorkflowRendering(LegacyViewRendering(wrapperText.value), ViewEnvironment())
+      WorkflowRendering(LegacyViewRendering(wrapperText.value), ViewEnvironment.EMPTY)
     }
 
     onView(withText("two")).check(matches(isDisplayed()))
@@ -164,7 +165,7 @@ internal class WorkflowRenderingTest {
 
     composeRule.setContent {
       val rendering = Named(LegacyViewRendering(wrapperText.value), "fnord")
-      WorkflowRendering(rendering, ViewEnvironment())
+      WorkflowRendering(rendering, ViewEnvironment.EMPTY)
     }
 
     onView(withText("two")).check(matches(isDisplayed()))
@@ -196,7 +197,7 @@ internal class WorkflowRenderingTest {
 
     var rendering: Any by mutableStateOf(LifecycleRecorder())
     composeRule.setContent {
-      WorkflowRendering(rendering, ViewEnvironment())
+      WorkflowRendering(rendering, ViewEnvironment.EMPTY)
     }
 
     composeRule.runOnIdle {
@@ -242,7 +243,7 @@ internal class WorkflowRenderingTest {
 
     var rendering: Any by mutableStateOf(LifecycleRecorder())
     composeRule.setContent {
-      WorkflowRendering(rendering, ViewEnvironment())
+      WorkflowRendering(rendering, ViewEnvironment.EMPTY)
     }
 
     composeRule.runOnIdle {
@@ -266,7 +267,7 @@ internal class WorkflowRenderingTest {
 
     composeRule.setContent {
       CompositionLocalProvider(LocalLifecycleOwner provides parentOwner) {
-        WorkflowRendering(LifecycleRecorder(states), ViewEnvironment())
+        WorkflowRendering(LifecycleRecorder(states), ViewEnvironment.EMPTY)
       }
     }
 
@@ -311,7 +312,7 @@ internal class WorkflowRenderingTest {
 
     composeRule.setContent {
       CompositionLocalProvider(LocalLifecycleOwner provides parentOwner) {
-        WorkflowRendering(LifecycleRecorder(states), ViewEnvironment())
+        WorkflowRendering(LifecycleRecorder(states), ViewEnvironment.EMPTY)
       }
     }
 
@@ -333,7 +334,7 @@ internal class WorkflowRenderingTest {
 
     composeRule.setContent {
       WorkflowRendering(
-        Rendering(), ViewEnvironment(),
+        Rendering(), ViewEnvironment.EMPTY,
         Modifier.size(width = 42.dp, height = 43.dp)
       )
     }
@@ -352,7 +353,7 @@ internal class WorkflowRenderingTest {
 
     composeRule.setContent {
       WorkflowRendering(
-        Rendering(), ViewEnvironment(),
+        Rendering(), ViewEnvironment.EMPTY,
         Modifier.sizeIn(minWidth = 42.dp, minHeight = 43.dp)
       )
     }
@@ -382,7 +383,7 @@ internal class WorkflowRenderingTest {
     composeRule.setContent {
       with(LocalDensity.current) {
         WorkflowRendering(
-          LegacyRendering(viewId), ViewEnvironment(),
+          LegacyRendering(viewId), ViewEnvironment.EMPTY,
           Modifier.size(42.toDp(), 43.toDp())
         )
       }
@@ -393,6 +394,7 @@ internal class WorkflowRenderingTest {
 
   @Test fun skipsPreviousContentWhenIncompatible() {
     var disposeCount = 0
+
     class Rendering(
       override val compatibilityKey: String
     ) : ComposableRendering<Rendering>, Compatible {
@@ -416,7 +418,7 @@ internal class WorkflowRenderingTest {
 
     var key by mutableStateOf("one")
     composeRule.setContent {
-      WorkflowRendering(Rendering(key), ViewEnvironment())
+      WorkflowRendering(Rendering(key), ViewEnvironment.EMPTY)
     }
 
     composeRule.onNodeWithTag("tag")
@@ -466,7 +468,7 @@ internal class WorkflowRenderingTest {
 
     var text by mutableStateOf("one")
     composeRule.setContent {
-      WorkflowRendering(Rendering(text), ViewEnvironment())
+      WorkflowRendering(Rendering(text), ViewEnvironment.EMPTY)
     }
 
     composeRule.onNodeWithTag("tag")
@@ -542,7 +544,7 @@ internal class WorkflowRenderingTest {
 
   private data class LegacyViewRendering(
     val text: String
-    ) : AndroidViewRendering<LegacyViewRendering> {
+  ) : AndroidViewRendering<LegacyViewRendering> {
     override val viewFactory: ViewFactory<LegacyViewRendering> =
       object : ViewFactory<LegacyViewRendering> {
         override val type = LegacyViewRendering::class

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -260,6 +260,10 @@ public final class com/squareup/workflow1/ui/container/BackStackConfig$Companion
 	public synthetic fun getDefault ()Ljava/lang/Object;
 }
 
+public final class com/squareup/workflow1/ui/container/BackStackConfigKt {
+	public static final fun plus (Lcom/squareup/workflow1/ui/ViewEnvironment;Lcom/squareup/workflow1/ui/container/BackStackConfig;)Lcom/squareup/workflow1/ui/ViewEnvironment;
+}
+
 public class com/squareup/workflow1/ui/container/BackStackContainer : android/widget/FrameLayout {
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
@@ -312,14 +316,18 @@ public abstract class com/squareup/workflow1/ui/container/ModalScreenOverlayDial
 	public final fun updateDialog (Landroid/app/Dialog;Lcom/squareup/workflow1/ui/container/ScreenOverlay;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
 }
 
-public final class com/squareup/workflow1/ui/container/ModalScreenOverlayOnBackPressed : com/squareup/workflow1/ui/ViewEnvironmentKey {
-	public static final field INSTANCE Lcom/squareup/workflow1/ui/container/ModalScreenOverlayOnBackPressed;
-	public fun getDefault ()Lcom/squareup/workflow1/ui/container/ModalScreenOverlayOnBackPressed$Handler;
+public abstract interface class com/squareup/workflow1/ui/container/ModalScreenOverlayOnBackPressed {
+	public static final field Companion Lcom/squareup/workflow1/ui/container/ModalScreenOverlayOnBackPressed$Companion;
+	public abstract fun onBackPressed (Landroid/view/View;)Z
+}
+
+public final class com/squareup/workflow1/ui/container/ModalScreenOverlayOnBackPressed$Companion : com/squareup/workflow1/ui/ViewEnvironmentKey {
+	public fun getDefault ()Lcom/squareup/workflow1/ui/container/ModalScreenOverlayOnBackPressed;
 	public synthetic fun getDefault ()Ljava/lang/Object;
 }
 
-public abstract interface class com/squareup/workflow1/ui/container/ModalScreenOverlayOnBackPressed$Handler {
-	public abstract fun onBackPressed (Landroid/view/View;)Z
+public final class com/squareup/workflow1/ui/container/ModalScreenOverlayOnBackPressedKt {
+	public static final fun plus (Lcom/squareup/workflow1/ui/ViewEnvironment;Lcom/squareup/workflow1/ui/container/ModalScreenOverlayOnBackPressed;)Lcom/squareup/workflow1/ui/ViewEnvironment;
 }
 
 public abstract interface class com/squareup/workflow1/ui/container/OverlayDialogFactory : com/squareup/workflow1/ui/ViewRegistry$Entry {

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/DecorativeScreenViewFactoryTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/DecorativeScreenViewFactoryTest.kt
@@ -44,8 +44,7 @@ internal class DecorativeScreenViewFactoryTest {
         events += "exit viewStarter"
       }
     )
-    val viewRegistry = ViewRegistry(innerViewFactory, outerViewFactory)
-    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+    val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(innerViewFactory, outerViewFactory)
 
     OuterRendering("outer", InnerRendering("inner")).buildView(
       viewEnvironment,
@@ -84,8 +83,7 @@ internal class DecorativeScreenViewFactoryTest {
         innerShowRendering(outerRendering.wrapped, env)
       }
     )
-    val viewRegistry = ViewRegistry(innerViewFactory, outerViewFactory)
-    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+    val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(innerViewFactory, outerViewFactory)
 
     OuterRendering("outer", InnerRendering("inner")).buildView(
       viewEnvironment,
@@ -146,8 +144,8 @@ internal class DecorativeScreenViewFactoryTest {
         events += "exit way out viewStarter"
       }
     )
-    val viewRegistry = ViewRegistry(innerViewFactory, outerViewFactory, wayOutViewFactory)
-    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+    val viewEnvironment =
+      ViewEnvironment.EMPTY + ViewRegistry(innerViewFactory, outerViewFactory, wayOutViewFactory)
 
     WayOutRendering("way out", OuterRendering("outer", InnerRendering("inner"))).buildView(
       viewEnvironment,
@@ -199,8 +197,7 @@ internal class DecorativeScreenViewFactoryTest {
         innerShowRendering(outerRendering.wrapped, env)
       }
     )
-    val viewRegistry = ViewRegistry(innerViewFactory, outerViewFactory)
-    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+    val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(innerViewFactory, outerViewFactory)
 
     val view = OuterRendering("out1", InnerRendering("in1")).buildView(
       viewEnvironment,

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/DecorativeViewFactoryTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/DecorativeViewFactoryTest.kt
@@ -47,7 +47,7 @@ internal class DecorativeViewFactoryTest {
       }
     )
     val viewRegistry = ViewRegistry(innerViewFactory, outerViewFactory)
-    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+    val viewEnvironment = ViewEnvironment.EMPTY + viewRegistry
 
     viewRegistry.buildView(
       OuterRendering("outer", InnerRendering("inner")),
@@ -88,7 +88,7 @@ internal class DecorativeViewFactoryTest {
       }
     )
     val viewRegistry = ViewRegistry(innerViewFactory, outerViewFactory)
-    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+    val viewEnvironment = ViewEnvironment.EMPTY + viewRegistry
 
     viewRegistry.buildView(
       OuterRendering("outer", InnerRendering("inner")),
@@ -151,7 +151,7 @@ internal class DecorativeViewFactoryTest {
       }
     )
     val viewRegistry = ViewRegistry(innerViewFactory, outerViewFactory, wayOutViewFactory)
-    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+    val viewEnvironment = ViewEnvironment.EMPTY + viewRegistry
 
     viewRegistry.buildView(
       WayOutRendering("way out", OuterRendering("outer", InnerRendering("inner"))),
@@ -205,7 +205,7 @@ internal class DecorativeViewFactoryTest {
       }
     )
     val viewRegistry = ViewRegistry(innerViewFactory, outerViewFactory)
-    val viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+    val viewEnvironment = ViewEnvironment.EMPTY + viewRegistry
 
     val view = viewRegistry.buildView(
       OuterRendering("out1", InnerRendering("in1")),

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/ViewStateCacheTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/ViewStateCacheTest.kt
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith
 internal class ViewStateCacheTest {
 
   private val instrumentation = InstrumentationRegistry.getInstrumentation()
-  private val viewEnvironment = ViewEnvironment()
+  private val viewEnvironment = ViewEnvironment.EMPTY
 
   private object AScreen : Screen
 

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
@@ -26,7 +26,10 @@ public fun <RenderingT : Any>
     )
 }
 
-@Deprecated("Use getEntryFor()")
+@Deprecated(
+  "Use getEntryFor()",
+  ReplaceWith("getEntryFor(renderingType)")
+)
 @WorkflowUiExperimentalApi
 public fun <RenderingT : Any> ViewRegistry.getFactoryFor(
   renderingType: KClass<out RenderingT>
@@ -34,8 +37,7 @@ public fun <RenderingT : Any> ViewRegistry.getFactoryFor(
   return getEntryFor(renderingType) as? ViewFactory<RenderingT>
 }
 
-@Suppress("DEPRECATION")
-@Deprecated("Use Screen.buildview")
+@Deprecated("Use Screen.buildView")
 @WorkflowUiExperimentalApi
 public fun <RenderingT : Any> ViewRegistry.buildView(
   initialRendering: RenderingT,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
@@ -78,7 +78,7 @@ public class WorkflowLayout(
     registry: ViewRegistry
   ) {
     @Suppress("DEPRECATION")
-    start(renderings, ViewEnvironment(mapOf(ViewRegistry to registry)))
+    start(renderings, ViewEnvironment.EMPTY + registry)
   }
 
   @Deprecated(
@@ -94,7 +94,7 @@ public class WorkflowLayout(
   )
   public fun start(
     renderings: Flow<Any>,
-    environment: ViewEnvironment = ViewEnvironment()
+    environment: ViewEnvironment = ViewEnvironment.EMPTY
   ) {
     takeWhileAttached(renderings) {
       @Suppress("DEPRECATION")

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BackStackConfig.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BackStackConfig.kt
@@ -1,7 +1,8 @@
 package com.squareup.workflow1.ui.container
 
-import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewEnvironmentKey
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.container.BackStackConfig.First
 import com.squareup.workflow1.ui.container.BackStackConfig.Other
 
@@ -32,3 +33,7 @@ public enum class BackStackConfig {
     override val default: BackStackConfig = None
   }
 }
+
+@WorkflowUiExperimentalApi
+public operator fun ViewEnvironment.plus(config: BackStackConfig): ViewEnvironment =
+  this + (BackStackConfig to config)

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BackStackContainer.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BackStackContainer.kt
@@ -77,7 +77,7 @@ public open class BackStackContainer @JvmOverloads constructor(
     updateStateRegistryKey(newViewEnvironment)
 
     val config = if (newRendering.backStack.isEmpty()) First else Other
-    val environment = newViewEnvironment + (BackStackConfig to config)
+    val environment = newViewEnvironment + config
 
     val named: BackStackScreen<NamedScreen<*>> = newRendering
       // ViewStateCache requires that everything be Named.

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BodyAndModalsContainer.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BodyAndModalsContainer.kt
@@ -36,6 +36,7 @@ internal class BodyAndModalsContainer @JvmOverloads constructor(
   }
 
   private val dialogs = LayeredDialogs(view = this, modal = true)
+
   // The bounds of this view in global (display) coordinates, as reported
   // by getGlobalVisibleRect.
   //
@@ -86,7 +87,7 @@ internal class BodyAndModalsContainer @JvmOverloads constructor(
 
     // Allow modal dialogs to restrict themselves to cover only this view.
     val dialogsEnv =
-      if (showingModals) viewEnvironment + (ModalArea to ModalArea(bounds)) else viewEnvironment
+      if (showingModals) viewEnvironment + ModalArea(bounds) else viewEnvironment
 
     dialogs.update(newScreen.modals, dialogsEnv)
   }
@@ -103,7 +104,7 @@ internal class BodyAndModalsContainer @JvmOverloads constructor(
   override fun onDetachedFromWindow() {
     // Don't leak the dialogs if we're suddenly yanked out of view.
     // https://github.com/square/workflow-kotlin/issues/314
-    dialogs.update(emptyList(), ViewEnvironment())
+    dialogs.update(emptyList(), ViewEnvironment.EMPTY)
     viewTreeObserver.removeOnGlobalLayoutListener(boundsListener)
     bounds.value = Rect()
     super.onDetachedFromWindow()

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreenViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreenViewFactory.kt
@@ -3,7 +3,7 @@ package com.squareup.workflow1.ui.container
 import com.squareup.workflow1.ui.DecorativeScreenViewFactory
 import com.squareup.workflow1.ui.ScreenViewFactory
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.updateFrom
+import com.squareup.workflow1.ui.merge
 
 @WorkflowUiExperimentalApi
 internal object EnvironmentScreenViewFactory : ScreenViewFactory<EnvironmentScreen<*>>
@@ -12,7 +12,7 @@ by DecorativeScreenViewFactory(
   map = { withEnvironment, inheritedEnvironment ->
     Pair(
       withEnvironment.screen,
-      inheritedEnvironment.updateFrom(withEnvironment.viewEnvironment)
+      inheritedEnvironment merge withEnvironment.viewEnvironment
     )
   }
 )

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/ModalArea.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/ModalArea.kt
@@ -1,6 +1,7 @@
 package com.squareup.workflow1.ui.container
 
 import android.graphics.Rect
+import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewEnvironmentKey
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,3 +19,7 @@ internal class ModalArea(
     override val default: ModalArea = ModalArea(MutableStateFlow(Rect()))
   }
 }
+
+@WorkflowUiExperimentalApi
+internal operator fun ViewEnvironment.plus(modalArea: ModalArea): ViewEnvironment =
+  this + (ModalArea to modalArea)

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/ModalScreenOverlayOnBackPressed.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/ModalScreenOverlayOnBackPressed.kt
@@ -1,9 +1,9 @@
 package com.squareup.workflow1.ui.container
 
 import android.view.View
+import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewEnvironmentKey
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.container.ModalScreenOverlayOnBackPressed.Handler
 import com.squareup.workflow1.ui.onBackPressedDispatcherOwnerOrNull
 
 /**
@@ -16,25 +16,31 @@ import com.squareup.workflow1.ui.onBackPressedDispatcherOwnerOrNull
  * that predates `OnBackPressedDispatcher`.
  */
 @WorkflowUiExperimentalApi
-public object ModalScreenOverlayOnBackPressed : ViewEnvironmentKey<Handler>(
-  type = Handler::class
-) {
-  public fun interface Handler {
-    /**
-     * Called when the device back button is pressed and a dialog built by a
-     * [ModalScreenOverlayDialogFactory] has window focus.
-     *
-     * @return true if the back press event was consumed
-     */
-    public fun onBackPressed(contentView: View): Boolean
-  }
+public fun interface ModalScreenOverlayOnBackPressed {
+  /**
+   * Called when the device back button is pressed and a dialog built by a
+   * [ModalScreenOverlayDialogFactory] has window focus.
+   *
+   * @return true if the back press event was consumed
+   */
+  public fun onBackPressed(contentView: View): Boolean
 
-  override val default: Handler = Handler { view ->
-    view.context.onBackPressedDispatcherOwnerOrNull()
-      ?.onBackPressedDispatcher
-      ?.let {
-        if (it.hasEnabledCallbacks()) it.onBackPressed()
+  public companion object : ViewEnvironmentKey<ModalScreenOverlayOnBackPressed>(
+    type = ModalScreenOverlayOnBackPressed::class
+  ) {
+    override val default: ModalScreenOverlayOnBackPressed =
+      ModalScreenOverlayOnBackPressed { view ->
+        view.context.onBackPressedDispatcherOwnerOrNull()
+          ?.onBackPressedDispatcher
+          ?.let {
+            if (it.hasEnabledCallbacks()) it.onBackPressed()
+          }
+        true
       }
-    true
   }
 }
+
+@WorkflowUiExperimentalApi
+public operator fun ViewEnvironment.plus(
+  onBackPressed: ModalScreenOverlayOnBackPressed
+): ViewEnvironment = this + (ModalScreenOverlayOnBackPressed to onBackPressed)

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/LegacyAndroidViewRegistryTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/LegacyAndroidViewRegistryTest.kt
@@ -153,7 +153,7 @@ internal class LegacyAndroidViewRegistryTest {
 
   @OptIn(WorkflowUiExperimentalApi::class)
   private fun <R : Any> ViewRegistry.buildView(rendering: R): View =
-    buildView(rendering, ViewEnvironment(mapOf(ViewRegistry to this)), mock())
+    buildView(rendering, ViewEnvironment.EMPTY + this, mock())
 
   @OptIn(WorkflowUiExperimentalApi::class)
   private class TestViewFactory<R : Any>(override val type: KClass<R>) : ViewFactory<R> {

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ScreenViewFactoryTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ScreenViewFactoryTest.kt
@@ -24,7 +24,7 @@ internal class ScreenViewFactoryTest {
         renderingType: KClass<out RenderingT>
       ): Entry<RenderingT>? = null
     }
-    val env = ViewEnvironment(mapOf(ViewRegistry to emptyReg))
+    val env = ViewEnvironment.EMPTY + emptyReg
 
     val fooScreen = object : Screen {
       override fun toString() = "FooScreen"
@@ -41,8 +41,7 @@ internal class ScreenViewFactoryTest {
   }
 
   @Test fun `buildView honors AndroidScreen`() {
-    val registry = ViewRegistry()
-    val env = ViewEnvironment(mapOf(ViewRegistry to registry))
+    val env = ViewEnvironment.EMPTY + ViewRegistry()
     val screen = MyAndroidScreen()
 
     screen.buildView(env, mock())
@@ -50,8 +49,7 @@ internal class ScreenViewFactoryTest {
   }
 
   @Test fun `buildView prefers registry entries to AndroidViewRendering`() {
-    val registry = ViewRegistry(overrideViewRenderingFactory)
-    val env = ViewEnvironment(mapOf(ViewRegistry to registry))
+    val env = ViewEnvironment.EMPTY + ViewRegistry(overrideViewRenderingFactory)
 
     val screen = MyAndroidScreen()
     screen.buildView(env, mock())

--- a/workflow-ui/core-common/api/core-common.api
+++ b/workflow-ui/core-common/api/core-common.api
@@ -63,6 +63,7 @@ public final class com/squareup/workflow1/ui/TextController {
 }
 
 public final class com/squareup/workflow1/ui/ViewEnvironment {
+	public static final field Companion Lcom/squareup/workflow1/ui/ViewEnvironment$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -75,16 +76,16 @@ public final class com/squareup/workflow1/ui/ViewEnvironment {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/squareup/workflow1/ui/ViewEnvironment$Companion {
+	public final fun getEMPTY ()Lcom/squareup/workflow1/ui/ViewEnvironment;
+}
+
 public abstract class com/squareup/workflow1/ui/ViewEnvironmentKey {
 	public fun <init> (Lkotlin/reflect/KClass;)V
 	public final fun equals (Ljava/lang/Object;)Z
 	public abstract fun getDefault ()Ljava/lang/Object;
 	public final fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/squareup/workflow1/ui/ViewEnvironmentKt {
-	public static final fun updateFrom (Lcom/squareup/workflow1/ui/ViewEnvironment;Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/ViewEnvironment;
 }
 
 public abstract interface class com/squareup/workflow1/ui/ViewRegistry {
@@ -105,6 +106,10 @@ public abstract interface class com/squareup/workflow1/ui/ViewRegistry$Entry {
 public final class com/squareup/workflow1/ui/ViewRegistryKt {
 	public static final fun ViewRegistry ()Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun ViewRegistry ([Lcom/squareup/workflow1/ui/ViewRegistry$Entry;)Lcom/squareup/workflow1/ui/ViewRegistry;
+	public static final fun merge (Lcom/squareup/workflow1/ui/ViewEnvironment;Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public static final fun merge (Lcom/squareup/workflow1/ui/ViewEnvironment;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public static final fun merge (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewRegistry;
+	public static final fun plus (Lcom/squareup/workflow1/ui/ViewEnvironment;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewEnvironment;
 	public static final fun plus (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewRegistry$Entry;)Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun plus (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewRegistry;
 }
@@ -195,7 +200,6 @@ public final class com/squareup/workflow1/ui/container/EnvironmentScreen : com/s
 }
 
 public final class com/squareup/workflow1/ui/container/EnvironmentScreenKt {
-	public static final fun plus (Lcom/squareup/workflow1/ui/container/EnvironmentScreen;Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/container/EnvironmentScreen;
 	public static final fun withEnvironment (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/container/EnvironmentScreen;
 	public static synthetic fun withEnvironment$default (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/container/EnvironmentScreen;
 	public static final fun withRegistry (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/container/EnvironmentScreen;

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/CompositeViewRegistry.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/CompositeViewRegistry.kt
@@ -37,7 +37,8 @@ internal class CompositeViewRegistry private constructor(
 
       fun putAllUnique(other: Map<KClass<*>, ViewRegistry>) {
         val duplicateKeys = registriesByKey.keys.intersect(other.keys)
-        check(duplicateKeys.isEmpty()) { "Must not have duplicate entries: $duplicateKeys" }
+        require(duplicateKeys.isEmpty()) { "Must not have duplicate entries: $duplicateKeys. " +
+          "Use merge to replace existing entries." }
         registriesByKey.putAll(other)
       }
 

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/ViewEnvironment.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/ViewEnvironment.kt
@@ -3,23 +3,30 @@ package com.squareup.workflow1.ui
 import kotlin.reflect.KClass
 
 /**
- * Immutable, append-only map of values that a parent view can pass down to
+ * Immutable map of values that a parent view can pass down to
  * its children. Allows containers to give descendants information about
  * the context in which they're drawing.
  *
  * Calling [Screen.withEnvironment][com.squareup.workflow1.ui.container.withEnvironment]
- * is the easiest way to customize its environment.
+ * on a [Screen] is the easiest way to customize its environment before rendering it.
  */
 @WorkflowUiExperimentalApi
-public class ViewEnvironment(
+public class ViewEnvironment
+@Deprecated(
+  "To eliminate runtime errors this constructor will become private. " +
+    "Use ViewEnvironment.EMPTY and ViewEnvironment.plus"
+)
+constructor(
   public val map: Map<ViewEnvironmentKey<*>, Any> = emptyMap()
 ) {
   @Suppress("UNCHECKED_CAST")
   public operator fun <T : Any> get(key: ViewEnvironmentKey<T>): T = map[key] as? T ?: key.default
 
+  @Suppress("DEPRECATION")
   public operator fun <T : Any> plus(pair: Pair<ViewEnvironmentKey<T>, T>): ViewEnvironment =
     ViewEnvironment(map + pair)
 
+  @Suppress("DEPRECATION")
   public operator fun plus(other: ViewEnvironment): ViewEnvironment =
     ViewEnvironment(map + other.map)
 
@@ -29,6 +36,11 @@ public class ViewEnvironment(
     (other as? ViewEnvironment)?.let { it.map == map } ?: false
 
   override fun hashCode(): Int = map.hashCode()
+  
+  public companion object {
+    @Suppress("DEPRECATION")
+    public val EMPTY : ViewEnvironment = ViewEnvironment()
+  }
 }
 
 /**
@@ -52,25 +64,4 @@ public abstract class ViewEnvironmentKey<T : Any>(
   override fun toString(): String {
     return "ViewEnvironmentKey($type)-${super.toString()}"
   }
-}
-
-/**
- * Combines the receiving [ViewEnvironment] with [other], taking care to merge
- * their [ViewRegistry] entries. Duplicate values in [other] replace those
- * in the receiver.
- */
-@WorkflowUiExperimentalApi
-public fun ViewEnvironment.updateFrom(other: ViewEnvironment): ViewEnvironment {
-  if (other.map.isEmpty()) return this
-
-  val myReg = this[ViewRegistry]
-  val yourReg = other[ViewRegistry]
-
-  val union = (myReg.keys + yourReg.keys).asSequence()
-    .map { yourReg.getEntryFor(it) ?: myReg.getEntryFor(it)!! }
-    .toList()
-    .toTypedArray()
-
-  val unionRegistry = ViewRegistry(*union)
-  return this + other + (ViewRegistry to unionRegistry)
 }

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
@@ -76,9 +76,7 @@ public interface ViewRegistry {
   public val keys: Set<KClass<*>>
 
   /**
-   * This method is not for general use, use [WorkflowViewStub] instead.
-   *
-   * Returns the [ViewFactory] that was registered for the given [renderingType], or null
+   * Returns the [Entry] that was registered for the given [renderingType], or null
    * if none was found.
    */
   public fun <RenderingT : Any> getEntryFor(
@@ -89,6 +87,10 @@ public interface ViewRegistry {
     override val default: ViewRegistry get() = ViewRegistry()
   }
 }
+
+@WorkflowUiExperimentalApi public inline operator fun <reified RenderingT : Any> ViewRegistry.get(
+  renderingType: KClass<out RenderingT>
+): Entry<RenderingT>? = getEntryFor(renderingType)
 
 @WorkflowUiExperimentalApi
 public fun ViewRegistry(vararg bindings: Entry<*>): ViewRegistry =
@@ -102,10 +104,67 @@ public fun ViewRegistry(vararg bindings: Entry<*>): ViewRegistry =
 @WorkflowUiExperimentalApi
 public fun ViewRegistry(): ViewRegistry = TypedViewRegistry()
 
+/**
+ *  @throws IllegalArgumentException if the receiver already has a matching [entry].
+ */
 @WorkflowUiExperimentalApi
-public operator fun ViewRegistry.plus(binding: Entry<*>): ViewRegistry =
-  this + ViewRegistry(binding)
+public operator fun ViewRegistry.plus(entry: Entry<*>): ViewRegistry =
+  this + ViewRegistry(entry)
 
+/** @throws IllegalArgumentException if other has redundant entries. */
 @WorkflowUiExperimentalApi
 public operator fun ViewRegistry.plus(other: ViewRegistry): ViewRegistry =
   CompositeViewRegistry(this, other)
+
+/**
+ * Replaces the existing [ViewRegistry] of the receiver with [registry]. Use
+ * [ViewEnvironment.merge] to combine them instead.
+ */
+@WorkflowUiExperimentalApi
+public operator fun ViewEnvironment.plus(registry: ViewRegistry): ViewEnvironment {
+  return this + (ViewRegistry to registry)
+}
+
+/**
+ * Combines the receiver with [other]. If there are conflicting entries,
+ * those in [other] are preferred.
+ */
+@WorkflowUiExperimentalApi
+public infix fun ViewRegistry.merge(other: ViewRegistry): ViewRegistry {
+  return (keys + other.keys).asSequence()
+    .map { other.getEntryFor(it) ?: getEntryFor(it)!! }
+    .toList()
+    .toTypedArray()
+    .let { ViewRegistry(*it) }
+}
+
+/**
+ * Merges the [ViewRegistry] of the receiver with [registry]. If there are conflicting entries,
+ * those in [registry] are preferred.
+ */
+@WorkflowUiExperimentalApi
+public infix fun ViewEnvironment.merge(registry: ViewRegistry): ViewEnvironment {
+  val oldReg = this[ViewRegistry]
+
+  val union = (oldReg.keys + registry.keys).asSequence()
+    .map { registry.getEntryFor(it) ?: oldReg.getEntryFor(it)!! }
+    .toList()
+    .toTypedArray()
+
+  val unionRegistry = ViewRegistry(*union)
+  return this + (ViewRegistry to unionRegistry)
+}
+
+/**
+ * Combines the receiving [ViewEnvironment] with [other], taking care to merge
+ * their [ViewRegistry] entries. Any other conflicting values in [other] replace those
+ * in the receiver.
+ */
+@WorkflowUiExperimentalApi
+public infix fun ViewEnvironment.merge(other: ViewEnvironment): ViewEnvironment {
+  if (other.map.isEmpty()) return this
+
+  val oldReg = this[ViewRegistry]
+  val newReg = other[ViewRegistry]
+  return this + other + (ViewRegistry to oldReg.merge(newReg))
+}

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreen.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreen.kt
@@ -5,7 +5,7 @@ import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.updateFrom
+import com.squareup.workflow1.ui.merge
 
 /**
  * Pairs a [screen] rendering with a [viewEnvironment] to support its display.
@@ -18,7 +18,7 @@ import com.squareup.workflow1.ui.updateFrom
 @WorkflowUiExperimentalApi
 public class EnvironmentScreen<V : Screen> internal constructor(
   public val screen: V,
-  public val viewEnvironment: ViewEnvironment = ViewEnvironment()
+  public val viewEnvironment: ViewEnvironment = ViewEnvironment.EMPTY
 ) : Compatible, Screen {
   /**
    * Ensures that we make the decision to update or replace the root view based on
@@ -27,35 +27,31 @@ public class EnvironmentScreen<V : Screen> internal constructor(
   override val compatibilityKey: String = Compatible.keyFor(screen, "EnvironmentScreen")
 }
 
-@WorkflowUiExperimentalApi
-public operator fun <T : Screen> EnvironmentScreen<T>.plus(
-  environment: ViewEnvironment
-): EnvironmentScreen<T> {
-  return when {
-    environment.map.isEmpty() -> this
-    else -> EnvironmentScreen(screen, viewEnvironment.updateFrom(environment))
-  }
-}
-
 /**
- * Returns a [EnvironmentScreen] derived from the receiver, whose [ViewEnvironment]
- * includes a [ViewRegistry] updated from the given [viewRegistry].
+ * Returns an [EnvironmentScreen] derived from the receiver, whose
+ * [EnvironmentScreen.viewEnvironment] includes [viewRegistry].
+ *
+ * If the receiver is an [EnvironmentScreen], uses [ViewRegistry.merge]
+ * to preserve the [ViewRegistry] entries of both.
  */
 @WorkflowUiExperimentalApi
 public fun Screen.withRegistry(viewRegistry: ViewRegistry): EnvironmentScreen<*> {
-  return withEnvironment(ViewEnvironment(mapOf(ViewRegistry to viewRegistry)))
+  return withEnvironment(ViewEnvironment.EMPTY merge viewRegistry)
 }
 
 /**
- * Returns a [EnvironmentScreen] derived from the receiver, whose [ViewEnvironment]
- * is [updated][updateFrom] the given [viewEnvironment].
+ * Returns an [EnvironmentScreen] derived from the receiver,
+ * whose [EnvironmentScreen.viewEnvironment] includes the values in the given [environment].
+ *
+ * If the receiver is an [EnvironmentScreen], uses [ViewEnvironment.merge]
+ * to preserve the [ViewRegistry] entries of both.
  */
 @WorkflowUiExperimentalApi
 public fun Screen.withEnvironment(
-  viewEnvironment: ViewEnvironment = ViewEnvironment()
+  environment: ViewEnvironment = ViewEnvironment.EMPTY
 ): EnvironmentScreen<*> {
   return when (this) {
-    is EnvironmentScreen<*> -> this + viewEnvironment
-    else -> EnvironmentScreen(this, viewEnvironment)
+    is EnvironmentScreen<*> -> EnvironmentScreen(screen, this.viewEnvironment merge environment)
+    else -> EnvironmentScreen(this, environment)
   }
 }

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/TypedViewRegistryTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/TypedViewRegistryTest.kt
@@ -35,7 +35,7 @@ internal class TypedViewRegistryTest {
     val fooFactory = TestEntry(FooRendering::class)
     val registry = ViewRegistry(fooFactory)
 
-    val factory = registry.getEntryFor(FooRendering::class)
+    val factory = registry[FooRendering::class]
     assertThat(factory).isSameInstanceAs(fooFactory)
   }
 
@@ -43,12 +43,38 @@ internal class TypedViewRegistryTest {
     val fooFactory = TestEntry(FooRendering::class)
     val registry = ViewRegistry(fooFactory)
 
-    assertThat(registry.getEntryFor(BarRendering::class)).isNull()
+    assertThat(registry[BarRendering::class]).isNull()
   }
 
   @Test fun `ViewRegistry with no arguments infers type`() {
     val registry = ViewRegistry()
     assertTrue(registry.keys.isEmpty())
+  }
+
+  @Test fun `merge prefers right side`() {
+    val factory1 = TestEntry(FooRendering::class)
+    val factory2 = TestEntry(FooRendering::class)
+    val merged = ViewRegistry(factory1) merge ViewRegistry(factory2)
+
+    assertThat(merged[FooRendering::class]).isSameInstanceAs(factory2)
+  }
+
+  @Test fun `merge into ViewEnvironment prefers right side`() {
+    val factory1 = TestEntry(FooRendering::class)
+    val factory2 = TestEntry(FooRendering::class)
+    val merged = (ViewEnvironment.EMPTY + ViewRegistry(factory1)) merge ViewRegistry(factory2)
+
+    assertThat(merged[ViewRegistry][FooRendering::class]).isSameInstanceAs(factory2)
+  }
+
+  @Test fun `merge of ViewEnvironments prefers right side`() {
+    val factory1 = TestEntry(FooRendering::class)
+    val factory2 = TestEntry(FooRendering::class)
+    val e1 = ViewEnvironment.EMPTY + ViewRegistry(factory1)
+    val e2 = ViewEnvironment.EMPTY + ViewRegistry(factory2)
+    val merged = e1 + e2
+
+    assertThat(merged[ViewRegistry][FooRendering::class]).isSameInstanceAs(factory2)
   }
 
   private class TestEntry<T : Any>(

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/ViewEnvironmentTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/ViewEnvironmentTest.kt
@@ -22,41 +22,39 @@ internal class ViewEnvironmentTest {
     }
   }
 
-  private val emptyEnv = ViewEnvironment()
-
   @Test fun defaults() {
-    assertThat(emptyEnv[DataHint]).isEqualTo(DataHint())
+    assertThat(ViewEnvironment.EMPTY[DataHint]).isEqualTo(DataHint())
   }
 
   @Test fun put() {
-    val environment = emptyEnv +
-        (StringHint to "fnord") +
-        (DataHint to DataHint(42, "foo"))
+    val environment = ViewEnvironment.EMPTY +
+      (StringHint to "fnord") +
+      (DataHint to DataHint(42, "foo"))
 
     assertThat(environment[StringHint]).isEqualTo("fnord")
     assertThat(environment[DataHint]).isEqualTo(DataHint(42, "foo"))
   }
 
   @Test fun `map equality`() {
-    val env1 = emptyEnv +
-        (StringHint to "fnord") +
-        (DataHint to DataHint(42, "foo"))
+    val env1 = ViewEnvironment.EMPTY +
+      (StringHint to "fnord") +
+      (DataHint to DataHint(42, "foo"))
 
-    val env2 = emptyEnv +
-        (StringHint to "fnord") +
-        (DataHint to DataHint(42, "foo"))
+    val env2 = ViewEnvironment.EMPTY +
+      (StringHint to "fnord") +
+      (DataHint to DataHint(42, "foo"))
 
     assertThat(env1).isEqualTo(env2)
   }
 
   @Test fun `map inequality`() {
-    val env1 = emptyEnv +
-        (StringHint to "fnord") +
-        (DataHint to DataHint(42, "foo"))
+    val env1 = ViewEnvironment.EMPTY +
+      (StringHint to "fnord") +
+      (DataHint to DataHint(42, "foo"))
 
-    val env2 = emptyEnv +
-        (StringHint to "fnord") +
-        (DataHint to DataHint(43, "foo"))
+    val env2 = ViewEnvironment.EMPTY +
+      (StringHint to "fnord") +
+      (DataHint to DataHint(43, "foo"))
 
     assertThat(env1).isNotEqualTo(env2)
   }
@@ -70,17 +68,17 @@ internal class ViewEnvironmentTest {
   }
 
   @Test fun override() {
-    val environment = emptyEnv +
-        (StringHint to "able") +
-        (StringHint to "baker")
+    val environment = ViewEnvironment.EMPTY +
+      (StringHint to "able") +
+      (StringHint to "baker")
 
     assertThat(environment[StringHint]).isEqualTo("baker")
   }
 
   @Test fun `keys of the same type`() {
-    val environment = emptyEnv +
-        (StringHint to "able") +
-        (OtherStringHint to "baker")
+    val environment = ViewEnvironment.EMPTY +
+      (StringHint to "able") +
+      (OtherStringHint to "baker")
 
     assertThat(environment[StringHint]).isEqualTo("able")
     assertThat(environment[OtherStringHint]).isEqualTo("baker")

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/container/EnvironmentScreenTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/container/EnvironmentScreenTest.kt
@@ -1,0 +1,95 @@
+package com.squareup.workflow1.ui.container
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.workflow1.ui.Screen
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewEnvironmentKey
+import com.squareup.workflow1.ui.ViewRegistry
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.get
+import com.squareup.workflow1.ui.plus
+import org.junit.Test
+import kotlin.reflect.KClass
+
+@OptIn(WorkflowUiExperimentalApi::class)
+internal class EnvironmentScreenTest {
+  private class TestFactory<T : Any>(
+    override val type: KClass<in T>
+  ) : ViewRegistry.Entry<T>
+
+  private data class TestValue(val value: String) {
+    companion object : ViewEnvironmentKey<TestValue>(TestValue::class) {
+      override val default: TestValue get() = error("Set a default")
+    }
+  }
+
+  private operator fun ViewEnvironment.plus(other: TestValue): ViewEnvironment {
+    return this + (TestValue to other)
+  }
+
+  private object FooScreen : Screen
+  private object BarScreen : Screen
+
+  @Test fun `Screen withRegistry works`() {
+    val fooFactory = TestFactory(FooScreen::class)
+    val viewRegistry = ViewRegistry(fooFactory)
+    val envScreen = FooScreen.withRegistry(viewRegistry)
+
+    assertThat(envScreen.viewEnvironment[ViewRegistry][FooScreen::class])
+      .isSameInstanceAs(fooFactory)
+
+    assertThat(envScreen.viewEnvironment[ViewRegistry][BarScreen::class])
+      .isNull()
+  }
+
+  @Test fun `Screen withEnvironment works`() {
+    val fooFactory = TestFactory(FooScreen::class)
+    val viewRegistry = ViewRegistry(fooFactory)
+    val envScreen = FooScreen.withEnvironment(
+      ViewEnvironment.EMPTY + viewRegistry + TestValue("foo")
+    )
+
+    assertThat(envScreen.viewEnvironment[ViewRegistry][FooScreen::class])
+      .isSameInstanceAs(fooFactory)
+    assertThat(envScreen.viewEnvironment[ViewRegistry][BarScreen::class])
+      .isNull()
+    assertThat(envScreen.viewEnvironment[TestValue])
+      .isEqualTo(TestValue("foo"))
+  }
+
+  @Test fun `EnvironmentScreen withRegistry merges`() {
+    val fooFactory1 = TestFactory(FooScreen::class)
+    val fooFactory2 = TestFactory(FooScreen::class)
+    val barFactory = TestFactory(BarScreen::class)
+
+    val left = FooScreen.withRegistry(ViewRegistry(fooFactory1, barFactory))
+    val union = left.withRegistry(ViewRegistry(fooFactory2))
+
+    assertThat(union.viewEnvironment[ViewRegistry][FooScreen::class])
+      .isSameInstanceAs(fooFactory2)
+
+    assertThat(union.viewEnvironment[ViewRegistry][BarScreen::class])
+      .isSameInstanceAs(barFactory)
+  }
+
+  @Test fun `EnvironmentScreen withEnvironment merges`() {
+    val fooFactory1 = TestFactory(FooScreen::class)
+    val fooFactory2 = TestFactory(FooScreen::class)
+    val barFactory = TestFactory(BarScreen::class)
+
+    val left = FooScreen.withEnvironment(
+      ViewEnvironment.EMPTY + ViewRegistry(fooFactory1, barFactory) + TestValue("left")
+    )
+
+    val union = left.withEnvironment(
+      ViewEnvironment.EMPTY + ViewRegistry(fooFactory2) + TestValue("right")
+    )
+
+    assertThat(union.viewEnvironment[ViewRegistry][FooScreen::class])
+      .isSameInstanceAs(fooFactory2)
+    assertThat(union.viewEnvironment[ViewRegistry][BarScreen::class])
+      .isSameInstanceAs(barFactory)
+    assertThat(union.viewEnvironment[TestValue])
+      .isEqualTo(TestValue("right"))
+  }
+}

--- a/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity.kt
+++ b/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity.kt
@@ -19,6 +19,7 @@ import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.WorkflowViewStub
 import com.squareup.workflow1.ui.bindShowRendering
+import com.squareup.workflow1.ui.plus
 import kotlin.reflect.KClass
 
 /**
@@ -57,7 +58,7 @@ public abstract class AbstractLifecycleTestActivity : WorkflowUiTestActivity() {
     // This will override WorkflowUiTestActivity's retention of the environment across config
     // changes. This is intentional, since our ViewRegistry probably contains a leafBinding which
     // captures the events list.
-    viewEnvironment = ViewEnvironment(mapOf(ViewRegistry to viewRegistry))
+    viewEnvironment = ViewEnvironment.EMPTY + viewRegistry
   }
 
   override fun onStart() {


### PR DESCRIPTION
`ViewEnvironment(Map<ViewEnvironmentKey<*>, Any>)` makes it easy to build a
`ViewEnvironment` whose with values that don't match the type of the
`ViewEnvironmentKey`s. We deprecate it with an eye toward making it
non-public down the road. In its place we introduce `ViewEnvironment.EMPTY`,
and guide people to use it and the type safe `plus` operators.

We introduce a pattern of providing more `plus` operators with new environment
value types.

For `ViewRegistry`, in addition to the `plus` operator we provide a set of
`merge` methods, which finish the long overdue job of making it simpler to
mess with `ViewEnvironment` without stomping on `ViewRegistry` entries, and
to override them. `EnvironmentScreen.withRegistry` and `.withEnvironment` use
these.

Fixes #395.