### PR TITLE
Introduces ViewEnvironmentKey.combine, makes ViewRegistry use it.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.squareup.workflow1
-VERSION_NAME=1.8.0-uiUpdate03-SNAPSHOT
+VERSION_NAME=1.8.0-uiUpdate04-SNAPSHOT
 
 POM_DESCRIPTION=Square Workflow
 

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -199,7 +199,12 @@ public abstract interface class com/squareup/workflow1/ui/ScreenViewHolder {
 }
 
 public final class com/squareup/workflow1/ui/ScreenViewHolder$Companion {
-	public final fun getShowing ()Lcom/squareup/workflow1/ui/ViewEnvironmentKey;
+}
+
+public final class com/squareup/workflow1/ui/ScreenViewHolder$Companion$Showing : com/squareup/workflow1/ui/ViewEnvironmentKey {
+	public static final field INSTANCE Lcom/squareup/workflow1/ui/ScreenViewHolder$Companion$Showing;
+	public fun getDefault ()Lcom/squareup/workflow1/ui/Screen;
+	public synthetic fun getDefault ()Ljava/lang/Object;
 }
 
 public final class com/squareup/workflow1/ui/ScreenViewHolder$Companion$ShowingNothing : com/squareup/workflow1/ui/Screen {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewHolder.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewHolder.kt
@@ -44,7 +44,9 @@ public interface ScreenViewHolder<in ScreenT : Screen> {
      * Provides access to the [Screen] instance most recently shown in a [ScreenViewHolder]'s
      * [view] via [show]. Call [showing] for more convenient access.
      */
-    public val Showing: ViewEnvironmentKey<Screen> = ViewEnvironmentKey { ShowingNothing }
+    public object Showing : ViewEnvironmentKey<Screen>(Screen::class) {
+      override val default: Screen = ShowingNothing
+    }
   }
 }
 

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BackStackContainer.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BackStackContainer.kt
@@ -20,6 +20,7 @@ import com.squareup.workflow1.ui.Compatible.Companion.keyFor
 import com.squareup.workflow1.ui.NamedScreen
 import com.squareup.workflow1.ui.R
 import com.squareup.workflow1.ui.ScreenViewHolder
+import com.squareup.workflow1.ui.ScreenViewHolder.Companion.Showing
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.androidx.WorkflowAndroidXSupport.stateRegistryOwnerFromViewTreeOrContext
@@ -65,7 +66,7 @@ public open class BackStackContainer @JvmOverloads constructor(
     newRendering: BackStackScreen<*>,
     newViewEnvironment: ViewEnvironment
   ) {
-    savedStateParentKey = keyFor(newViewEnvironment[ScreenViewHolder.Showing])
+    savedStateParentKey = keyFor(newViewEnvironment[Showing])
 
     val config = if (newRendering.backStack.isEmpty()) First else Other
     val environment = newViewEnvironment + config

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BodyAndModalsContainer.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BodyAndModalsContainer.kt
@@ -17,6 +17,7 @@ import com.squareup.workflow1.ui.Compatible.Companion.keyFor
 import com.squareup.workflow1.ui.R
 import com.squareup.workflow1.ui.ScreenViewFactory
 import com.squareup.workflow1.ui.ScreenViewHolder
+import com.squareup.workflow1.ui.ScreenViewHolder.Companion.Showing
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.WorkflowViewStub
@@ -82,7 +83,7 @@ internal class BodyAndModalsContainer @JvmOverloads constructor(
     newScreen: BodyAndModalsScreen<*, *>,
     viewEnvironment: ViewEnvironment
   ) {
-    savedStateParentKey = keyFor(viewEnvironment[ScreenViewHolder.Showing])
+    savedStateParentKey = keyFor(viewEnvironment[Showing])
 
     val showingModals = newScreen.modals.isNotEmpty()
 

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreenLegacyViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreenLegacyViewFactory.kt
@@ -5,7 +5,6 @@ package com.squareup.workflow1.ui.container
 import com.squareup.workflow1.ui.DecorativeViewFactory
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.merge
 
 @Suppress("DEPRECATION")
 @WorkflowUiExperimentalApi
@@ -13,6 +12,6 @@ internal object EnvironmentScreenLegacyViewFactory : ViewFactory<EnvironmentScre
 by DecorativeViewFactory(
   type = EnvironmentScreen::class,
   map = { environmentScreen, inheritedEnvironment ->
-    Pair(environmentScreen.wrapped, environmentScreen.environment merge inheritedEnvironment)
+    Pair(environmentScreen.wrapped, environmentScreen.environment + inheritedEnvironment)
   }
 )

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreenViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreenViewFactory.kt
@@ -4,7 +4,6 @@ import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ScreenViewFactory
 import com.squareup.workflow1.ui.ScreenViewFactory.Companion.fromCode
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.merge
 import com.squareup.workflow1.ui.toUnwrappingViewFactory
 import com.squareup.workflow1.ui.toViewFactory
 
@@ -12,13 +11,13 @@ import com.squareup.workflow1.ui.toViewFactory
 internal fun <WrappedT : Screen> EnvironmentScreenViewFactory():
   ScreenViewFactory<EnvironmentScreen<WrappedT>> {
   return fromCode { initialEnvScreen, initialEnvironment, context, container ->
-    val mergedInitialEnvironment = initialEnvironment merge initialEnvScreen.environment
+    val mergedInitialEnvironment = initialEnvironment + initialEnvScreen.environment
 
     initialEnvScreen.wrapped.toViewFactory(mergedInitialEnvironment)
       .toUnwrappingViewFactory<EnvironmentScreen<WrappedT>, WrappedT>(
         unwrap = { it.wrapped },
         showWrapperScreen = { _, envScreen, environment, showUnwrapped ->
-          showUnwrapped(envScreen.wrapped, environment merge envScreen.environment)
+          showUnwrapped(envScreen.wrapped, environment + envScreen.environment)
         }
       )
       .buildView(initialEnvScreen, mergedInitialEnvironment, context, container)

--- a/workflow-ui/core-common/api/core-common.api
+++ b/workflow-ui/core-common/api/core-common.api
@@ -102,14 +102,11 @@ public final class com/squareup/workflow1/ui/ViewEnvironment$Companion {
 
 public abstract class com/squareup/workflow1/ui/ViewEnvironmentKey {
 	public fun <init> (Lkotlin/reflect/KClass;)V
+	public fun combine (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun equals (Ljava/lang/Object;)Z
 	public abstract fun getDefault ()Ljava/lang/Object;
 	public final fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/squareup/workflow1/ui/ViewEnvironmentKt {
-	public static final synthetic fun ViewEnvironmentKey (Lkotlin/jvm/functions/Function0;)Lcom/squareup/workflow1/ui/ViewEnvironmentKey;
+	public final fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/squareup/workflow1/ui/ViewRegistry {
@@ -119,6 +116,8 @@ public abstract interface class com/squareup/workflow1/ui/ViewRegistry {
 }
 
 public final class com/squareup/workflow1/ui/ViewRegistry$Companion : com/squareup/workflow1/ui/ViewEnvironmentKey {
+	public fun combine (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewRegistry;
+	public synthetic fun combine (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun getDefault ()Lcom/squareup/workflow1/ui/ViewRegistry;
 	public synthetic fun getDefault ()Ljava/lang/Object;
 }
@@ -131,8 +130,6 @@ public final class com/squareup/workflow1/ui/ViewRegistryKt {
 	public static final fun ViewRegistry ()Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun ViewRegistry ([Lcom/squareup/workflow1/ui/ViewRegistry$Entry;)Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final synthetic fun get (Lcom/squareup/workflow1/ui/ViewRegistry;Lkotlin/reflect/KClass;)Lcom/squareup/workflow1/ui/ViewRegistry$Entry;
-	public static final fun merge (Lcom/squareup/workflow1/ui/ViewEnvironment;Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/ViewEnvironment;
-	public static final fun merge (Lcom/squareup/workflow1/ui/ViewEnvironment;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewEnvironment;
 	public static final fun merge (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewRegistry;
 	public static final fun plus (Lcom/squareup/workflow1/ui/ViewEnvironment;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/ViewEnvironment;
 	public static final fun plus (Lcom/squareup/workflow1/ui/ViewRegistry;Lcom/squareup/workflow1/ui/ViewRegistry$Entry;)Lcom/squareup/workflow1/ui/ViewRegistry;

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreen.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreen.kt
@@ -5,7 +5,7 @@ import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.merge
+import com.squareup.workflow1.ui.plus
 
 /**
  * Pairs a [wrapped] rendering with a [environment] to support its display.
@@ -36,7 +36,7 @@ public class EnvironmentScreen<V : Screen>(
  */
 @WorkflowUiExperimentalApi
 public fun Screen.withRegistry(viewRegistry: ViewRegistry): EnvironmentScreen<*> {
-  return withEnvironment(ViewEnvironment.EMPTY merge viewRegistry)
+  return withEnvironment(ViewEnvironment.EMPTY + viewRegistry)
 }
 
 /**
@@ -53,7 +53,7 @@ public fun Screen.withEnvironment(
   return when (this) {
     is EnvironmentScreen<*> -> {
       if (environment.map.isEmpty()) this
-      else EnvironmentScreen(wrapped, this.environment merge environment)
+      else EnvironmentScreen(wrapped, this.environment + environment)
     }
     else -> EnvironmentScreen(this, environment)
   }

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/ViewEnvironmentTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/ViewEnvironmentTest.kt
@@ -99,4 +99,22 @@ internal class ViewEnvironmentTest {
     val environment = EMPTY + (StringHint to "able")
     assertThat(environment + environment).isSameInstanceAs(environment)
   }
+
+  @Test fun `honors combine`() {
+    val combiningHint = object : ViewEnvironmentKey<String>(String::class) {
+      override val default: String
+        get() = error("")
+
+      override fun combine(
+        left: String,
+        right: String
+      ): String {
+        return "$left-$right"
+      }
+    }
+
+    val left = EMPTY + (combiningHint to "able")
+    val right = EMPTY + (combiningHint to "baker")
+    assertThat((left + right)[combiningHint]).isEqualTo("able-baker")
+  }
 }

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/ViewRegistryTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/ViewRegistryTest.kt
@@ -60,22 +60,27 @@ internal class ViewRegistryTest {
     assertThat(merged[FooRendering::class]).isSameInstanceAs(factory2)
   }
 
-  @Test fun `merge into ViewEnvironment prefers right side`() {
-    val factory1 = TestEntry(FooRendering::class)
-    val factory2 = TestEntry(FooRendering::class)
-    val merged = (EMPTY + ViewRegistry(factory1)) merge ViewRegistry(factory2)
+  @Test fun `ViewEnvironment plus ViewRegistry prefers new registry values`() {
+    val leftBar = TestEntry(BarRendering::class)
+    val rightBar = TestEntry(BarRendering::class)
 
-    assertThat(merged[ViewRegistry][FooRendering::class]).isSameInstanceAs(factory2)
+    val env = EMPTY + ViewRegistry(leftBar)
+    val merged = env + ViewRegistry(rightBar, TestEntry(FooRendering::class))
+
+    assertThat(merged[ViewRegistry][BarRendering::class]).isSameInstanceAs(rightBar)
+    assertThat(merged[ViewRegistry][FooRendering::class]).isNotNull()
   }
 
-  @Test fun `merge of ViewEnvironments prefers right side`() {
-    val factory1 = TestEntry(FooRendering::class)
-    val factory2 = TestEntry(FooRendering::class)
-    val e1 = EMPTY + ViewRegistry(factory1)
-    val e2 = EMPTY + ViewRegistry(factory2)
-    val merged = e1 + e2
+  @Test fun `ViewEnvironment plus ViewEnvironment prefers right ViewRegistry`() {
+    val leftBar = TestEntry(BarRendering::class)
+    val rightBar = TestEntry(BarRendering::class)
 
-    assertThat(merged[ViewRegistry][FooRendering::class]).isSameInstanceAs(factory2)
+    val leftEnv = EMPTY + ViewRegistry(leftBar)
+    val rightEnv = EMPTY + ViewRegistry(rightBar, TestEntry(FooRendering::class))
+    val merged = leftEnv + rightEnv
+
+    assertThat(merged[ViewRegistry][BarRendering::class]).isSameInstanceAs(rightBar)
+    assertThat(merged[ViewRegistry][FooRendering::class]).isNotNull()
   }
 
   @Test fun `plus of empty returns this`() {
@@ -96,21 +101,6 @@ internal class ViewRegistryTest {
   @Test fun `merge to empty reg returns other`() {
     val reg = ViewRegistry(TestEntry(FooRendering::class))
     assertThat(ViewRegistry() merge reg).isSameInstanceAs(reg)
-  }
-
-  @Test fun `env merge of empty reg returns this env`() {
-    val env = EMPTY + ViewRegistry(TestEntry(FooRendering::class))
-    assertThat(env merge ViewRegistry()).isSameInstanceAs(env)
-  }
-
-  @Test fun `env merge of empty env returns other env`() {
-    val env = EMPTY + ViewRegistry(TestEntry(FooRendering::class))
-    assertThat(env merge EMPTY).isSameInstanceAs(env)
-  }
-
-  @Test fun `env merge to empty env returns other env`() {
-    val env = EMPTY + ViewRegistry(TestEntry(FooRendering::class))
-    assertThat(EMPTY merge env).isSameInstanceAs(env)
   }
 
   @Test fun `env plus empty reg returns env`() {
@@ -134,17 +124,6 @@ internal class ViewRegistryTest {
   @Test fun `registry merge self returns self`() {
     val reg = ViewRegistry(TestEntry(FooRendering::class))
     assertThat(reg merge reg).isSameInstanceAs(reg)
-  }
-
-  @Test fun `env merges same reg returns self`() {
-    val reg = ViewRegistry(TestEntry(FooRendering::class))
-    val env = EMPTY + reg
-    assertThat(env merge reg).isSameInstanceAs(env)
-  }
-
-  @Test fun `env merges self reg returns self`() {
-    val env = EMPTY + ViewRegistry(TestEntry(FooRendering::class))
-    assertThat(env merge env).isSameInstanceAs(env)
   }
 
   private class TestEntry<T : Any>(


### PR DESCRIPTION
`ViewEnvironmentKey.combine` is called from `ViewEnvironment.plus` when both operands have keys of the same type. `ViewRegistry.Companion` is already a `ViewEnvironmentKey`, and now it implements `combine`, calling `ViewRegistry.merge`.

This changes `ViewEnvironment.plus` to merge the values of `ViewRegistry` entries instead of replacing the registry on the left with the one on the right, which is the only thing we've ever actually wanted to do. This allows us to eliminate `ViewEnvironment.merge`.

We have never seen a use case for completely stomping the `ViewRegistry` on the left, but have done it by accident a lot. If the need really does arise, we can add a `ViewEnvironment.minus` operator.

Also eliminates the `ViewEnvironmentKey()` factory function, which was just silly.