### PR TITLE
Sacrificing some chickens to the espresso gods

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -63,8 +63,9 @@ jobs:
       fail-fast: false
       matrix:
         api-level:
-          - 21
-          - 24
+          - 29
+      # Unclear that older versions actually honor command to disable animation.
+      # Newer versions are reputed to be too slow: https://github.com/ReactiveCircus/android-emulator-runner/issues/222
     steps:
       - uses: actions/checkout@v2
       - name: set up JDK 11.0.7

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -52,7 +52,6 @@ object Dependencies {
   const val cycler = "com.squareup.cycler:cycler:0.1.9"
 
   // Required for Dungeon Crawler sample.
-  const val desugar_jdk_libs = "com.android.tools:desugar_jdk_libs:1.1.5"
   const val leakcanary = "com.squareup.leakcanary:leakcanary-android:2.8.1"
   const val radiography = "com.squareup.radiography:radiography:2.4.0"
   const val rxandroid2 = "io.reactivex.rxjava2:rxandroid:2.1.1"

--- a/samples/dungeon/app/build.gradle.kts
+++ b/samples/dungeon/app/build.gradle.kts
@@ -13,17 +13,9 @@ android {
 
     testInstrumentationRunner = "com.squareup.sample.dungeon.DungeonTestRunner"
   }
-
-  compileOptions {
-    // Required for SnakeYAML.
-    isCoreLibraryDesugaringEnabled = true
-  }
 }
 
 dependencies {
-  // Required for SnakeYAML.
-  "coreLibraryDesugaring"(Dependencies.desugar_jdk_libs)
-
   debugImplementation(Dependencies.leakcanary)
 
   implementation(project(":samples:dungeon:common"))


### PR DESCRIPTION
Two commits so far:

###     Drops AVD 21, bumps 27 to 29

21 has long been a source of nothing but noise, and I suspect that 29 is the first that actually honors the commands we use to turn of animation.

We have at least one test that only fails on 32, but that's not available yet. 30 and 31 are reputed to be [too slow to use](https://github.com/ReactiveCircus/android-emulator-runner/issues/222).


###    Drops com.android.tools:desugar_jdk_libs

Suspecting that it's the cause of a frequent CI failure building `samples:dungeon:common:compileKotlin`:

```
Caused by: org.gradle.api.GradleException: Could not read directory path '/Users/runner/work/workflow-kotlin/workflow-kotlin/samples/dungeon/common/build/kotlin/compileKotlin/caches-jvm/inputs'.
```

At any rate, it's the only interesting thing about that build, and doesn't appear to be necessary any longer.
