### PR TITLE
LegacyComposeViewTreeIntegrationTest is more purely legacy.

### DIFF
--- a/workflow-ui/internal-testing-android/api/internal-testing-android.api
+++ b/workflow-ui/internal-testing-android/api/internal-testing-android.api
@@ -77,6 +77,21 @@ public final class com/squareup/workflow1/ui/internal/test/IdlingDispatcherRule 
 	public static final field INSTANCE Lcom/squareup/workflow1/ui/internal/test/IdlingDispatcherRule;
 }
 
+public class com/squareup/workflow1/ui/internal/test/LegacyWorkflowUiTestActivity : androidx/appcompat/app/AppCompatActivity {
+	public field viewEnvironment Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public fun <init> ()V
+	public final fun getCustomNonConfigurationData ()Ljava/util/Map;
+	public final fun getRestoreRenderingAfterConfigChange ()Z
+	public final fun getRootRenderedView ()Landroid/view/View;
+	public final fun getViewEnvironment ()Lcom/squareup/workflow1/ui/ViewEnvironment;
+	protected fun onCreate (Landroid/os/Bundle;)V
+	public final fun onRetainCustomNonConfigurationInstance ()Ljava/lang/Object;
+	public final fun recreateViewsOnNextRendering ()V
+	public final fun setRendering (Ljava/lang/Object;)Landroid/view/View;
+	public final fun setRestoreRenderingAfterConfigChange (Z)V
+	public final fun setViewEnvironment (Lcom/squareup/workflow1/ui/ViewEnvironment;)V
+}
+
 public class com/squareup/workflow1/ui/internal/test/WorkflowUiTestActivity : androidx/appcompat/app/AppCompatActivity {
 	public field viewEnvironment Lcom/squareup/workflow1/ui/ViewEnvironment;
 	public fun <init> ()V

--- a/workflow-ui/internal-testing-android/src/main/AndroidManifest.xml
+++ b/workflow-ui/internal-testing-android/src/main/AndroidManifest.xml
@@ -1,8 +1,14 @@
-<manifest package="com.squareup.workflow1.ui.internal.test"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.squareup.workflow1.ui.internal.test">
+
   <application>
     <activity
         android:name=".WorkflowUiTestActivity"
-        android:theme="@style/Theme.AppCompat.NoActionBar"/>
+        android:theme="@style/Theme.AppCompat.NoActionBar"
+        />
+    <activity
+        android:name=".LegacyWorkflowUiTestActivity"
+        android:theme="@style/Theme.AppCompat.NoActionBar"
+        />
   </application>
 </manifest>

--- a/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/LegacyWorkflowUiTestActivity.kt
+++ b/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/LegacyWorkflowUiTestActivity.kt
@@ -1,0 +1,114 @@
+@file:Suppress("DEPRECATION")
+
+package com.squareup.workflow1.ui.internal.test
+
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import com.squareup.workflow1.ui.Named
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.WorkflowViewStub
+
+/**
+ * Helper for testing workflow-ui code in UI tests.
+ *
+ * The content view of the activity is a [WorkflowViewStub], which you can control by calling
+ * [setRendering].
+ *
+ * Typical usage:
+ * 1. Create an `ActivityScenarioRule` or `AndroidComposeRule` and pass this activity type.
+ * 2. In your `@Before` method, set the [viewEnvironment].
+ * 3. In your tests, call [setRendering] to update the stub.
+ *
+ * You can also test configuration changes by calling `ActivityScenarioRule.recreate()`. By default,
+ * the [viewEnvironment] and last rendering will be restored when the view is re-created. You can
+ * also retain your own data by mutating [customNonConfigurationData]. If you don't want the
+ * rendering to be automatically restored, set [restoreRenderingAfterConfigChange] to false before
+ * calling `recreate()`.
+ */
+@WorkflowUiExperimentalApi
+public open class LegacyWorkflowUiTestActivity : AppCompatActivity() {
+
+  private val rootStub by lazy { WorkflowViewStub(this) }
+  private var renderingCounter = 0
+  private lateinit var lastRendering: Any
+
+  /**
+   * The [ViewEnvironment] used to create views for renderings passed to [setRendering].
+   * This *must* be set before the first call to [setRendering].
+   * Once set, the value is retained across configuration changes.
+   */
+  public lateinit var viewEnvironment: ViewEnvironment
+
+  /**
+   * The [View] that was created to display the last rendering passed to [setRendering].
+   */
+  public val rootRenderedView: View get() = rootStub.actual
+
+  /**
+   * Key-value store for custom values that should be retained across configuration changes.
+   * Use this instead of using [getLastNonConfigurationInstance] or
+   * [getLastCustomNonConfigurationInstance] directly.
+   */
+  public val customNonConfigurationData: MutableMap<String, Any?> = mutableMapOf()
+
+  /**
+   * Simulates the effect of having the activity backed by a real workflow runtime – remembers the
+   * actual render instance across recreation and will immediately set it on the new container in
+   * [onCreate].
+   *
+   * True by default. If you need to change, do so before calling `recreate()`.
+   */
+  public var restoreRenderingAfterConfigChange: Boolean = true
+
+  /**
+   * Causes the next [setRendering] call to force a new view to be created, even if it otherwise wouldn't
+   * be (i.e. because the rendering is compatible with the previous one).
+   */
+  public fun recreateViewsOnNextRendering() {
+    renderingCounter++
+  }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(rootStub)
+
+    (lastCustomNonConfigurationInstance as NonConfigurationData?)?.let { data ->
+      viewEnvironment = data.viewEnvironment
+      customNonConfigurationData.apply {
+        clear()
+        putAll(data.customData)
+      }
+      // setRendering must be called last since it may consume the other values.
+      data.lastRendering?.let(::setRendering)
+    }
+  }
+
+  final override fun onRetainCustomNonConfigurationInstance(): Any = NonConfigurationData(
+    viewEnvironment = viewEnvironment,
+    lastRendering = lastRendering.takeIf { restoreRenderingAfterConfigChange },
+    customData = customNonConfigurationData,
+  )
+
+  /**
+   * Updates the [WorkflowViewStub] to a new rendering value.
+   *
+   * If [recreateViewsOnNextRendering] was previously called, the old view tree will be torn down
+   * and re-created from scratch.
+   */
+  public fun setRendering(rendering: Any): View {
+    lastRendering = rendering
+    val named = Named(
+      wrapped = rendering,
+      name = renderingCounter.toString()
+    )
+    return rootStub.update(named, viewEnvironment)
+  }
+
+  private class NonConfigurationData(
+    val viewEnvironment: ViewEnvironment,
+    val lastRendering: Any?,
+    val customData: MutableMap<String, Any?>,
+  )
+}


### PR DESCRIPTION
I had cheated a bit on this, wrapping various things so that I could avoid the deprecated methods on WorkflowViewStub. Doing so caused testing difficulties in #703 that seem purely related to the tests themselves, not a reflection of problems in real life.

So we revert the wrapping in `LegacyComposeViewTreeIntegrationTest` and give it its own `Activity` to run against, full of comfortaing deprecation warnings.