### PR TITLE
`View.environmentOrNull`, `View.screenOrNull`.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.squareup.workflow1
-VERSION_NAME=1.8.0-uiUpdate04-SNAPSHOT
+VERSION_NAME=1.8.0-uiUpdate05-SNAPSHOT
 
 POM_DESCRIPTION=Square Workflow
 

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -276,7 +276,9 @@ public final class com/squareup/workflow1/ui/ViewShowRenderingKt {
 	public static final fun bindShowRendering (Landroid/view/View;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)V
 	public static final fun canShowRendering (Landroid/view/View;Ljava/lang/Object;)Z
 	public static final fun getEnvironment (Landroid/view/View;)Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public static final fun getEnvironmentOrNull (Landroid/view/View;)Lcom/squareup/workflow1/ui/ViewEnvironment;
 	public static final synthetic fun getRendering (Landroid/view/View;)Ljava/lang/Object;
+	public static final fun getScreenOrNull (Landroid/view/View;)Lcom/squareup/workflow1/ui/Screen;
 	public static final fun getShowRendering (Landroid/view/View;)Lkotlin/jvm/functions/Function2;
 	public static final fun getStarter (Landroid/view/View;)Lkotlin/jvm/functions/Function1;
 	public static final fun getStarterOrNull (Landroid/view/View;)Lkotlin/jvm/functions/Function1;

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/RealScreenViewHolder.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/RealScreenViewHolder.kt
@@ -15,6 +15,7 @@ internal class RealScreenViewHolder<ScreenT : Screen>(
   override val runner: ScreenViewRunner<ScreenT> =
     ScreenViewRunner { newScreen, newEnvironment ->
       _environment = newEnvironment
+      view.setTag(R.id.workflow_environment, newEnvironment)
       viewRunner.showRendering(newScreen, newEnvironment)
     }
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
@@ -1,6 +1,7 @@
 package com.squareup.workflow1.ui
 
 import android.view.View
+import com.squareup.workflow1.ui.ScreenViewHolder.Companion.Showing
 import com.squareup.workflow1.ui.WorkflowViewState.New
 import com.squareup.workflow1.ui.WorkflowViewState.Started
 
@@ -59,7 +60,7 @@ public fun <RenderingT : Any> View.bindShowRendering(
  * - It is an error to call [View.showRendering] without having called this method first.
  */
 @WorkflowUiExperimentalApi
-@Deprecated("Use ScreenViewFactory.start to create a ScreenViewHolder")
+@Deprecated("Use ScreenViewFactory.startShowing to create a ScreenViewHolder")
 public fun View.start() {
   val current = workflowViewStateAsNew
   workflowViewState = Started(current.showing, current.environment, current.showRendering)
@@ -118,7 +119,10 @@ public fun <RenderingT : Any> View.showRendering(
  * @throws ClassCastException if the current rendering is not of type [RenderingT]
  */
 @WorkflowUiExperimentalApi
-@Deprecated("Replaced by ViewEnvironment[Screen]")
+@Deprecated(
+  "Replaced by View.screenOrNull",
+  ReplaceWith("screenOrNull", "com.squareup.workflow1.ui.screenOrNull")
+)
 public inline fun <reified RenderingT : Any> View.getRendering(): RenderingT? {
   // Can't use a val because of the parameter type.
   return when (val showing = workflowViewStateOrNull?.showing) {
@@ -128,13 +132,33 @@ public inline fun <reified RenderingT : Any> View.getRendering(): RenderingT? {
 }
 
 /**
+ * Returns the most recent [Screen] rendering [shown][ScreenViewHolder.show] in this view,
+ * or `null` if the receiver was not created via [ScreenViewFactory.startShowing].
+ */
+@WorkflowUiExperimentalApi
+public val View.screenOrNull: Screen?
+  get() = environmentOrNull?.get(Showing)
+
+/**
  * Returns the most recent [ViewEnvironment] applied to this view, or null if [bindShowRendering]
  * has never been called.
  */
 @WorkflowUiExperimentalApi
-@Deprecated("Replaced by ScreenViewHolder.environment")
+@Deprecated(
+  "Replaced by View.environmentOrNull",
+  ReplaceWith("environmentOrNull", "com.squareup.workflow1.ui.environmentOrNull")
+)
 public val View.environment: ViewEnvironment?
+  get() = environmentOrNull
+
+/**
+ * Returns the most recent [ViewEnvironment] applied to this view, or null if [bindShowRendering]
+ * has never been called.
+ */
+@WorkflowUiExperimentalApi
+public val View.environmentOrNull: ViewEnvironment?
   get() = workflowViewStateOrNull?.environment
+    ?: getTag(R.id.workflow_environment) as? ViewEnvironment
 
 /**
  * Returns the function set by the most recent call to [bindShowRendering], or null

--- a/workflow-ui/core-android/src/main/res/values/ids.xml
+++ b/workflow-ui/core-android/src/main/res/values/ids.xml
@@ -25,6 +25,6 @@
   <item name="workflow_layout" type="id"/>
   <!-- View Tag used by ModalScreenOverlayDialogFactory to find the content ScreenViewHolder. -->
   <item name="workflow_modal_dialog_content" type="id"/>
-  <!-- View Tag used for ScreenViewRunner. -->
-  <item name="workflow_view_runner" type="id"/>
+  <!-- View Tag for the ViewEnvironment that last updated this view. -->
+  <item name="workflow_environment" type="id"/>
 </resources>

--- a/workflow-ui/radiography/src/main/java/com/squareup/workflow1/ui/radiography/WorkflowViewRenderer.kt
+++ b/workflow-ui/radiography/src/main/java/com/squareup/workflow1/ui/radiography/WorkflowViewRenderer.kt
@@ -7,6 +7,7 @@ import com.squareup.workflow1.ui.Named
 import com.squareup.workflow1.ui.NamedScreen
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.getRendering
+import com.squareup.workflow1.ui.screenOrNull
 import radiography.AttributeAppendable
 import radiography.ScannableView
 import radiography.ScannableView.AndroidView
@@ -14,8 +15,8 @@ import radiography.ViewStateRenderer
 import radiography.ViewStateRenderers
 
 /**
- * Renders information about views that were created by view factories, i.e. views with associated
- * rendering tags.
+ * Renders information about views that were created by workflow-ui, i.e. views
+ * that return non-null values from [getRendering] or [screenOrNull].
  */
 @Suppress("unused")
 public val ViewStateRenderers.WorkflowViewRenderer: ViewStateRenderer
@@ -26,7 +27,7 @@ private object WorkflowViewRendererImpl : ViewStateRenderer {
 
   override fun AttributeAppendable.render(view: ScannableView) {
     val androidView = (view as? AndroidView)?.view ?: return
-    val rendering = androidView.getRendering<Any>() ?: return
+    val rendering = androidView.getRendering<Any>() ?: androidView.screenOrNull ?: return
     renderRendering(rendering)
   }
 


### PR DESCRIPTION
I'd like to bring back the ability to peek at a View and see if/how workflow-ui created it, even though we no longer need that ability at runtime. I don't see how we can preserve our Radiography support without it, and it's also handy for espresso testing (#741).
