### PR TITLE
Upgrades leak canary, testing, androidx lifecycle.

### DIFF
--- a/.buildscript/android-ui-tests.gradle
+++ b/.buildscript/android-ui-tests.gradle
@@ -1,7 +1,6 @@
 android {
   defaultConfig {
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    testInstrumentationRunnerArgument "listener", "leakcanary.FailTestOnLeakRunListener"
   }
 
   testOptions {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -25,15 +25,15 @@ object Dependencies {
       const val ui = "androidx.compose.ui:ui:1.1.0-rc01"
     }
 
-    const val constraint_layout = "androidx.constraintlayout:constraintlayout:2.1.0"
+    const val constraint_layout = "androidx.constraintlayout:constraintlayout:2.1.2"
     const val fragment = "androidx.fragment:fragment:1.3.6"
     const val fragmentKtx = "androidx.fragment:fragment-ktx:1.3.6"
     const val gridlayout = "androidx.gridlayout:gridlayout:1.0.0"
 
     object Lifecycle {
-      const val ktx = "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
-      const val viewModel = "androidx.lifecycle:lifecycle-viewmodel:2.3.1"
-      const val viewModelKtx = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1"
+      const val ktx = "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
+      const val viewModel = "androidx.lifecycle:lifecycle-viewmodel:2.4.0"
+      const val viewModelKtx = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0"
       const val viewModelSavedState = "androidx.lifecycle:lifecycle-viewmodel-savedstate:1.1.0"
     }
 
@@ -53,7 +53,7 @@ object Dependencies {
 
   // Required for Dungeon Crawler sample.
   const val desugar_jdk_libs = "com.android.tools:desugar_jdk_libs:1.1.5"
-  const val leakcanary = "com.squareup.leakcanary:leakcanary-android:2.7"
+  const val leakcanary = "com.squareup.leakcanary:leakcanary-android:2.8.1"
   const val radiography = "com.squareup.radiography:radiography:2.4.0"
   const val rxandroid2 = "io.reactivex.rxjava2:rxandroid:2.1.1"
   const val seismic = "com.squareup:seismic:1.0.2"
@@ -126,7 +126,7 @@ object Dependencies {
     object AndroidX {
       const val compose = "androidx.compose.ui:ui-test-junit4:1.0.1"
       const val core = "androidx.test:core:1.3.0"
-      const val lifecycle = "androidx.lifecycle:lifecycle-runtime-testing:2.3.1"
+      const val lifecycle = "androidx.lifecycle:lifecycle-runtime-testing:2.4.0"
 
       object Espresso {
         const val core = "androidx.test.espresso:espresso-core:3.3.0"
@@ -134,15 +134,15 @@ object Dependencies {
         const val intents = "androidx.test.espresso:espresso-intents:3.3.0"
       }
 
-      const val junitExt = "androidx.test.ext:junit:1.1.2"
-      const val runner = "androidx.test:runner:1.3.0"
-      const val truthExt = "androidx.test.ext:truth:1.3.0"
+      const val junitExt = "androidx.test.ext:junit:1.1.3"
+      const val runner = "androidx.test:runner:1.4.0"
+      const val truthExt = "androidx.test.ext:truth:1.4.0"
       const val uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
     }
 
     const val hamcrestCore = "org.hamcrest:hamcrest-core:2.2"
     const val junit = "junit:junit:4.13.2"
-    const val leakcanaryInstrumentation = "com.squareup.leakcanary:leakcanary-android-instrumentation:2.7"
+    const val leakcanaryInstrumentation = "com.squareup.leakcanary:leakcanary-android-instrumentation:2.8.1"
     const val mockito = "org.mockito:mockito-core:3.3.3"
     const val robolectric = "org.robolectric:robolectric:4.5.1"
     const val truth = "com.google.truth:truth:1.1.3"

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/hellocompose/HelloComposeTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/hellocompose/HelloComposeTest.kt
@@ -7,16 +7,20 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 class HelloComposeTest {
 
-  @get:Rule val composeRule = createAndroidComposeRule<HelloComposeActivity>()
-  @get:Rule val idleAfterTest = IdleAfterTestRule
+  private val composeRule = createAndroidComposeRule<HelloComposeActivity>()
+  @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+    .around(IdleAfterTestRule)
+    .around(composeRule)
 
   @Test fun togglesBetweenStates() {
     composeRule.onNodeWithText("Hello")

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/hellocomposebinding/HelloBindingTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/hellocomposebinding/HelloBindingTest.kt
@@ -7,16 +7,20 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 class HelloBindingTest {
 
-  @get:Rule val composeRule = createAndroidComposeRule<HelloBindingActivity>()
-  @get:Rule val idleAfterTest = IdleAfterTestRule
+  private val composeRule = createAndroidComposeRule<HelloBindingActivity>()
+  @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+    .around(IdleAfterTestRule)
+    .around(composeRule)
 
   @Test fun togglesBetweenStates() {
     composeRule.onNodeWithText("Hello")

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/hellocomposeworkflow/HelloComposeWorkflowTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/hellocomposeworkflow/HelloComposeWorkflowTest.kt
@@ -7,16 +7,20 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 class HelloComposeWorkflowTest {
 
-  @get:Rule val composeRule = createAndroidComposeRule<HelloComposeWorkflowActivity>()
-  @get:Rule val idleAfterTest = IdleAfterTestRule
+  private val composeRule = createAndroidComposeRule<HelloComposeWorkflowActivity>()
+  @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+    .around(IdleAfterTestRule)
+    .around(composeRule)
 
   @Test fun togglesBetweenStates() {
     composeRule.onNodeWithText("Hello")

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/inlinerendering/InlineRenderingTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/inlinerendering/InlineRenderingTest.kt
@@ -8,16 +8,20 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 class InlineRenderingTest {
 
-  @get:Rule val composeRule = createAndroidComposeRule<InlineRenderingActivity>()
-  @get:Rule val idleAfterTest = IdleAfterTestRule
+  private val composeRule = createAndroidComposeRule<InlineRenderingActivity>()
+  @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+    .around(IdleAfterTestRule)
+    .around(composeRule)
 
   @Test fun counterIncrements() {
     composeRule.onNode(hasClickAction())

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/launcher/SampleLauncherTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/launcher/SampleLauncherTest.kt
@@ -13,16 +13,20 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.squareup.sample.compose.R
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 class SampleLauncherTest {
 
-  @get:Rule val composeRule = createAndroidComposeRule<SampleLauncherActivity>()
-  @get:Rule val idleAfterTest = IdleAfterTestRule
+  private val composeRule = createAndroidComposeRule<SampleLauncherActivity>()
+  @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+    .around(IdleAfterTestRule)
+    .around(composeRule)
 
   @OptIn(ExperimentalTestApi::class)
   @Test fun allSamplesLaunch() {

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsTest.kt
@@ -11,8 +11,10 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 private const val ADD_BUTTON_TEXT = "Add Child"
@@ -21,8 +23,10 @@ private const val ADD_BUTTON_TEXT = "Add Child"
 @OptIn(WorkflowUiExperimentalApi::class)
 class NestedRenderingsTest {
 
-  @get:Rule val composeRule = createAndroidComposeRule<NestedRenderingsActivity>()
-  @get:Rule val idleAfterTest = IdleAfterTestRule
+  private val composeRule = createAndroidComposeRule<NestedRenderingsActivity>()
+  @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+    .around(IdleAfterTestRule)
+    .around(composeRule)
 
   @Test fun childrenAreAddedAndRemoved() {
     composeRule.onNodeWithText(ADD_BUTTON_TEXT)

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/preview/PreviewTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/preview/PreviewTest.kt
@@ -7,16 +7,20 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 class PreviewTest {
 
-  @get:Rule val composeRule = createAndroidComposeRule<PreviewActivity>()
-  @get:Rule val idleAfterTest = IdleAfterTestRule
+  private val composeRule = createAndroidComposeRule<PreviewActivity>()
+  @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+    .around(IdleAfterTestRule)
+    .around(composeRule)
 
   @Test fun showsPreviewRendering() {
     composeRule.onNodeWithText(ContactDetailsRendering::class.java.simpleName, substring = true)

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/textinput/TextInputTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/textinput/TextInputTest.kt
@@ -15,16 +15,20 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 class TextInputTest {
 
-  @get:Rule val composeRule = createAndroidComposeRule<TextInputActivity>()
-  @get:Rule val idleAfterTest = IdleAfterTestRule
+  private val composeRule = createAndroidComposeRule<TextInputActivity>()
+  @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+    .around(IdleAfterTestRule)
+    .around(composeRule)
 
   @OptIn(ExperimentalTestApi::class)
   @Test fun allowsTextEditing() {

--- a/samples/containers/app-poetry/src/androidTest/java/com/squareup/sample/poetryapp/PoetryAppTest.kt
+++ b/samples/containers/app-poetry/src/androidTest/java/com/squareup/sample/poetryapp/PoetryAppTest.kt
@@ -8,18 +8,21 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.sample.container.poetryapp.R
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.inAnyView
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 class PoetryAppTest {
 
-  @get:Rule val scenarioRule = ActivityScenarioRule(PoetryActivity::class.java)
+  private val scenarioRule = ActivityScenarioRule(PoetryActivity::class.java)
+  @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess()).around(scenarioRule)!!
 
   @Test fun launches() {
     inAnyView(withText(R.string.poems))
-        .check(matches(isDisplayed()))
+      .check(matches(isDisplayed()))
   }
 }

--- a/samples/containers/app-raven/src/androidTest/java/com/squareup/sample/ravenapp/RavenAppTest.kt
+++ b/samples/containers/app-raven/src/androidTest/java/com/squareup/sample/ravenapp/RavenAppTest.kt
@@ -7,18 +7,21 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.inAnyView
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 class RavenAppTest {
 
-  @get:Rule val scenarioRule = ActivityScenarioRule(RavenActivity::class.java)
+  private val scenarioRule = ActivityScenarioRule(RavenActivity::class.java)
+  @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess()).around(scenarioRule)!!
 
   @Test fun launches() {
     inAnyView(withText("The Raven"))
-        .check(matches(isDisplayed()))
+      .check(matches(isDisplayed()))
   }
 }

--- a/samples/containers/hello-back-button/src/androidTest/java/com/squareup/sample/hellobackbutton/HelloBackButtonEspressoTest.kt
+++ b/samples/containers/hello-back-button/src/androidTest/java/com/squareup/sample/hellobackbutton/HelloBackButtonEspressoTest.kt
@@ -10,15 +10,18 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.inAnyView
 import com.squareup.workflow1.ui.internal.test.actuallyPressBack
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 class HelloBackButtonEspressoTest {
 
-  @get:Rule val scenarioRule = ActivityScenarioRule(HelloBackButtonActivity::class.java)
+  private val scenarioRule = ActivityScenarioRule(HelloBackButtonActivity::class.java)
+  @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess()).around(scenarioRule)!!
 
   @Test fun wrappedTakesPrecedence() {
     inAnyView(withId(R.id.hello_message)).apply {

--- a/samples/dungeon/app/build.gradle.kts
+++ b/samples/dungeon/app/build.gradle.kts
@@ -12,7 +12,6 @@ android {
     multiDexEnabled = true
 
     testInstrumentationRunner = "com.squareup.sample.dungeon.DungeonTestRunner"
-    testInstrumentationRunnerArguments["listener"] = "leakcanary.FailTestOnLeakRunListener"
   }
 
   compileOptions {

--- a/samples/dungeon/app/src/androidTest/java/com/squareup/sample/dungeon/DungeonAppTest.kt
+++ b/samples/dungeon/app/src/androidTest/java/com/squareup/sample/dungeon/DungeonAppTest.kt
@@ -7,15 +7,18 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.inAnyView
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 class DungeonAppTest {
 
-  @get:Rule val scenarioRule = ActivityScenarioRule(DungeonActivity::class.java)
+  private val scenarioRule = ActivityScenarioRule(DungeonActivity::class.java)
+  @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess()).around(scenarioRule)!!
 
   @Test fun loadsBoardsList() {
     inAnyView(withText(R.string.boards_list_label))

--- a/samples/hello-workflow-fragment/src/androidTest/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragmentAppTest.kt
+++ b/samples/hello-workflow-fragment/src/androidTest/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragmentAppTest.kt
@@ -10,9 +10,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SdkSuppress
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.inAnyView
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.hamcrest.Matchers.containsString
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 // Life is too short to debug why LeakCanary breaks this on API 21
@@ -22,7 +24,8 @@ import org.junit.runner.RunWith
 @OptIn(WorkflowUiExperimentalApi::class)
 class HelloWorkflowFragmentAppTest {
 
-  @get:Rule val scenarioRule = ActivityScenarioRule(HelloWorkflowFragmentActivity::class.java)
+  private val scenarioRule = ActivityScenarioRule(HelloWorkflowFragmentActivity::class.java)
+  @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess()).around(scenarioRule)!!
 
   @Test fun togglesHelloAndGoodbye() {
     inAnyView(withText(containsString("Hello")))

--- a/samples/hello-workflow/src/androidTest/java/com/squareup/sample/helloworkflow/HelloWorkflowAppTest.kt
+++ b/samples/hello-workflow/src/androidTest/java/com/squareup/sample/helloworkflow/HelloWorkflowAppTest.kt
@@ -8,15 +8,18 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.inAnyView
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 class HelloWorkflowAppTest {
 
-  @get:Rule val scenarioRule = ActivityScenarioRule(HelloWorkflowActivity::class.java)
+  private val scenarioRule = ActivityScenarioRule(HelloWorkflowActivity::class.java)
+  @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess()).around(scenarioRule)!!
 
   @Test fun togglesHelloAndGoodbye() {
     inAnyView(withText("Hello"))

--- a/samples/stub-visibility/src/androidTest/java/com/squareup/sample/stubvisibility/StubVisibilityAppTest.kt
+++ b/samples/stub-visibility/src/androidTest/java/com/squareup/sample/stubvisibility/StubVisibilityAppTest.kt
@@ -9,16 +9,19 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.inAnyView
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.hamcrest.CoreMatchers.not
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 internal class StubVisibilityAppTest {
 
-  @get:Rule val scenarioRule = ActivityScenarioRule(StubVisibilityActivity::class.java)
+  private val scenarioRule = ActivityScenarioRule(StubVisibilityActivity::class.java)
+  @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess()).around(scenarioRule)!!
 
   @Test fun togglesFooter() {
     inAnyView(withId(R.id.should_be_wrapped))

--- a/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
+++ b/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
@@ -27,10 +27,12 @@ import com.squareup.workflow1.ui.environment
 import com.squareup.workflow1.ui.getRendering
 import com.squareup.workflow1.ui.internal.test.inAnyView
 import com.squareup.workflow1.ui.internal.test.actuallyPressBack
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import java.util.concurrent.atomic.AtomicReference
 
@@ -38,7 +40,8 @@ import java.util.concurrent.atomic.AtomicReference
 @RunWith(AndroidJUnit4::class)
 class TicTacToeEspressoTest {
 
-  @get:Rule var scenarioRule = ActivityScenarioRule(TicTacToeActivity::class.java)
+  private val scenarioRule = ActivityScenarioRule(TicTacToeActivity::class.java)
+  @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess()).around(scenarioRule)!!
   private val scenario get() = scenarioRule.scenario
 
   @Before

--- a/samples/todo-android/app/src/androidTest/java/com/squareup/sample/mainactivity/TodoAppTest.kt
+++ b/samples/todo-android/app/src/androidTest/java/com/squareup/sample/mainactivity/TodoAppTest.kt
@@ -14,18 +14,21 @@ import com.squareup.sample.todo.ToDoActivity
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.inAnyView
 import com.squareup.workflow1.ui.internal.test.actuallyPressBack
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 class TodoAppTest {
 
-  @get:Rule val scenarioRule = ActivityScenarioRule(ToDoActivity::class.java)
+  private val scenarioRule = ActivityScenarioRule(ToDoActivity::class.java)
+  @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess()).around(scenarioRule)!!
   private val uiDevice by lazy { UiDevice.getInstance(getInstrumentation()) }
 
   @Before

--- a/workflow-ui/compose-tooling/src/androidTest/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewFactoryTest.kt
+++ b/workflow-ui/compose-tooling/src/androidTest/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewFactoryTest.kt
@@ -19,16 +19,20 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.WorkflowRendering
 import com.squareup.workflow1.ui.compose.composeViewFactory
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class PreviewViewFactoryTest {
 
-  @get:Rule val composeRule = createComposeRule()
-  @get:Rule val idleAfterTest = IdleAfterTestRule
+  private val composeRule = createComposeRule()
+  @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+    .around(IdleAfterTestRule)
+    .around(composeRule)
 
   @Test fun singleChild() {
     composeRule.setContent {

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewFactoryTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewFactoryTest.kt
@@ -22,16 +22,21 @@ import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.WorkflowViewStub
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class ComposeViewFactoryTest {
 
-  @get:Rule val composeRule = createComposeRule()
-  @get:Rule val idleAfterTest = IdleAfterTestRule
+  private val composeRule = createComposeRule()
+  @get:Rule val rules: RuleChain =
+    RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+      .around(IdleAfterTestRule)
+      .around(composeRule)
 
   @Test fun showsComposeContent() {
     val viewFactory = composeViewFactory<Unit> { _, _ ->

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -37,18 +37,22 @@ import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
 import com.squareup.workflow1.ui.internal.test.WorkflowUiTestActivity
 import com.squareup.workflow1.ui.modal.HasModals
 import com.squareup.workflow1.ui.modal.ModalViewContainer
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import kotlin.reflect.KClass
 
 @OptIn(WorkflowUiExperimentalApi::class)
 internal class ComposeViewTreeIntegrationTest {
 
-  @get:Rule val composeRule = createAndroidComposeRule<WorkflowUiTestActivity>()
-  private val scenario get() = composeRule.activityRule.scenario
+  private val composeRule = createAndroidComposeRule<WorkflowUiTestActivity>()
+  @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+    .around(IdleAfterTestRule)
+    .around(composeRule)
 
-  @get:Rule val idleAfterTest = IdleAfterTestRule
+  private val scenario get() = composeRule.activityRule.scenario
 
   @Before fun setUp() {
     scenario.onActivity {

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/CompositionRootTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/CompositionRootTest.kt
@@ -9,16 +9,20 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(WorkflowUiExperimentalApi::class)
 internal class CompositionRootTest {
 
-  @get:Rule val composeRule = createComposeRule()
-  @get:Rule val idleAfterTest = IdleAfterTestRule
+  private val composeRule = createComposeRule()
+  @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+    .around(IdleAfterTestRule)
+    .around(composeRule)
 
   @Test fun wrappedWithRootIfNecessary_wrapsWhenNecessary() {
     val root: CompositionRoot = { content ->

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/RenderAsStateTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/RenderAsStateTest.kt
@@ -32,11 +32,13 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.job
 import kotlinx.coroutines.test.TestCoroutineScope
+import leakcanary.DetectLeaksAfterTestSuccess
 import okio.ByteString
 import okio.ByteString.Companion.decodeBase64
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import kotlin.test.assertFailsWith
 
@@ -44,8 +46,10 @@ import kotlin.test.assertFailsWith
 @OptIn(WorkflowUiExperimentalApi::class)
 internal class RenderAsStateTest {
 
-  @get:Rule val composeRule = createComposeRule()
-  @get:Rule val idleAfterTest = IdleAfterTestRule
+  private val composeRule = createComposeRule()
+  @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+    .around(IdleAfterTestRule)
+    .around(composeRule)
 
   @Test fun passesPropsThrough() {
     val workflow = Workflow.stateless<String, Nothing, String> { it }

--- a/workflow-ui/container-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/BackstackContainerTest.kt
+++ b/workflow-ui/container-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/BackstackContainerTest.kt
@@ -16,14 +16,17 @@ import com.squareup.workflow1.ui.backstack.test.fixtures.BackStackContainerLifec
 import com.squareup.workflow1.ui.backstack.test.fixtures.ViewStateTestView
 import com.squareup.workflow1.ui.backstack.test.fixtures.viewForScreen
 import com.squareup.workflow1.ui.backstack.test.fixtures.waitForScreen
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 
 @OptIn(WorkflowUiExperimentalApi::class)
 internal class BackstackContainerTest {
 
-  @get:Rule internal val scenarioRule =
+  private val scenarioRule =
     ActivityScenarioRule(BackStackContainerLifecycleActivity::class.java)
+  @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess()).around(scenarioRule)!!
   private val scenario get() = scenarioRule.scenario
 
   // region Basic instance state save/restore tests

--- a/workflow-ui/container-android/src/androidTest/java/com/squareup/workflow1/ui/modal/test/ModalViewContainerLifecycleTest.kt
+++ b/workflow-ui/container-android/src/androidTest/java/com/squareup/workflow1/ui/modal/test/ModalViewContainerLifecycleTest.kt
@@ -8,16 +8,19 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.workflow1.ui.modal.ModalViewContainer
 import com.squareup.workflow1.ui.modal.test.ModalViewContainerLifecycleActivity.TestRendering.LeafRendering
 import com.squareup.workflow1.ui.modal.test.ModalViewContainerLifecycleActivity.TestRendering.RecurseRendering
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 
 /**
  * Tests for [ModalViewContainer]'s [LifecycleOwner] integration.
  */
 internal class ModalViewContainerLifecycleTest {
 
-  @get:Rule internal val scenarioRule =
+  private val scenarioRule =
     ActivityScenarioRule(ModalViewContainerLifecycleActivity::class.java)
+  @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess()).around(scenarioRule)!!
   private val scenario get() = scenarioRule.scenario
 
   /**

--- a/workflow-ui/core-android/build.gradle.kts
+++ b/workflow-ui/core-android/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
   implementation(Dependencies.AndroidX.activity)
   implementation(Dependencies.AndroidX.fragment)
   implementation(Dependencies.AndroidX.Lifecycle.ktx)
+  implementation(Dependencies.AndroidX.Lifecycle.viewModel)
+  implementation(Dependencies.AndroidX.Lifecycle.viewModelKtx)
   implementation(Dependencies.AndroidX.savedstate)
   implementation(Dependencies.Kotlin.Coroutines.android)
   implementation(Dependencies.Kotlin.Coroutines.core)
@@ -41,6 +43,5 @@ dependencies {
   testImplementation(Dependencies.Test.robolectric)
 
   androidTestImplementation(Dependencies.AndroidX.appcompat)
-  androidTestImplementation(Dependencies.AndroidX.Lifecycle.viewModel)
   androidTestImplementation(Dependencies.Test.truth)
 }

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/WorkflowViewStubLifecycleTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/WorkflowViewStubLifecycleTest.kt
@@ -29,9 +29,11 @@ import com.squareup.workflow1.ui.WorkflowViewStubLifecycleActivity.TestRendering
 import com.squareup.workflow1.ui.WorkflowViewStubLifecycleActivity.TestRendering.LeafRendering
 import com.squareup.workflow1.ui.WorkflowViewStubLifecycleActivity.TestRendering.RecurseRendering
 import com.squareup.workflow1.ui.WorkflowViewStubLifecycleActivity.TestRendering.ViewRendering
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.hamcrest.Matchers.equalTo
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 
 /**
  * Tests for [WorkflowViewStub]'s [LifecycleOwner] integration.
@@ -39,8 +41,9 @@ import org.junit.Test
 @OptIn(WorkflowUiExperimentalApi::class)
 internal class WorkflowViewStubLifecycleTest {
 
-  @get:Rule internal val scenarioRule =
+  private val scenarioRule =
     ActivityScenarioRule(WorkflowViewStubLifecycleActivity::class.java)
+  @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess()).around(scenarioRule)!!
   private val scenario get() = scenarioRule.scenario
 
   /**


### PR DESCRIPTION
Note that we hold off on upgrading androidx activity, appcompat, etc. Those push androidx core past 1.6.0, which breaks https://github.com/cashapp/paparazzi. We should hold off until they catch up, which should happen soon after AS Bumblebee freezes.
