### PR TITLE
Adds missing integration tests EnvironmentScreen, NamedScreen.

### DIFF
--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/container/EnvironmentScreenAndroidIntegrationTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/container/EnvironmentScreenAndroidIntegrationTest.kt
@@ -1,0 +1,57 @@
+@file:OptIn(WorkflowUiExperimentalApi::class)
+
+package com.squareup.workflow1.ui.container
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.workflow1.ui.ViewEnvironment.Companion.EMPTY
+import com.squareup.workflow1.ui.ViewRegistry
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.buildView
+import com.squareup.workflow1.ui.environment
+import com.squareup.workflow1.ui.getRendering
+import com.squareup.workflow1.ui.plus
+import com.squareup.workflow1.ui.showRendering
+import com.squareup.workflow1.ui.start
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+internal class EnvironmentScreenAndroidIntegrationTest {
+  @Test fun mergingWorksForBuild() {
+    // By putting altFactory into the environment in envScreen,
+    // we expect it to build the view for wrappedScreen instead of the hard
+    // coded default, wrappedScreen.viewFactory
+    val altFactory = WrappedFactory()
+    val env = EMPTY + (SomeEnvValue to "hi") + ViewRegistry(altFactory)
+
+    val wrappedScreen = WrappedScreen()
+    val envScreen = wrappedScreen.withEnvironment(env)
+    val view = envScreen.buildView(EMPTY, mock())
+
+    assertThat(wrappedScreen.viewFactory.lastView).isNull()
+
+    // altFactory made the view.
+    assertThat(view).isSameInstanceAs(altFactory.lastView)
+
+    // The wrapper env reached the inner view factory.
+    assertThat(altFactory.lastEnv!![SomeEnvValue]).isEqualTo("hi")
+    // The wrapper env is on the view.
+    assertThat(view.environment!![SomeEnvValue]).isEqualTo("hi")
+    // The wrapper rendering is on the view.
+    assertThat(view.getRendering<Any>()).isEqualTo(envScreen)
+  }
+
+  @Test fun mergingWorksForUpdate() {
+    val wrappedScreen = WrappedScreen()
+    val view = wrappedScreen.withEnvironment(EMPTY + (SomeEnvValue to "hi"))
+      .buildView(EMPTY, mock())
+    assertThat(view.environment!![SomeEnvValue]).isEqualTo("hi")
+
+    view.start()
+    view.showRendering(wrappedScreen.withEnvironment(EMPTY + (SomeEnvValue to "bye")), EMPTY)
+
+    assertThat(wrappedScreen.viewFactory.lastEnv!![SomeEnvValue]).isEqualTo("bye")
+
+    // TODO To be fixed or obviated by https://github.com/square/workflow-kotlin/pull/703
+    // assertThat(view.environment!![SomeEnvValue]).isEqualTo("bye")
+  }
+}

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/container/NamedScreenAndroidIntegrationTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/container/NamedScreenAndroidIntegrationTest.kt
@@ -1,0 +1,37 @@
+@file:OptIn(WorkflowUiExperimentalApi::class)
+
+package com.squareup.workflow1.ui.container
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.workflow1.ui.NamedScreen
+import com.squareup.workflow1.ui.ViewEnvironment.Companion.EMPTY
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.buildView
+import com.squareup.workflow1.ui.getRendering
+import com.squareup.workflow1.ui.showRendering
+import com.squareup.workflow1.ui.start
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+internal class NamedScreenAndroidIntegrationTest {
+  @Test fun buildsOkay() {
+    val wrappedScreen = WrappedScreen()
+    val named = NamedScreen(wrappedScreen, "fred")
+
+    val view = named.buildView(EMPTY, mock())
+    assertThat(view).isSameInstanceAs(wrappedScreen.viewFactory.lastView)
+    assertThat(view.getRendering<Any>()).isSameInstanceAs(named)
+  }
+
+  @Test fun updatesOkay() {
+    val wrappedScreen = WrappedScreen()
+    val named = NamedScreen(wrappedScreen, "fred")
+
+    val view = named.buildView(EMPTY, mock())
+    view.start()
+
+    view.showRendering(NamedScreen(wrappedScreen, "fred"), EMPTY)
+    assertThat(view).isSameInstanceAs(view)
+    assertThat(view.getRendering<Any>()).isNotSameInstanceAs(named)
+  }
+}

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/container/ScreenViewFactoryTestUtil.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/container/ScreenViewFactoryTestUtil.kt
@@ -1,0 +1,62 @@
+@file:OptIn(WorkflowUiExperimentalApi::class)
+
+package com.squareup.workflow1.ui.container
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import com.squareup.workflow1.ui.AndroidScreen
+import com.squareup.workflow1.ui.ScreenViewFactory
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewEnvironmentKey
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.bindShowRendering
+import org.mockito.kotlin.isA
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+internal fun mockView(): View {
+  return mock<View>().also { view ->
+    val tags = mutableMapOf<Int, Any>()
+    whenever(view.getTag(isA())).thenAnswer { invocation ->
+      val id = invocation.arguments[0] as Int
+      tags[id]
+    }
+    whenever(view.setTag(isA(), isA())).thenAnswer { invocation ->
+      val id = invocation.arguments[0] as Int
+      val value = invocation.arguments[1] as Any
+      tags[id] = value
+      Unit
+    }
+  }
+}
+
+internal object SomeEnvValue : ViewEnvironmentKey<String>(String::class) {
+  override val default: String get() = error("Unset")
+}
+
+internal class WrappedScreen : AndroidScreen<WrappedScreen> {
+  override val viewFactory = WrappedFactory()
+}
+
+internal class WrappedFactory : ScreenViewFactory<WrappedScreen> {
+  override val type = WrappedScreen::class
+
+  var lastEnv: ViewEnvironment? = null
+  var lastView: View? = null
+
+  override fun buildView(
+    initialRendering: WrappedScreen,
+    initialViewEnvironment: ViewEnvironment,
+    contextForNewView: Context,
+    container: ViewGroup?
+  ): View {
+    lastEnv = initialViewEnvironment
+    return mockView().also { view ->
+      view.bindShowRendering(initialRendering, initialViewEnvironment) { _, environment ->
+        lastEnv = environment
+      }
+      lastView = view
+    }
+  }
+}


### PR DESCRIPTION
The other default `ScreenViewFactory` implementations are well covered by all the espresso tests. Really, so is `NamedScreen`, but it was so easy to write.

Note that `EnvironmentScreen` is broken, so one assertion is commented out.
