### PR TITLE
debugging CI flakes around Guava resolution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ buildscript {
     classpath(Dependencies.Kotlin.binaryCompatibilityValidatorPlugin)
     classpath(Dependencies.Kotlin.gradlePlugin)
     classpath(Dependencies.Kotlin.Serialization.gradlePlugin)
+    classpath(Dependencies.ksp)
     classpath(Dependencies.ktlint)
     classpath(Dependencies.mavenPublish)
   }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -110,6 +110,7 @@ object Dependencies {
   }
 
   const val mavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
+  const val ksp = "com.google.devtools.ksp:symbol-processing-gradle-plugin:1.6.10-1.0.2"
   const val ktlint = "org.jlleitschuh.gradle:ktlint-gradle:10.2.1"
   const val lanterna = "com.googlecode.lanterna:lanterna:3.1.1"
   const val okio = "com.squareup.okio:okio:2.10.0"

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/textinput/TextInputTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/textinput/TextInputTest.kt
@@ -1,9 +1,6 @@
 package com.squareup.sample.compose.textinput
 
-import androidx.compose.ui.semantics.SemanticsProperties.EditableText
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.SemanticsMatcher.Companion.expectValue
-import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -11,7 +8,6 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
-import androidx.compose.ui.text.AnnotatedString
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
@@ -33,22 +29,25 @@ class TextInputTest {
   @OptIn(ExperimentalTestApi::class)
   @Test fun allowsTextEditing() {
     composeRule.onNode(hasSetTextAction()).performTextInput("he")
-    composeRule.onNode(hasSetTextAction()).assert(hasEditableTextEqualTo("he"))
+    composeRule.onNode(hasSetTextAction()).assertTextEquals("he")
 
     // For some reason performTextInput("llo") is flaky when running all the tests in this module.
     composeRule.onNode(hasSetTextAction())
       .performTextReplacement("hello")
-    composeRule.onNode(hasSetTextAction()).assert(hasEditableTextEqualTo("hello"))
+    composeRule.onNode(hasSetTextAction()).assertTextEquals("hello")
   }
 
   @Test fun swapsText() {
     composeRule.onNode(hasSetTextAction()).performTextInput("hello")
-    composeRule.onNode(hasSetTextAction()).assert(hasEditableTextEqualTo("hello"))
+    composeRule.onNode(hasSetTextAction()).assertTextEquals("hello")
 
     // Swap to empty field.
     composeRule.onNodeWithText("Swap").performClick()
 
-    composeRule.onNode(hasSetTextAction()).assert(hasEditableTextEqualTo(""))
+    // The EditableText is empty, but it's showing a hint of `Enter some text`.
+    // Even though the actual EditableText is blank/empty, if it's included, the assertion fails.
+    composeRule.onNode(hasSetTextAction())
+      .assertTextEquals("Enter some text", includeEditableText = false)
     composeRule.onNodeWithText("hello").assertDoesNotExist()
 
     composeRule.onNode(hasSetTextAction()).performTextInput("world")
@@ -57,10 +56,7 @@ class TextInputTest {
     // Swap back to first field.
     composeRule.onNodeWithText("Swap").performClick()
 
-    composeRule.onNode(hasSetTextAction()).assert(hasEditableTextEqualTo("hello"))
+    composeRule.onNode(hasSetTextAction()).assertTextEquals("hello")
     composeRule.onNodeWithText("world").assertDoesNotExist()
   }
-
-  private fun hasEditableTextEqualTo(text: String) =
-    expectValue(EditableText, AnnotatedString(text))
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,33 @@
 rootProject.name = "workflow"
 
+plugins {
+  id("com.gradle.enterprise").version("3.8.1")
+}
+
+gradleEnterprise {
+  buildScan {
+
+    termsOfServiceUrl = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = "yes"
+
+    val githubActionID = System.getenv("GITHUB_ACTION")
+
+    if (!githubActionID.isNullOrBlank()) {
+      publishAlways()
+      tag("CI")
+      link(
+        "WorkflowURL",
+        "https://github.com/" +
+          System.getenv("GITHUB_REPOSITORY") +
+          "/pull/" +
+          System.getenv("PR_NUMBER") +
+          "/checks?check_run_id=" +
+          System.getenv("GITHUB_RUN_ID")
+      )
+    }
+  }
+}
+
 include(
     ":internal-testing-utils",
     ":samples:compose-samples",

--- a/trace-encoder/build.gradle.kts
+++ b/trace-encoder/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   `java-library`
   kotlin("jvm")
-  kotlin("kapt")
+  id("com.google.devtools.ksp")
   id("com.vanniktech.maven.publish")
 }
 
@@ -16,7 +16,7 @@ dependencies {
   compileOnly(Dependencies.Annotations.intellij)
   compileOnly(Dependencies.Moshi.codeGen)
 
-  kapt(Dependencies.Moshi.codeGen)
+  ksp(Dependencies.Moshi.codeGen)
 
   api(Dependencies.Kotlin.Stdlib.jdk8)
   api(Dependencies.Kotlin.Coroutines.core)

--- a/workflow-tracing/build.gradle.kts
+++ b/workflow-tracing/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   `java-library`
   kotlin("jvm")
-  kotlin("kapt")
+  id("com.google.devtools.ksp")
   id("com.vanniktech.maven.publish")
 }
 
@@ -16,7 +16,7 @@ dependencies {
   compileOnly(Dependencies.Annotations.intellij)
   compileOnly(Dependencies.Moshi.codeGen)
 
-  kapt(Dependencies.Moshi.codeGen)
+  ksp(Dependencies.Moshi.codeGen)
 
   api(project(":trace-encoder"))
   api(project(":workflow-runtime"))


### PR DESCRIPTION
Relates to #641 

CI says it's failing because it can't resolve dependencies (usually Guava) during `:trace-encoder:kaptGenerateStubsKotlin`.  Kapt is used for Moshi's codegen.

I don't believe this is the real problem, because it's very consistent and no one's connection is that spotty.  I think something else is failing on a different thread (like a test), and that exception isn't being handled correctly.

So, this draft PR switches from using KAPT to KSP, since that's now stable.  It also enables build scans by default in CI.

Even though I like these changes, I have no strong feelings about actually merging this.  I'm just hoping to get some insight into what's failing.