### PR TITLE
auto-publish a snapshot after pushing to `main` or `ray/ui-update`

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,28 @@
+name: Publish snapshot
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - ray/ui-update
+
+jobs:
+  publish-snapshot :
+    runs-on : ubuntu-latest
+    if : github.repository == 'square/workflow-kotlin'
+    timeout-minutes : 25
+
+    steps :
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
+      - name: set up JDK 11.0.7
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11.0.7
+
+      - name : Publish Snapshots
+        run: ./gradlew clean build && ./gradlew publish --no-parallel --no-daemon
+        env :
+          ORG_GRADLE_PROJECT_mavenCentralUsername : ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword : ${{ secrets.SONATYPE_NEXUS_PASSWORD }}


### PR DESCRIPTION
Note @rjrjr that we'll need to change the ui branch's version to something like `1.7.0-ui-SNAPSHOT` in order to avoid overwrites.