### PR TITLE
Allow repeatOnLifecycle state to be configurable.

### DIFF
--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloBindingActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloBindingActivity.kt
@@ -36,7 +36,11 @@ class HelloBindingActivity : AppCompatActivity() {
     val model: HelloBindingModel by viewModels()
     setContentView(
       WorkflowLayout(this).apply {
-        start(lifecycle, model.renderings, viewEnvironment)
+        start(
+          lifecycle = lifecycle,
+          renderings = model.renderings,
+          environment = viewEnvironment
+        )
       }
     )
   }

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsActivity.kt
@@ -38,7 +38,11 @@ class NestedRenderingsActivity : AppCompatActivity() {
     val model: NestedRenderingsModel by viewModels()
     setContentView(
       WorkflowLayout(this).apply {
-        start(lifecycle, model.renderings, viewEnvironment)
+        start(
+          lifecycle = lifecycle,
+          renderings = model.renderings,
+          environment = viewEnvironment
+        )
       }
     )
   }

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -231,11 +231,11 @@ public abstract interface class com/squareup/workflow1/ui/ViewStarter {
 public final class com/squareup/workflow1/ui/WorkflowLayout : android/widget/FrameLayout {
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun start (Landroidx/lifecycle/Lifecycle;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
+	public final fun start (Landroidx/lifecycle/Lifecycle;Lkotlinx/coroutines/flow/Flow;Landroidx/lifecycle/Lifecycle$State;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
 	public final fun start (Landroidx/lifecycle/Lifecycle;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewRegistry;)V
 	public final fun start (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
 	public final fun start (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewRegistry;)V
-	public static synthetic fun start$default (Lcom/squareup/workflow1/ui/WorkflowLayout;Landroidx/lifecycle/Lifecycle;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewEnvironment;ILjava/lang/Object;)V
+	public static synthetic fun start$default (Lcom/squareup/workflow1/ui/WorkflowLayout;Landroidx/lifecycle/Lifecycle;Lkotlinx/coroutines/flow/Flow;Landroidx/lifecycle/Lifecycle$State;Lcom/squareup/workflow1/ui/ViewEnvironment;ILjava/lang/Object;)V
 	public static synthetic fun start$default (Lcom/squareup/workflow1/ui/WorkflowLayout;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewEnvironment;ILjava/lang/Object;)V
 	public final fun update (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
@@ -73,15 +73,18 @@ public class WorkflowLayout(
    *
    * @param [lifecycle] the lifecycle that defines when and how this view should be updated.
    * Typically this comes from `ComponentActivity.lifecycle` or  `Fragment.lifecycle`.
+   * @param [repeatOnLifecycle] the lifecycle state in which renderings should be actively
+   * updated. Defaults to STARTED, which is appropriate for Activity and Fragment.
    */
   public fun start(
     lifecycle: Lifecycle,
     renderings: Flow<Any>,
+    repeatOnLifecycle: Lifecycle.State = Lifecycle.State.STARTED,
     environment: ViewEnvironment = ViewEnvironment()
   ) {
     // Just like https://medium.com/androiddevelopers/a-safer-way-to-collect-flows-from-android-uis-23080b1f8bda
     lifecycle.coroutineScope.launch {
-      lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+      lifecycle.repeatOnLifecycle(repeatOnLifecycle) {
         renderings.collect { update(it, environment) }
       }
     }
@@ -96,7 +99,11 @@ public class WorkflowLayout(
     renderings: Flow<Any>,
     registry: ViewRegistry
   ) {
-    start(lifecycle, renderings, ViewEnvironment(mapOf(ViewRegistry to registry)))
+    start(
+      lifecycle = lifecycle,
+      renderings = renderings,
+      environment = ViewEnvironment(mapOf(ViewRegistry to registry))
+    )
   }
 
   @Deprecated(


### PR DESCRIPTION
While most workflow use cases is likely to be inside an Activity and can specify renderings
to be updated while in the Lifecycle.State.STARTED state, there are certain use cases
where we want the workflow to depend on the application's lifecycle (using ProcessLifecycleOwner.)
which will not work when calling repeatOnLifecycle with Lifecycle.State.STARTED as this state event
is tied to Activities.