### PR TITLE
Replace KAPT with KSP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ buildscript {
     classpath(Dependencies.Kotlin.binaryCompatibilityValidatorPlugin)
     classpath(Dependencies.Kotlin.gradlePlugin)
     classpath(Dependencies.Kotlin.Serialization.gradlePlugin)
+    classpath(Dependencies.ksp)
     classpath(Dependencies.ktlint)
     classpath(Dependencies.mavenPublish)
   }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -110,6 +110,7 @@ object Dependencies {
   }
 
   const val mavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
+  const val ksp = "com.google.devtools.ksp:symbol-processing-gradle-plugin:1.6.10-1.0.2"
   const val ktlint = "org.jlleitschuh.gradle:ktlint-gradle:10.2.1"
   const val lanterna = "com.googlecode.lanterna:lanterna:3.1.1"
   const val okio = "com.squareup.okio:okio:2.10.0"

--- a/trace-encoder/build.gradle.kts
+++ b/trace-encoder/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   `java-library`
   kotlin("jvm")
-  kotlin("kapt")
+  id("com.google.devtools.ksp")
   id("com.vanniktech.maven.publish")
 }
 
@@ -16,7 +16,7 @@ dependencies {
   compileOnly(Dependencies.Annotations.intellij)
   compileOnly(Dependencies.Moshi.codeGen)
 
-  kapt(Dependencies.Moshi.codeGen)
+  ksp(Dependencies.Moshi.codeGen)
 
   api(Dependencies.Kotlin.Stdlib.jdk8)
   api(Dependencies.Kotlin.Coroutines.core)

--- a/workflow-tracing/build.gradle.kts
+++ b/workflow-tracing/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   `java-library`
   kotlin("jvm")
-  kotlin("kapt")
   id("com.vanniktech.maven.publish")
 }
 
@@ -14,9 +13,6 @@ apply(from = rootProject.file(".buildscript/configure-maven-publish.gradle"))
 
 dependencies {
   compileOnly(Dependencies.Annotations.intellij)
-  compileOnly(Dependencies.Moshi.codeGen)
-
-  kapt(Dependencies.Moshi.codeGen)
 
   api(project(":trace-encoder"))
   api(project(":workflow-runtime"))


### PR DESCRIPTION
CI is very frequently flaking when trying to resolve dependencies (usually Guava) during `:trace-encoder:kaptGenerateStubsKotlin`.

We're using KAPT to generate a few Moshi adapters.  We could be using KSP instead, as it has now been upstreamed into Moshi and is stable.

The build servers shouldn't be failing to resolve anything, and KSP certainly doesn't fix that.  But, by adding it as a classpath dependency of the root project, KSP is resolved immediately.  In the worst-case scenario, this means that if it's going to fail to resolve, it will fail 20 minutes sooner.

These changes also remove KAPT and Moshi's codegen from `:workflow-tracing`, as that module doesn't actually use the codegen.

fixes #641