### PR TITLE
ParcelableTextController

### DIFF
--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -85,6 +85,25 @@ public final class com/squareup/workflow1/ui/NamedViewFactory : com/squareup/wor
 	public fun getType ()Lkotlin/reflect/KClass;
 }
 
+public final class com/squareup/workflow1/ui/ParcelableTextController : android/os/Parcelable, com/squareup/workflow1/ui/TextController {
+	public static final field CREATOR Lcom/squareup/workflow1/ui/ParcelableTextController$CREATOR;
+	public synthetic fun <init> (Landroid/os/Parcel;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun describeContents ()I
+	public fun getOnTextChanged ()Lkotlinx/coroutines/flow/Flow;
+	public fun getTextValue ()Ljava/lang/String;
+	public fun setTextValue (Ljava/lang/String;)V
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/squareup/workflow1/ui/ParcelableTextController$CREATOR : android/os/Parcelable$Creator {
+	public fun createFromParcel (Landroid/os/Parcel;)Lcom/squareup/workflow1/ui/ParcelableTextController;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public fun newArray (I)[Lcom/squareup/workflow1/ui/ParcelableTextController;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/squareup/workflow1/ui/PickledTreesnapshot : android/os/Parcelable {
 	public static final field CREATOR Lcom/squareup/workflow1/ui/PickledTreesnapshot$CREATOR;
 	public fun <init> (Lcom/squareup/workflow1/TreeSnapshot;)V

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ParcelableTextController.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ParcelableTextController.kt
@@ -1,0 +1,35 @@
+package com.squareup.workflow1.ui
+
+import android.os.Parcel
+import android.os.Parcelable
+import android.os.Parcelable.Creator
+
+/**
+ * [Parcelable] implementation of [TextController].
+ */
+@WorkflowUiExperimentalApi
+public class ParcelableTextController private constructor(
+  controllerImplementation: TextController
+) : TextController by controllerImplementation, Parcelable {
+
+  public constructor(initialValue: String = "") : this(TextController(initialValue))
+
+  private constructor(parcel: Parcel) : this(parcel.readString() ?: "")
+
+  override fun writeToParcel(
+    out: Parcel,
+    flags: Int
+  ) {
+    out.writeString(textValue)
+  }
+
+  override fun describeContents(): Int = 0
+
+  public companion object CREATOR : Creator<ParcelableTextController> {
+
+    override fun createFromParcel(source: Parcel): ParcelableTextController =
+      ParcelableTextController(source)
+
+    override fun newArray(size: Int): Array<ParcelableTextController?> = arrayOfNulls(size)
+  }
+}

--- a/workflow-ui/core-common/api/core-common.api
+++ b/workflow-ui/core-common/api/core-common.api
@@ -26,13 +26,15 @@ public final class com/squareup/workflow1/ui/Named : com/squareup/workflow1/ui/C
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/squareup/workflow1/ui/TextController {
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getOnTextChanged ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getTextValue ()Ljava/lang/String;
-	public final fun setTextValue (Ljava/lang/String;)V
+public abstract interface class com/squareup/workflow1/ui/TextController {
+	public abstract fun getOnTextChanged ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getTextValue ()Ljava/lang/String;
+	public abstract fun setTextValue (Ljava/lang/String;)V
+}
+
+public final class com/squareup/workflow1/ui/TextControllerKt {
+	public static final fun TextController (Ljava/lang/String;)Lcom/squareup/workflow1/ui/TextController;
+	public static synthetic fun TextController$default (Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/TextController;
 }
 
 public abstract interface annotation class com/squareup/workflow1/ui/WorkflowUiExperimentalApi : java/lang/annotation/Annotation {

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/TextController.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/TextController.kt
@@ -33,7 +33,35 @@ import kotlinx.coroutines.flow.drop
  * worker.
  */
 @WorkflowUiExperimentalApi
-public class TextController(initialValue: String = "") {
+public interface TextController {
+
+  /**
+   * A [Flow] that emits the text value whenever it changes -- and only when it changes, the current value
+   * is not provided at subscription time. Workflows can safely observe changes by
+   * converting this value to a worker. (When using multiple instances, remember to provide unique
+   * key values to each `asWorker` call.)
+   *
+   * If you can do processing that doesn't require running a `WorkflowAction` or triggering a render
+   * pass, it can be done in regular Flow operators before converting to a worker.
+   */
+  public val onTextChanged: Flow<String>
+
+  /**
+   * The current text value.
+   */
+  public var textValue: String
+}
+
+@WorkflowUiExperimentalApi
+public fun TextController(initialValue: String = ""): TextController {
+  return TextControllerImpl(initialValue)
+}
+
+/**
+ * Default implementation of [TextController].
+ */
+@WorkflowUiExperimentalApi
+private class TextControllerImpl(initialValue: String) : TextController {
 
   /**
    * This flow is not exposed as a StateFlow intentionally. Doing so would encourage observing it from
@@ -49,21 +77,9 @@ public class TextController(initialValue: String = "") {
    */
   private val _textValue: MutableStateFlow<String> = MutableStateFlow(initialValue)
 
-  /**
-   * A [Flow] that emits the text value whenever it changes -- and only when it changes, the current value
-   * is not provided at subscription time. Workflows can safely observe changes by
-   * converting this value to a worker. (When using multiple instances, remember to provide unique
-   * key values to each `asWorker` call.)
-   *
-   * If you can do processing that doesn't require running a `WorkflowAction` or triggering a render
-   * pass, it can be done in regular Flow operators before converting to a worker.
-   */
-  public val onTextChanged: Flow<String> = _textValue.drop(1)
+  override val onTextChanged: Flow<String> = _textValue.drop(1)
 
-  /**
-   * The current text value.
-   */
-  public var textValue: String
+  override var textValue: String
     get() = _textValue.value
     set(value) {
       _textValue.value = value

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/TextController.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/TextController.kt
@@ -52,6 +52,9 @@ public interface TextController {
   public var textValue: String
 }
 
+/**
+ * Create instance for default implementation of [TextController].
+ */
 @WorkflowUiExperimentalApi
 public fun TextController(initialValue: String = ""): TextController {
   return TextControllerImpl(initialValue)


### PR DESCRIPTION
Implemented Parcelable version of TextController for Android use case. 
It's a wrapper class around TextController interface that delegates logic to the default implementation and only handles Parcelization.

It is designed for following use cases, example
```kotlin
class ExampleWorkflow : StatefulWorkflow<Unit, ExampleState, Unit, Any>() {

    final override fun initialState(props: Unit, snapshot: Snapshot?): StateT {
        return ExampleState(ParcelableTextController("example"))
    }
    
    override fun snapshotState(state: ExampleState): Snapshot = state.toSnapshot()
    ...
}

@Parcelize
data class ExampleState(val text: ParcelableTextController) : Parcelable
```