### PR TITLE
Adds EnvironmentScreenLegacyViewFactory.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.squareup.workflow1
-VERSION_NAME=1.8.0-uiUpdate01-SNAPSHOT
+VERSION_NAME=1.8.0-uiUpdate02-SNAPSHOT
 
 POM_DESCRIPTION=Square Workflow
 

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -570,6 +570,13 @@ public final class com/squareup/workflow1/ui/container/DispatchCancelEventKt {
 	public static final fun dispatchCancelEvent (Lkotlin/jvm/functions/Function1;)V
 }
 
+public final class com/squareup/workflow1/ui/container/EnvironmentScreenLegacyViewFactory : com/squareup/workflow1/ui/ViewFactory {
+	public static final field INSTANCE Lcom/squareup/workflow1/ui/container/EnvironmentScreenLegacyViewFactory;
+	public fun buildView (Lcom/squareup/workflow1/ui/container/EnvironmentScreen;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun getType ()Lkotlin/reflect/KClass;
+}
+
 public final class com/squareup/workflow1/ui/container/EnvironmentScreenViewFactoryKt {
 	public static final fun EnvironmentScreenViewFactory ()Lcom/squareup/workflow1/ui/ScreenViewFactory;
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
@@ -6,6 +6,8 @@ import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import com.squareup.workflow1.ui.container.BackStackScreen
+import com.squareup.workflow1.ui.container.EnvironmentScreen
+import com.squareup.workflow1.ui.container.EnvironmentScreenLegacyViewFactory
 import kotlin.reflect.KClass
 
 @Deprecated("Use ScreenViewFactoryFinder.getViewFactoryForRendering()")
@@ -19,6 +21,9 @@ public fun <RenderingT : Any> ViewRegistry.getFactoryForRendering(
     ?: (rendering as? AsScreen<*>)?.let { AsScreenLegacyViewFactory as ViewFactory<RenderingT> }
     ?: (rendering as? BackStackScreen<*>)?.let {
       BackStackScreenLegacyViewFactory as ViewFactory<RenderingT>
+    }
+    ?: (rendering as? EnvironmentScreen<*>)?.let {
+      EnvironmentScreenLegacyViewFactory as ViewFactory<RenderingT>
     }
     ?: (rendering as? Named<*>)?.let { NamedViewFactory as ViewFactory<RenderingT> }
     ?: throw IllegalArgumentException(

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreenLegacyViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreenLegacyViewFactory.kt
@@ -1,0 +1,18 @@
+@file:Suppress("DEPRECATION")
+
+package com.squareup.workflow1.ui.container
+
+import com.squareup.workflow1.ui.DecorativeViewFactory
+import com.squareup.workflow1.ui.ViewFactory
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.merge
+
+@Suppress("DEPRECATION")
+@WorkflowUiExperimentalApi
+internal object EnvironmentScreenLegacyViewFactory : ViewFactory<EnvironmentScreen<*>>
+by DecorativeViewFactory(
+  type = EnvironmentScreen::class,
+  map = { environmentScreen, inheritedEnvironment ->
+    Pair(environmentScreen.wrapped, environmentScreen.environment merge inheritedEnvironment)
+  }
+)


### PR DESCRIPTION
Each standard container or wrapper rendering needs both a legacy `ViewFactory` and a `ScreenViewFactory`.