### PR TITLE
Compose overhaul WIP, is it "too pure"?

### DIFF
--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeScreen.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeScreen.kt
@@ -1,0 +1,26 @@
+package com.squareup.workflow1.ui.compose
+
+import androidx.compose.runtime.Composable
+import com.squareup.workflow1.ui.Screen
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+
+/**
+ * Interface implemented by a rendering class to allow it to drive an Android UI
+ * via an appropriate `@Composable` [Content] function.
+ */
+@WorkflowUiExperimentalApi
+public interface ComposeScreen<S : ComposeScreen<S>> : Screen {
+
+  /**
+   * The composable content of this rendering. This method will be called
+   * any time a new rendering is emitted, or the [viewEnvironment]
+   * changes.
+   *
+   * This function will either serve as the root of a
+   * [ComposeView][androidx.compose.ui.platform.ComposeView], or else
+   * be called as the child of a [Box][androidx.compose.foundation.layout.Box]
+   */
+  @Suppress("FunctionName")
+  @Composable public fun Content(viewEnvironment: ViewEnvironment)
+}

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeScreenViewFactory.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeScreenViewFactory.kt
@@ -1,0 +1,39 @@
+package com.squareup.workflow1.ui.compose
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import com.squareup.workflow1.ui.Screen
+import com.squareup.workflow1.ui.ScreenViewFactory
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.bindShowRendering
+
+/**
+ * Bridge between [ScreenViewFactory] and [ScreenComposableFactory], and thus between
+ * classic [View]s and Compose UI.
+ */
+@WorkflowUiExperimentalApi
+public abstract class ComposeScreenViewFactory<RenderingT : Screen> : ScreenViewFactory<RenderingT>,
+  ScreenComposableFactory<RenderingT> {
+
+  final override fun buildView(
+    initialRendering: RenderingT,
+    initialViewEnvironment: ViewEnvironment,
+    contextForNewView: Context,
+    container: ViewGroup?
+  ): View = ComposeView(contextForNewView).also { composeView ->
+    // Update the state whenever a new rendering is emitted.
+    // This lambda will be executed synchronously before bindShowRendering returns.
+    composeView.bindShowRendering(
+      initialRendering,
+      initialViewEnvironment
+    ) { rendering, environment ->
+      // Entry point to the world of Compose.
+      composeView.setContent {
+        Content(rendering, environment)
+      }
+    }
+  }
+}

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ScreenComposableFactory.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ScreenComposableFactory.kt
@@ -1,0 +1,128 @@
+package com.squareup.workflow1.ui.compose
+
+import android.view.View
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewTreeLifecycleOwner
+import com.squareup.workflow1.ui.Screen
+import com.squareup.workflow1.ui.ScreenViewFactory
+import com.squareup.workflow1.ui.ScreenViewFactoryFinder
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewFactory
+import com.squareup.workflow1.ui.ViewRegistry
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.WorkflowViewStub
+import com.squareup.workflow1.ui.getShowRendering
+import com.squareup.workflow1.ui.showRendering
+import com.squareup.workflow1.ui.start
+import kotlin.reflect.KClass
+
+@WorkflowUiExperimentalApi
+public interface ScreenComposableFactory<in RenderingT : Screen> : ViewRegistry.Entry<RenderingT> {
+
+  /**
+   * The composable content of this factory. This method will be called any time [rendering]
+   * or [viewEnvironment] change, wrapped in a [Box][androidx.compose.foundation.layout.Box].
+   * It is the Compose-based analogue of
+   * [ScreenViewRunner.showRendering][com.squareup.workflow1.ui.ScreenViewRunner.showRendering].
+   */
+  @Suppress("FunctionName")
+  @Composable public fun Content(
+    rendering: RenderingT,
+    viewEnvironment: ViewEnvironment
+  )
+}
+
+@WorkflowUiExperimentalApi
+public fun <T : Screen> T.toComposableFactory(
+  viewEnvironment: ViewEnvironment
+): ScreenComposableFactory<T> {
+  val entry = viewEnvironment[ViewRegistry].getEntryFor(this::class)
+
+  @Suppress("UNCHECKED_CAST")
+  return entry as? ScreenComposableFactory<T>
+    ?: viewEnvironment[ScreenViewFactoryFinder]
+        .getViewFactoryForRenderingOrNull(viewEnvironment, this)?.asComposableFactory()
+    ?: (this as? ComposeScreen<*>)?.let {
+      object : ScreenComposableFactory<T> {
+        override val type: KClass<in T> get() = error("Unused, this isn't in a ViewRegistry")
+
+        @Composable override fun Content(
+          rendering: T,
+          viewEnvironment: ViewEnvironment
+        ) {
+          (rendering as ComposeScreen<*>).Content(viewEnvironment)
+        }
+      }
+    }
+    ?: throw IllegalArgumentException(
+      "Is this even possible? Failed to find or create a ScreenComposableFactory" +
+        "to display $this, and it doesn't implement ComposeScreen. Instead found $entry."
+    )
+
+  // TODO Need to add default wrapper types here s.t. they don't force views to be created.
+  //  NamedScreen, EnvironmentScreen
+}
+
+@WorkflowUiExperimentalApi
+private fun <T : Screen> ScreenViewFactory<T>.asComposableFactory(): ScreenComposableFactory<T> {
+  return object : ScreenComposableFactory<T> {
+    override val type: KClass<in T> get() = error("Unused, this isn't in a ViewRegistry")
+
+    /**
+     * This is effectively the logic of [WorkflowViewStub], but translated into Compose idioms.
+     * This approach has a few advantages:
+     *
+     *  - Avoids extra custom views required to host `WorkflowViewStub` inside a Composition. Its trick
+     *    of replacing itself in its parent doesn't play nicely with Compose.
+     *  - Allows us to pass the correct parent view for inflation (the root of the composition).
+     *  - Avoids `WorkflowViewStub` having to do its own lookup to find the correct [ViewFactory], since
+     *    we already have the correct one.
+     *  - Propagate the current [LifecycleOwner] from [LocalLifecycleOwner] by setting it as the
+     *    [ViewTreeLifecycleOwner] on the view.
+     *
+     * Like `WorkflowViewStub`, this function uses the original [ScreenViewFactory] to create and
+     * memoize a [View] to display the [rendering], keeps it updated with the latest [rendering] and
+     * [viewEnvironment], and adds it to the composition.
+     */
+    override fun Content(
+      rendering: T,
+      viewEnvironment: ViewEnvironment
+    ) {
+      val lifecycleOwner = LocalLifecycleOwner.current
+
+      AndroidView(
+        factory = { context ->
+          // We pass in a null container because the container isn't a View, it's a composable. The
+          // compose machinery will generate an intermediate view that it ends up adding this to but
+          // we don't have access to that.
+          buildView(rendering, viewEnvironment, context, container = null)
+            .also { view ->
+              view.start()
+
+              // Mirrors the check done in Screen.buildView.
+              checkNotNull(view.getShowRendering<Any>()) {
+                "View.bindShowRendering should have been called for $view, typically by the " +
+                  "ScreenViewFactory that created it."
+              }
+
+              // Unfortunately AndroidView doesn't propagate this itself.
+              ViewTreeLifecycleOwner.set(view, lifecycleOwner)
+              // We don't propagate the (non-compose) SavedStateRegistryOwner, or the (compose)
+              // SaveableStateRegistry, because currently all our navigation is implemented as
+              // Android views, which ensures there is always an Android view between any state
+              // registry and any Android view shown as a child of it, even if there's a compose
+              // view in between.
+            }
+        },
+        // This function will be invoked every time this composable is recomposed, which means that
+        // any time a new rendering or view environment are passed in we'll send them to the view.
+        update = { view ->
+          view.showRendering(rendering, viewEnvironment)
+        }
+      )
+    }
+  }
+}

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
@@ -8,7 +8,7 @@ import android.view.ViewGroup
 import com.squareup.workflow1.ui.container.BackStackScreen
 import kotlin.reflect.KClass
 
-@Deprecated("Use ScreenViewFactoryFinder.getViewFactoryForRendering()")
+@Deprecated("Use ScreenViewFactoryFinder.getViewFactoryForRenderingOrNull()")
 @WorkflowUiExperimentalApi
 public fun <RenderingT : Any> ViewRegistry.getFactoryForRendering(
   rendering: RenderingT

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewFactory.kt
@@ -57,9 +57,13 @@ public fun <ScreenT : Screen> ScreenT.buildView(
   container: ViewGroup? = null,
   viewStarter: ViewStarter? = null,
 ): View {
-  val viewFactory = viewEnvironment[ScreenViewFactoryFinder].getViewFactoryForRendering(
-    viewEnvironment, this
-  )
+  val viewFactory = viewEnvironment[ScreenViewFactoryFinder]
+    .getViewFactoryForRenderingOrNull(viewEnvironment, this)
+    ?: throw IllegalArgumentException(
+      "A ScreenViewFactory should have been registered to display $this, " +
+        "or that class should implement AndroidScreen. " +
+        "Instead found ${viewEnvironment[ViewRegistry].getEntryFor(this::class)}."
+    )
 
   return viewFactory.buildView(this, viewEnvironment, contextForNewView, container).also { view ->
     checkNotNull(view.workflowViewStateOrNull) {

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/ViewRegistry.kt
@@ -88,6 +88,7 @@ public interface ViewRegistry {
   }
 }
 
+// TODO: either get rid of this or [getEntryFor], having both is just confusing.
 @WorkflowUiExperimentalApi public inline operator fun <reified RenderingT : Any> ViewRegistry.get(
   renderingType: KClass<out RenderingT>
 ): Entry<RenderingT>? = getEntryFor(renderingType)


### PR DESCRIPTION
_This is mostly a note to Monday me, with extra formatting effort so that it can serve as the basis of a commit message some day soon._

The existing Compose support is completely tied to `ViewFactory`, which makes sense, because there was nothing else. It works _very_ well.

In this rewrite, I've tried to follow the patterns introduced by `Screen` and `Overlay`, now that `ViewRegistry.Entry` allows us to have multiple kinds of factories:

| Marker Interface | Extension backed by…      | … a ViewRegistry.Entry | Compile time binding interface |
| ---              | ---                       | ---                    | --- |
| `Screen`         | `Screen.buildView`        | `ScreenViewFactory`     | `AndroidScreen` |
| `Overlay`        | `Overlay.toDialogFactory` | `OverlayDialogFactory` | `AndroidOverlay`|

This PR updates that table like so:

| Marker Interface | Extension backed by…      | … a ViewRegistry.Entry | Compile time binding interface |
| ---              | ---                       | ---                    | --- |
| `Screen`         | `Screen.buildView`        | `ScreenViewFactory`     | `AndroidScreen` |
|                  | `Screen.toComposableFactory` | `ScreenComposableFactory`| `ComposeScreen` |
| `Overlay`        | `Overlay.toDialogFactory` | `OverlayDialogFactory` | `AndroidOverlay`|

- There is a new `Screen.toComposableFactory` extension, backed by…

- `ScreenComposableFactory`, a new `ViewRegistry.Entry` that can turn a `Screen` into a `@Composable` function, and…

- `ComposeScreen`, like `AndroidScreen` / `AndroidViewRendering`, an interface implemented by renderings that lets them define their `@Composable fun Content()` at compile time.

I have no idea yet if it works.

I'm concerned that there is going to be a bootstrap problem. With the existing stuff, you're basically forced to create both a `@Composeable` entry point and a `ViewFactory` entry point, because everything `ViewFactory` is the only show in town. (It's not a burden in practice, the View-specific bits all happen for free.) Because of this, we're able to map every rendering into both a `@Composable` and a `View` automatically, regardless of whether its base binding is `View`-based or Compose-based.

In the new world, by separating `ScreenViewFactory` and `ScreenComposableFactory`, I'm losing some of the  every-rendering-provides-both-factories nature.

It's okay in the Compose > Classic direction. `Screen.toComposableFactory` is able to do the trick. It can find an existing `ScreenComposableFactory`, or wrap a `ScreenViewFactory` with one.

But I can't seamlessly go in the other direction, Classic > Compose.  `Screen.buildView` can't find and automatically wrap a `ScreenComposableFactory` with a `ComposeView` unless we do one of the following:

 1. Provide a Compose specific `ScreenViewFactoryFinder`, and require Compose apps to set it up. (`ScreenViewFactoryFinder` is the customizable strategy object that backs `Screen.buildView`.)

 2. Make all of workflow-ui depend on Compose, and build knowledge of it into the default `ScreenViewFactoryFinder`

 3. Forget about the new `ScreenComposableFactory : ViewRegistry.Entry`, and just port the current stuff from `ViewFactory` to `ScreenViewFactory`. Make `CompseScreen` an abstract subclass of `AndroidScreen`.

Option three would be a lot easier, really. It's a little ugly on the implementation side, but I'm hard pressed to see any actual downside.
