### PR TITLE
set explicit Robolectric SDK version for IdlingDispatcherTest

### DIFF
--- a/.buildscript/configure-android-defaults.gradle
+++ b/.buildscript/configure-android-defaults.gradle
@@ -13,6 +13,13 @@ android {
     versionName "1.0"
   }
 
+  testOptions {
+    unitTests {
+      returnDefaultValues = true
+      includeAndroidResources = true
+    }
+  }
+
   buildFeatures.buildConfig = false
 
   // See https://github.com/Kotlin/kotlinx.coroutines/issues/1064#issuecomment-479412940

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ mockito-core = "3.3.3"
 mockito-kotlin = "3.2.0"
 
 mockk = "1.11.0"
-robolectric = "4.5.1"
+robolectric = "4.6.1"
 
 rxjava2-android = "2.1.1"
 rxjava2-core = "2.2.21"

--- a/workflow-ui/container-android/src/test/java/com/squareup/workflow1/ui/modal/ModalContainerTest.kt
+++ b/workflow-ui/container-android/src/test/java/com/squareup/workflow1/ui/modal/ModalContainerTest.kt
@@ -16,7 +16,7 @@ import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 // SDK 28 required for the four-arg constructor we use in our custom view classes.
-@Config(manifest = Config.NONE, sdk = [28])
+@Config(sdk = [28])
 @OptIn(WorkflowUiExperimentalApi::class)
 internal class ModalContainerTest {
   private val context: Context = ApplicationProvider.getApplicationContext()

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/androidx/WorkflowSavedStateRegistryAggregatorTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/androidx/WorkflowSavedStateRegistryAggregatorTest.kt
@@ -59,7 +59,7 @@ internal class WorkflowSavedStateRegistryAggregatorTest {
       )
     }
 
-    assertThat(error).hasMessageThat().startsWith("Expected android.view.View@")
+    assertThat(error).hasMessageThat().startsWith("Expected android.view.View{")
     assertThat(error).hasMessageThat()
       .endsWith("(key) to have a ViewTreeLifecycleOwner. Use WorkflowLifecycleOwner to fix that.")
   }

--- a/workflow-ui/internal-testing-android/src/test/java/com/squareup/workflow1/ui/internal/test/IdlingDispatcherTest.kt
+++ b/workflow-ui/internal-testing-android/src/test/java/com/squareup/workflow1/ui/internal/test/IdlingDispatcherTest.kt
@@ -11,11 +11,14 @@ import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 
+// The SDK should be unimportant, but Robolectric 4.6.1 has shadowing issues if it isn't set.
+@Config(sdk = [28])
 @RunWith(RobolectricTestRunner::class)
-class IdlingDIspatcherTest {
+class IdlingDispatcherTest {
 
   @Test fun `should not go to idle when dispatching to another dispatcher`() = runBlocking {
 


### PR DESCRIPTION
This test is fine with Robolectric `4.5.1`, but `4.6.1` fails when trying to resolve who-knows-what.

```
java.lang.ExceptionInInitializerError
	at androidx.test.espresso.idling.CountingIdlingResource.<init>(CountingIdlingResource.java:115)
	at androidx.test.espresso.idling.CountingIdlingResource.<init>(CountingIdlingResource.java:104)
	at com.squareup.workflow1.ui.internal.test.IdlingDispatcher.<init>(IdlingDispatcher.kt:31)
	at com.squareup.workflow1.ui.internal.test.IdlingDispatcherTest$should return to idle if a coroutine is cancelled before completion$1.invokeSuspend(IdlingDispatcherTest.kt:53)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at com.squareup.workflow1.ui.internal.test.IdlingDispatcherTest.should return to idle if a coroutine is cancelled before completion(IdlingDispatcherTest.kt:48)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:570)
	at org.robolectric.internal.SandboxTestRunner$2.lambda$evaluate$0(SandboxTestRunner.java:278)
	at org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThread$0(Sandbox.java:89)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at org.robolectric.internal.bytecode.ShadowWrangler.classInitializing(ShadowWrangler.java:181)
	at org.robolectric.internal.bytecode.RobolectricInternals.classInitializing(RobolectricInternals.java:21)
	at android.text.TextUtils.<clinit>(TextUtils.java)
	... 29 more
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.robolectric.internal.bytecode.RobolectricInternals.performStaticInitialization(RobolectricInternals.java:61)
	at org.robolectric.internal.bytecode.ShadowWrangler.classInitializing(ShadowWrangler.java:178)
	... 31 more
Caused by: java.lang.NullPointerException
	at org.robolectric.shadows.ShadowLegacyAssetManager.getAndResolve(ShadowLegacyAssetManager.java:1019)
	at org.robolectric.shadows.ShadowLegacyAssetManager.getResourceText(ShadowLegacyAssetManager.java:285)
	at android.content.res.AssetManager.getResourceText(AssetManager.java)
	at android.content.res.Resources.getText(Resources.java:225)
	at android.content.res.Resources.getString(Resources.java:313)
	at android.text.TextUtils.__staticInitializer__(TextUtils.java:1704)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.robolectric.internal.bytecode.RobolectricInternals.performStaticInitialization(RobolectricInternals.java:61)
	at org.robolectric.internal.bytecode.ShadowWrangler.classInitializing(ShadowWrangler.java:178)
	at org.robolectric.internal.bytecode.RobolectricInternals.classInitializing(RobolectricInternals.java:21)
	at android.text.TextUtils.<clinit>(TextUtils.java)
	at androidx.test.espresso.idling.CountingIdlingResource.<init>(CountingIdlingResource.java:115)
	at androidx.test.espresso.idling.CountingIdlingResource.<init>(CountingIdlingResource.java:104)
	at com.squareup.workflow1.ui.internal.test.IdlingDispatcher.<init>(IdlingDispatcher.kt:31)
	at com.squareup.workflow1.ui.internal.test.IdlingDispatcherTest$should return to idle if a coroutine is cancelled before completion$1.invokeSuspend(IdlingDispatcherTest.kt:53)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at com.squareup.workflow1.ui.internal.test.IdlingDispatcherTest.should return to idle if a coroutine is cancelled before completion(IdlingDispatcherTest.kt:48)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	... 12 more
```

Just setting the SDK level to 28 makes it pass again with 4.6.1.  No assets/resources/manifests/activities/sdk levels have any bearing on this test, so that should be good enough for now.