### PR TITLE
Introduces WorkflowLayout.update.

### DIFF
--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -206,6 +206,7 @@ public final class com/squareup/workflow1/ui/WorkflowLayout : android/widget/Fra
 	public final fun start (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
 	public final fun start (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewRegistry;)V
 	public static synthetic fun start$default (Lcom/squareup/workflow1/ui/WorkflowLayout;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewEnvironment;ILjava/lang/Object;)V
+	public final fun update (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
 }
 
 public abstract class com/squareup/workflow1/ui/WorkflowViewState {


### PR DESCRIPTION
We make the core `update` method for `WorkflowLayout` public to give apps complete control over how exactly they collect renderings.

Doing this because the `takeWhileAttached` method used by `start` is causing problems. Opening this up lets those impacted by these problems avoid them. In a downstream release, we will upgrade `androidx.lifecycle:lifecycle-viewmodel` and update the convenient `start` method to use its improved API. Details in #632.