### PR TITLE
introduce `artifacts-check` plugin

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -78,7 +78,7 @@ jobs:
           gradle-dependencies-cache-key : |
             gradle/libs.versions.toml
           arguments : |
-            test apiCheck lint ktlintCheck jmhJar --no-daemon --stacktrace --continue
+            test apiCheck artifactsCheck lint ktlintCheck jmhJar --no-daemon --stacktrace --continue
           concurrent : true
           gradle-build-scan-report : false
           gradle-distribution-sha-256-sum-warning : false

--- a/artifacts.json
+++ b/artifacts.json
@@ -1,0 +1,114 @@
+[
+  {
+    "gradlePath": ":internal-testing-utils",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-internal-testing-utils",
+    "description": "Workflow internal testing utilities",
+    "packaging": "jar",
+    "javaVersion": "1.8"
+  },
+  {
+    "gradlePath": ":trace-encoder",
+    "group": "com.squareup.workflow1",
+    "artifactId": "trace-encoder",
+    "description": "Trace Encoder",
+    "packaging": "jar",
+    "javaVersion": "1.8"
+  },
+  {
+    "gradlePath": ":workflow-core",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-core-jvm",
+    "description": "Workflow Core",
+    "packaging": "jar",
+    "javaVersion": "1.8"
+  },
+  {
+    "gradlePath": ":workflow-runtime",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-runtime-jvm",
+    "description": "Workflow Runtime",
+    "packaging": "jar",
+    "javaVersion": "1.8"
+  },
+  {
+    "gradlePath": ":workflow-rx2",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-rx2",
+    "description": "Workflow RxJava2",
+    "packaging": "jar",
+    "javaVersion": "1.8"
+  },
+  {
+    "gradlePath": ":workflow-testing",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-testing-jvm",
+    "description": "Workflow Testing",
+    "packaging": "jar",
+    "javaVersion": "1.8"
+  },
+  {
+    "gradlePath": ":workflow-tracing",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-tracing",
+    "description": "Workflow Tracing",
+    "packaging": "jar",
+    "javaVersion": "1.8"
+  },
+  {
+    "gradlePath": ":workflow-ui:compose",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-ui-compose",
+    "description": "Workflow UI Compose",
+    "packaging": "aar",
+    "javaVersion": "1.8"
+  },
+  {
+    "gradlePath": ":workflow-ui:compose-tooling",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-ui-compose-tooling",
+    "description": "Workflow UI Compose Tooling",
+    "packaging": "aar",
+    "javaVersion": "1.8"
+  },
+  {
+    "gradlePath": ":workflow-ui:container-android",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-ui-container-android",
+    "description": "Workflow UI Container Android",
+    "packaging": "aar",
+    "javaVersion": "1.8"
+  },
+  {
+    "gradlePath": ":workflow-ui:container-common",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-ui-container-common-jvm",
+    "description": "Workflow UI Container",
+    "packaging": "jar",
+    "javaVersion": "1.8"
+  },
+  {
+    "gradlePath": ":workflow-ui:core-android",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-ui-core-android",
+    "description": "Workflow UI Android",
+    "packaging": "aar",
+    "javaVersion": "1.8"
+  },
+  {
+    "gradlePath": ":workflow-ui:core-common",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-ui-core-common-jvm",
+    "description": "Workflow UI Core",
+    "packaging": "jar",
+    "javaVersion": "1.8"
+  },
+  {
+    "gradlePath": ":workflow-ui:radiography",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-ui-radiography",
+    "description": "Workflow UI Radiography Support",
+    "packaging": "aar",
+    "javaVersion": "1.8"
+  }
+]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,11 @@ buildscript {
   }
 }
 
+plugins {
+  base
+  `artifacts-check`
+}
+
 // See https://stackoverflow.com/questions/25324880/detect-ide-environment-with-gradle
 val isRunningFromIde get() = project.properties["android.injected.invoked.from.ide"] == "true"
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,24 @@
+@Suppress("UnstableApiUsage")
 plugins {
   `kotlin-dsl`
+  alias(libs.plugins.google.ksp)
 }
 
 repositories {
   mavenCentral()
+  google()
+}
+
+dependencies {
+  compileOnly(gradleApi())
+
+  implementation(libs.squareup.moshi)
+  implementation(libs.squareup.moshi.adapters)
+
+  ksp(libs.squareup.moshi.codegen)
+}
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
 }

--- a/buildSrc/src/main/java/artifacts-check.gradle.kts
+++ b/buildSrc/src/main/java/artifacts-check.gradle.kts
@@ -1,0 +1,22 @@
+import com.squareup.workflow1.buildsrc.artifacts.ArtifactsCheckTask
+import com.squareup.workflow1.buildsrc.artifacts.ArtifactsDumpTask
+
+check(project.rootProject == project) {
+  "Only apply this plugin to the project root."
+}
+
+val artifactsDump by tasks.registering(ArtifactsDumpTask::class)
+
+val artifactsCheck by tasks.registering(ArtifactsCheckTask::class)
+
+// Automatically run `artifactsCheck` when running `check`
+tasks.named("check") {
+  dependsOn(artifactsCheck)
+}
+
+// Before any publishing task (local or remote) ensure that the artifacts check is executed.
+allprojects {
+  tasks.withType(AbstractPublishToMaven::class.java) {
+    dependsOn(artifactsCheck)
+  }
+}

--- a/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/artifacts/ArtifactConfig.kt
+++ b/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/artifacts/ArtifactConfig.kt
@@ -1,0 +1,31 @@
+package com.squareup.workflow1.buildsrc.artifacts
+
+import com.squareup.moshi.JsonClass
+import java.io.Serializable
+
+/**
+ * Models the module-specific properties of published maven artifacts.
+ *
+ * see (Niklas Baudy's
+ * [gradle-maven-publish-plugin](https://github.com/vanniktech/gradle-maven-publish-plugin))
+ *
+ * @param gradlePath the path of the Gradle project, such as `:workflow-core`
+ * @param group The maven "group", which should always be `com.squareup.workflow1`. This is the
+ *   `GROUP` property in the Gradle plugin.
+ * @param artifactId The maven "module", such as `workflow-core-jvm`. This is the
+ *   `POM_ARTIFACT_ID` property in the Gradle plugin.
+ * @param description The description of this specific artifact, such as "Workflow Core". This is
+ *   the `POM_NAME` property in the Gradle plugin.
+ * @param packaging `aar` or `jar`. This is the `POM_PACKAGING` property in the Gradle plugin.
+ * @param javaVersion the java version of the artifact (typically 8 or 11). If not set
+ *   explicitly, this defaults to the JDK version used to build the artifact.
+ */
+@JsonClass(generateAdapter = true)
+data class ArtifactConfig(
+  val gradlePath: String,
+  val group: String,
+  val artifactId: String,
+  val description: String,
+  val packaging: String,
+  val javaVersion: String
+) : Serializable

--- a/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/artifacts/ArtifactsCheckTask.kt
+++ b/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/artifacts/ArtifactsCheckTask.kt
@@ -1,0 +1,221 @@
+package com.squareup.workflow1.buildsrc.artifacts
+
+import com.squareup.workflow1.buildsrc.artifacts.ArtifactsCheckTask.Color.RESET
+import com.squareup.workflow1.buildsrc.artifacts.ArtifactsCheckTask.Color.YELLOW
+import org.gradle.api.GradleException
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.tasks.TaskAction
+import java.util.Locale
+import javax.inject.Inject
+
+/**
+ * Evaluates all published artifacts in the project and compares the results to `/artifacts.json`.
+ *
+ * If there are any differences, the task will fail with a descriptive message.
+ */
+open class ArtifactsCheckTask @Inject constructor(
+  projectLayout: ProjectLayout
+) : ArtifactsTask(projectLayout) {
+
+  init {
+    description = "Parses the Maven artifact parameters for all modules " +
+      "and compares them to those recorded in artifacts.json"
+    group = "verification"
+  }
+
+  @TaskAction
+  fun run() {
+
+    val fromJson = moshiAdapter.fromJson(reportFile.asFile.readText())
+      .orEmpty()
+      .associateBy { it.gradlePath }
+
+    val currentPaths = currentList.mapTo(mutableSetOf()) { it.gradlePath }
+
+    val extraFromJson = fromJson.values.filterNot { it.gradlePath in currentPaths }
+    val extraFromCurrent = currentList.filterNot { it.gradlePath in fromJson.keys }
+
+    val changed = currentList.minus(fromJson.values)
+      .minus(extraFromCurrent)
+      .map { artifact ->
+        fromJson.getValue(artifact.gradlePath) to artifact
+      }
+
+    // Each artifact needs to have a unique ID.  Repository managers will quietly allow overwrites
+    // with duplicate IDs, so this is the last chance to catch it before publishing.
+    val duplicateArtifactIds = currentList.findDuplicates { artifactId }
+
+    // This is mostly superficial, but it ensures that a copy/pasted module also doesn't retain the
+    // original's pom description.
+    val duplicateDescriptions = currentList.findDuplicates { description }
+
+    val foundSomething = sequenceOf(
+      duplicateArtifactIds.keys,
+      duplicateDescriptions.keys,
+      extraFromJson,
+      extraFromCurrent,
+      changed
+    ).any { it.isNotEmpty() }
+
+    if (foundSomething) {
+      reportChanges(
+        duplicateArtifactIds = duplicateArtifactIds,
+        duplicatePomNames = duplicateDescriptions,
+        missing = extraFromJson,
+        extraFromCurrent = extraFromCurrent,
+        changed = changed
+      )
+    }
+  }
+
+  private fun <R : Comparable<R>> List<ArtifactConfig>.findDuplicates(
+    selector: ArtifactConfig.() -> R
+  ): Map<R, List<ArtifactConfig>> = groupBy(selector)
+    .filter { it.value.size > 1 }
+
+  private fun reportChanges(
+    duplicateArtifactIds: Map<String, List<ArtifactConfig>>,
+    duplicatePomNames: Map<String, List<ArtifactConfig>>,
+    missing: List<ArtifactConfig>,
+    extraFromCurrent: List<ArtifactConfig>,
+    changed: List<Pair<ArtifactConfig, ArtifactConfig>>
+  ) {
+
+    val message = buildString {
+
+      appendLine(
+        "\tArtifact definitions don't match.  If this is intended, " +
+          "run `./gradlew artifactsDump` and commit changes."
+      )
+      appendLine()
+
+      maybeAddDuplicateValueMessages(duplicateArtifactIds, "artifact id")
+      maybeAddDuplicateValueMessages(duplicatePomNames, "pom name")
+
+      maybeAddMissingArtifactMessages(missing)
+
+      maybeAddExtraArtifactMessages(extraFromCurrent)
+
+      maybeAddChangedValueMessages(changed)
+    }
+
+    logger.error(message.colorized(YELLOW))
+
+    throw GradleException("Artifacts check failed")
+  }
+
+  private fun StringBuilder.maybeAddDuplicateValueMessages(
+    duplicates: Map<String, List<ArtifactConfig>>,
+    propertyName: String
+  ) = apply {
+
+    if (duplicates.isNotEmpty()) {
+      appendLine("\tDuplicate properties were found where they should be unique:")
+      appendLine()
+      duplicates.forEach { (value, artifacts) ->
+        appendLine("\t\t       projects - ${artifacts.map { it.gradlePath }}")
+        appendLine("\t\t       property - $propertyName")
+        appendLine("\t\tduplicate value - $value")
+        appendLine()
+      }
+    }
+  }
+
+  private fun StringBuilder.maybeAddMissingArtifactMessages(
+    missing: List<ArtifactConfig>
+  ) = apply {
+
+    if (missing.isNotEmpty()) {
+      val isAre = if (missing.size == 1) "is" else "are"
+      appendLine(
+        "\t${pluralsString(missing.size)} defined in `artifacts.json` but " +
+          "$isAre duplicates from the project:"
+      )
+      appendLine()
+      missing.forEach {
+        appendLine(it.message())
+        appendLine()
+      }
+    }
+  }
+
+  private fun StringBuilder.maybeAddExtraArtifactMessages(
+    extraFromCurrent: List<ArtifactConfig>
+  ) = apply {
+
+    if (extraFromCurrent.isNotEmpty()) {
+      appendLine("\t${pluralsString(extraFromCurrent.size)} new:\n")
+      extraFromCurrent.forEach {
+        appendLine(it.message())
+        appendLine()
+      }
+    }
+  }
+
+  private fun StringBuilder.maybeAddChangedValueMessages(
+    changed: List<Pair<ArtifactConfig, ArtifactConfig>>
+  ): StringBuilder = apply {
+
+    fun appendDiff(
+      propertyName: String,
+      old: String,
+      new: String
+    ) {
+      appendLine("\t\t\told $propertyName - $old")
+      appendLine("\t\t\tnew $propertyName - $new")
+    }
+
+    if (changed.isNotEmpty()) {
+      appendLine("\t${pluralsString(changed.size)} changed:")
+      changed.forEach { (old, new) ->
+
+        appendLine()
+        appendLine("\t    ${old.gradlePath} -")
+
+        if (old.group != new.group) {
+          appendDiff("group", old.group, new.group)
+        }
+
+        if (old.artifactId != new.artifactId) {
+          appendDiff("artifact id", old.artifactId, new.artifactId)
+        }
+
+        if (old.description != new.description) {
+          appendDiff("pom name", old.description, new.description)
+        }
+
+        if (old.packaging != new.packaging) {
+          appendDiff("packaging", old.packaging, new.packaging)
+        }
+      }
+      appendLine()
+    }
+  }
+
+  private fun pluralsString(size: Int): String {
+    return if (size == 1) "This artifact is"
+    else "These artifacts are"
+  }
+
+  private fun ArtifactConfig.message(): String {
+    return """
+            |                gradlePath  - $gradlePath
+            |                group       - $group
+            |                artifactId  - $artifactId
+            |                pom name    - $description
+            |                packaging   - $packaging
+    """.trimMargin()
+  }
+
+  enum class Color(val escape: String) {
+    RESET("\u001B[0m"),
+    YELLOW("\u001B[33m")
+  }
+
+  private val supported = "win" !in System.getProperty("os.name").toLowerCase(Locale.ROOT)
+  private fun String.colorized(color: Color) = if (supported) {
+    "${color.escape}$this${RESET.escape}"
+  } else {
+    this
+  }
+}

--- a/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/artifacts/ArtifactsDumpTask.kt
+++ b/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/artifacts/ArtifactsDumpTask.kt
@@ -1,0 +1,27 @@
+package com.squareup.workflow1.buildsrc.artifacts
+
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
+
+/**
+ * Evaluates all published artifacts in the project and writes the results to `/artifacts.json`
+ */
+open class ArtifactsDumpTask @Inject constructor(
+  projectLayout: ProjectLayout
+) : ArtifactsTask(projectLayout) {
+
+  init {
+    description = "Parses the Maven artifact parameters for all modules " +
+      "and writes them to artifacts.json"
+    group = "other"
+  }
+
+  @TaskAction
+  fun run() {
+
+    val json = moshiAdapter.indent("  ").toJson(currentList)
+
+    reportFile.asFile.writeText(json)
+  }
+}

--- a/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/artifacts/ArtifactsTask.kt
+++ b/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/artifacts/ArtifactsTask.kt
@@ -1,0 +1,94 @@
+package com.squareup.workflow1.buildsrc.artifacts
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RegularFile
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.kotlin.dsl.getByType
+
+abstract class ArtifactsTask(
+  private val projectLayout: ProjectLayout
+) : DefaultTask() {
+
+  /**
+   * This file contains all definitions for published artifacts.
+   *
+   * It's located at the root of the project, assuming that the task is run from the root project.
+   */
+  @get:OutputFile
+  protected val reportFile: RegularFile by lazy {
+    projectLayout.projectDirectory.file("artifacts.json")
+  }
+
+  /**
+   * All artifacts as they are defined in the project right now.
+   *
+   * This is a lazy delegate because it's accessing [project], and Gradle's configuration caching
+   * doesn't allow direct references to `project` in task properties or inside task actions.
+   * Somehow, it doesn't complain about this even though it's definitely accessed at runtime.
+   */
+  @get:Internal
+  protected val currentList by lazy { project.createArtifactList() }
+
+  @get:Internal
+  protected val moshiAdapter: JsonAdapter<List<ArtifactConfig>> by lazy {
+
+    val type = Types.newParameterizedType(
+      List::class.java,
+      ArtifactConfig::class.java
+    )
+
+    Moshi.Builder()
+      .build()
+      .adapter(type)
+  }
+
+  private fun Project.createArtifactList(): List<ArtifactConfig> {
+
+    val map = subprojects
+      .mapNotNull { sub ->
+
+        val group = sub.properties["GROUP"] as? String
+        val artifactId = sub.properties["POM_ARTIFACT_ID"] as? String
+        val pomName = sub.properties["POM_NAME"] as? String
+        val packaging = sub.properties["POM_PACKAGING"] as? String
+
+        listOfNotNull(group, artifactId, pomName, packaging)
+          .also { allProperties ->
+
+            require(allProperties.size == 1 || allProperties.size == 4) {
+              "expected all properties to be null or none to be null for project `${sub.path}, " +
+                "but got:\n" +
+                "group : $group\n" +
+                "artifactId : $artifactId\n" +
+                "pom name : $pomName\n" +
+                "packaging : $packaging"
+            }
+          }
+          .takeIf { it.size == 4 }
+          ?.let { (group, artifactId, pomName, packaging) ->
+
+            val javaVersion = sub.extensions.getByType(JavaPluginExtension::class)
+              .sourceCompatibility
+              .toString()
+
+            ArtifactConfig(
+              gradlePath = sub.path,
+              group = group,
+              artifactId = artifactId,
+              description = pomName,
+              packaging = packaging,
+              javaVersion = javaVersion
+            )
+          }
+      }
+
+    return map
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,6 +88,8 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 
+google-ksp = { id = "com.google.devtools.ksp", version.ref = "google-ksp"}
+
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlinx-apiBinaryCompatibility = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binary-compatibility" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }


### PR DESCRIPTION
Have you ever copy/pasted a module in order to create a new one, but forgot to update the artifact ID in `gradle.properties`? 🖐️ 

Have you ever published from a new machine, then realized (too late) that the library now targets a different JDK level? 🖐️ 

Have you ever migrated from one publishing plugin/script to another without any way to be sure the same artifacts are going to the same places?

This plugin is similar to [Kotlinx binary compatibility plugin](https://github.com/Kotlin/binary-compatibility-validator), except it records the particulars of each Maven artifact instead of the api surface.  This is done at the root project level, so that it can look at everything at once in order to find duplicate artifact IDs or descriptions.

The **`artifactsDump`** task is just like `apiDump`.  It should be re-run any time there's an intentional change.  Its output is `artifacts.json` in the project root, which is added to git.

The **`artifactsCheck`** task is similar to `apiCheck`.  It parses the current state of things and compares that to the canonical `artifacts.json`.  The task fails if there are any changes, with an output something like this:
```
> Task :artifactsCheck FAILED
   Artifact definitions don't match.  If this is intended, run `./gradlew artifactsDump` and commit changes.

        This artifact is changed:

            :trace-encoder -
                        old packaging - aar
                        new packaging - jar
```

`artifactsCheck` is hooked into the basic `check` task by convention.  We don't use `check` in CI, but if we did it would automatically include this new task.  

`artifactsCheck` will also automatically run before `publish` or `publishToMavenLocal`.

Finally, I'm adding this _before_ replacing the existing [publishing groovy script](https://github.com/square/workflow-kotlin/blob/9f6a2d2705fa4c22626a4e74141a329901109a2b/.buildscript/configure-maven-publish.gradle) with a convention plugin.  The new plugin may use the new [Base plugin](https://github.com/vanniktech/gradle-maven-publish-plugin#base-plugin) which eliminates the need for a `gradle.properties` in each module.  This `artifacts-check` plugin will ensure that we don't suddenly start shipping compose-ui with the testing-utils artifact ID.