### PR TITLE
Fixes rapid BackStackContainer.update calls.

### DIFF
--- a/samples/containers/android/src/androidTest/java/com/squareup/sample/container/overviewdetail/BackStackContainerTest.kt
+++ b/samples/containers/android/src/androidTest/java/com/squareup/sample/container/overviewdetail/BackStackContainerTest.kt
@@ -1,0 +1,102 @@
+package com.squareup.sample.container.overviewdetail
+
+import android.content.Context
+import android.view.View
+import androidx.activity.ComponentActivity
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import com.google.common.truth.Truth.assertThat
+import com.squareup.workflow1.ui.AndroidViewRendering
+import com.squareup.workflow1.ui.BuilderViewFactory
+import com.squareup.workflow1.ui.Compatible
+import com.squareup.workflow1.ui.Named
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewFactory
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.backstack.BackStackContainer
+import com.squareup.workflow1.ui.backstack.BackStackScreen
+import com.squareup.workflow1.ui.bindShowRendering
+import com.squareup.workflow1.ui.getRendering
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(WorkflowUiExperimentalApi::class)
+internal class BackStackContainerTest {
+  @get:Rule val scenarioRule = ActivityScenarioRule(ComponentActivity::class.java)
+  private val scenario get() = scenarioRule.scenario
+
+  private data class Rendering(val name: String) : Compatible, AndroidViewRendering<Rendering> {
+    override val compatibilityKey = name
+    override val viewFactory: ViewFactory<Rendering>
+      get() = BuilderViewFactory(Rendering::class) { r, e, ctx, _ ->
+        View(ctx).also { it.bindShowRendering(r, e) { _, _ -> /* Noop */ } }
+      }
+  }
+
+  @Test fun firstScreenIsRendered() {
+    scenario.onActivity { activity ->
+      val c = VisibleBackStackContainer(activity)
+
+      c.show(BackStackScreen(Rendering("able")))
+      val showing = c.visibleRendering as Rendering
+      assertThat(showing).isEqualTo(Rendering("able"))
+    }
+  }
+
+  @Test fun secondScreenIsRendered() {
+    scenario.onActivity { activity ->
+      val c = VisibleBackStackContainer(activity)
+
+      c.show(BackStackScreen(Rendering("able")))
+      c.show(BackStackScreen(Rendering("baker")))
+      val showing = c.visibleRendering as Rendering
+      assertThat(showing).isEqualTo(Rendering("baker"))
+    }
+  }
+
+  @Test fun thirdScreenIsRendered() {
+    scenario.onActivity { activity ->
+      val c = VisibleBackStackContainer(activity)
+
+      c.show(BackStackScreen(Rendering("able")))
+      c.show(BackStackScreen(Rendering("baker")))
+      c.show(BackStackScreen(Rendering("charlie")))
+      val showing = c.visibleRendering as Rendering
+      assertThat(showing).isEqualTo(Rendering("charlie"))
+
+      // This used to fail because of our naive use of TransitionManager. The
+      // transition from baker view to charlie view was dropped because the
+      // transition from able view to baker view was still in progress.
+    }
+  }
+
+  @Test fun isDebounced() {
+    scenario.onActivity { activity ->
+      val c = VisibleBackStackContainer(activity)
+
+      c.show(BackStackScreen(Rendering("able")))
+      c.show(BackStackScreen(Rendering("able")))
+      c.show(BackStackScreen(Rendering("able")))
+      c.show(BackStackScreen(Rendering("able")))
+
+      assertThat(c.transitionCount).isEqualTo(1)
+    }
+  }
+
+  private class VisibleBackStackContainer(context: Context) : BackStackContainer(context) {
+    var transitionCount = 0
+    val visibleRendering: Any? get() = getChildAt(0)?.getRendering<Named<*>>()?.wrapped
+
+    fun show(rendering: BackStackScreen<*>) {
+      update(rendering, ViewEnvironment())
+    }
+
+    override fun performTransition(
+      oldViewMaybe: View?,
+      newView: View,
+      popped: Boolean
+    ) {
+      transitionCount++
+      super.performTransition(oldViewMaybe, newView, popped)
+    }
+  }
+}

--- a/samples/containers/android/src/androidTest/java/com/squareup/sample/container/overviewdetail/OverviewDetailContainerTest.kt
+++ b/samples/containers/android/src/androidTest/java/com/squareup/sample/container/overviewdetail/OverviewDetailContainerTest.kt
@@ -4,18 +4,15 @@ import android.view.View
 import android.widget.FrameLayout
 import androidx.activity.ComponentActivity
 import androidx.test.ext.junit.rules.ActivityScenarioRule
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
 import com.squareup.sample.container.R
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.WorkflowViewStub
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import kotlin.test.assertFailsWith
 
 @OptIn(WorkflowUiExperimentalApi::class)
-@RunWith(AndroidJUnit4::class)
 internal class OverviewDetailContainerTest {
   @get:Rule val scenarioRule = ActivityScenarioRule(ComponentActivity::class.java)
   private val scenario get() = scenarioRule.scenario

--- a/workflow-ui/container-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/BackStackContainerPersistenceTest.kt
+++ b/workflow-ui/container-android/src/androidTest/java/com/squareup/workflow1/ui/backstack/test/BackStackContainerPersistenceTest.kt
@@ -13,6 +13,7 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.backstack.test.fixtures.BackStackContainerLifecycleActivity
 import com.squareup.workflow1.ui.backstack.test.fixtures.BackStackContainerLifecycleActivity.TestRendering.LeafRendering
 import com.squareup.workflow1.ui.backstack.test.fixtures.BackStackContainerLifecycleActivity.TestRendering.RecurseRendering
+import com.squareup.workflow1.ui.backstack.test.fixtures.NoTransitionBackStackContainer
 import com.squareup.workflow1.ui.backstack.test.fixtures.ViewStateTestView
 import com.squareup.workflow1.ui.backstack.test.fixtures.viewForScreen
 import com.squareup.workflow1.ui.backstack.test.fixtures.waitForScreen
@@ -22,8 +23,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 
+/**
+ * Uses a custom subclass, [NoTransitionBackStackContainer], to ensure transitions
+ * are synchronus.
+ */
 @OptIn(WorkflowUiExperimentalApi::class)
-internal class BackstackContainerTest {
+internal class BackStackContainerPersistenceTest {
 
   private val scenarioRule =
     ActivityScenarioRule(BackStackContainerLifecycleActivity::class.java)

--- a/workflow-ui/container-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
+++ b/workflow-ui/container-android/src/main/java/com/squareup/workflow1/ui/backstack/BackStackContainer.kt
@@ -134,6 +134,7 @@ public open class BackStackContainer @JvmOverloads constructor(
           .addTransition(Slide(inEdge).addTarget(newTarget))
           .setInterpolator(AccelerateDecelerateInterpolator())
 
+        TransitionManager.endTransitions(this)
         TransitionManager.go(Scene(this, newView), transition)
         return
       }


### PR DESCRIPTION
Turns out that `TransitionManager.go()` is a no-op if there is already a transition in progress, so a new screen shown before the previous one was done animating would never be displayed. Even better, a redundant call to display that last screen again would cause a crash in `WorkflowSavedStateRegistryAggregator`, when we would try to register the name already logged for the lost view.