### PR TITLE
fix TextInputTest flakes

### DIFF
--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/textinput/TextInputTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/textinput/TextInputTest.kt
@@ -1,9 +1,6 @@
 package com.squareup.sample.compose.textinput
 
-import androidx.compose.ui.semantics.SemanticsProperties.EditableText
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.SemanticsMatcher.Companion.expectValue
-import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -11,7 +8,6 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
-import androidx.compose.ui.text.AnnotatedString
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
@@ -33,22 +29,25 @@ class TextInputTest {
   @OptIn(ExperimentalTestApi::class)
   @Test fun allowsTextEditing() {
     composeRule.onNode(hasSetTextAction()).performTextInput("he")
-    composeRule.onNode(hasSetTextAction()).assert(hasEditableTextEqualTo("he"))
+    composeRule.onNode(hasSetTextAction()).assertTextEquals("he")
 
     // For some reason performTextInput("llo") is flaky when running all the tests in this module.
     composeRule.onNode(hasSetTextAction())
       .performTextReplacement("hello")
-    composeRule.onNode(hasSetTextAction()).assert(hasEditableTextEqualTo("hello"))
+    composeRule.onNode(hasSetTextAction()).assertTextEquals("hello")
   }
 
   @Test fun swapsText() {
     composeRule.onNode(hasSetTextAction()).performTextInput("hello")
-    composeRule.onNode(hasSetTextAction()).assert(hasEditableTextEqualTo("hello"))
+    composeRule.onNode(hasSetTextAction()).assertTextEquals("hello")
 
     // Swap to empty field.
     composeRule.onNodeWithText("Swap").performClick()
 
-    composeRule.onNode(hasSetTextAction()).assert(hasEditableTextEqualTo(""))
+    // The EditableText is empty, but it's showing a hint of `Enter some text`.
+    // Even though the actual EditableText is blank/empty, if it's included, the assertion fails.
+    composeRule.onNode(hasSetTextAction())
+      .assertTextEquals("Enter some text", includeEditableText = false)
     composeRule.onNodeWithText("hello").assertDoesNotExist()
 
     composeRule.onNode(hasSetTextAction()).performTextInput("world")
@@ -57,10 +56,7 @@ class TextInputTest {
     // Swap back to first field.
     composeRule.onNodeWithText("Swap").performClick()
 
-    composeRule.onNode(hasSetTextAction()).assert(hasEditableTextEqualTo("hello"))
+    composeRule.onNode(hasSetTextAction()).assertTextEquals("hello")
     composeRule.onNodeWithText("world").assertDoesNotExist()
   }
-
-  private fun hasEditableTextEqualTo(text: String) =
-    expectValue(EditableText, AnnotatedString(text))
 }


### PR DESCRIPTION
The previous method of `expectValue(EditableText, AnnotatedString(text))` intermittently fails when I run it locally against an IRL Pixel 3a XL.

The node in the assertion is already being matched with `hasSetTextAction()`, so that's already established.  It should be fine to just assert against the text.

I'm tempted to say that the flakes are device-dependant, with different phones creating slight variations on `AnnotatedString`, but my Pixel isn't exactly changing in between test runs.  What we need is an expert in both Compose and Text.