### PR TITLE
Defers most deprecation and restores deleted kdoc

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.squareup.workflow1
-VERSION_NAME=1.8.0-uiUpdate05-SNAPSHOT
+VERSION_NAME=1.8.0-uiUpdate06-SNAPSHOT
 
 POM_DESCRIPTION=Square Workflow
 

--- a/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/backstack/BackStackScreen.kt
+++ b/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/backstack/BackStackScreen.kt
@@ -1,4 +1,4 @@
-@file:Suppress("DEPRECATION")
+// @file:Suppress("DEPRECATION")
 
 package com.squareup.workflow1.ui.backstack
 
@@ -7,8 +7,26 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.asScreen
 import com.squareup.workflow1.ui.container.BackStackScreen as NewBackStackScreen
 
+/**
+ * **This will be deprecated in favor of
+ * [com.squareup.workflow1.ui.container.BackStackScreen] very soon.**
+ *
+ * Represents an active screen ([top]), and a set of previously visited screens to which we may
+ * return ([backStack]). By rendering the entire history we allow the UI to do things like maintain
+ * cached view state, implement drag-back gestures without waiting for the workflow, etc.
+ *
+ * Effectively a list that can never be empty.
+ *
+ * If multiple [BackStackScreen]s are used as sibling renderings within the same parent navigation
+ * container (either the root activity or another [BackStackScreen]), then the siblings must be
+ * distinguished by wrapping them in [Named][com.squareup.workflow1.ui.Named] renderings in order to
+ * correctly support AndroidX `SavedStateRegistry`.
+ *
+ * @param bottom the bottom-most entry in the stack
+ * @param rest the rest of the stack, empty by default
+ */
 @WorkflowUiExperimentalApi
-@Deprecated("Use com.squareup.workflow1.ui.container.BackStackScreen")
+// @Deprecated("Use com.squareup.workflow1.ui.container.BackStackScreen")
 public class BackStackScreen<StackedT : Any>(
   bottom: StackedT,
   rest: List<StackedT>

--- a/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/modal/AlertContainerScreen.kt
+++ b/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/modal/AlertContainerScreen.kt
@@ -1,22 +1,27 @@
-@file:Suppress("DEPRECATION")
+// @file:Suppress("DEPRECATION")
 
 package com.squareup.workflow1.ui.modal
 
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
 /**
+ * **This will be deprecated in favor of
+ * [AlertOverlay][com.squareup.workflow1.ui.container.AlertOverlay] and
+ * [BodyAndModalsScreen][com.squareup.workflow1.ui.container.BodyAndModalsScreen]
+ * very soon.**
+ *
  * May show a stack of [AlertScreen] over a [beneathModals].
  *
  * @param B the type of [beneathModals]
  */
 @WorkflowUiExperimentalApi
-@Deprecated(
-  "Use BodyAndModalsScreen and AlertOverlay",
-  ReplaceWith(
-    "BodyAndModalsScreen<B>(beneathModals, modals)",
-    "com.squareup.workflow1.ui.container.BodyAndModalsScreen"
-  )
-)
+// @Deprecated(
+//   "Use BodyAndModalsScreen and AlertOverlay",
+//   ReplaceWith(
+//     "BodyAndModalsScreen<B>(beneathModals, modals)",
+//     "com.squareup.workflow1.ui.container.BodyAndModalsScreen"
+//   )
+// )
 public data class AlertContainerScreen<B : Any>(
   override val beneathModals: B,
   override val modals: List<AlertScreen> = emptyList()

--- a/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/modal/AlertScreen.kt
+++ b/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/modal/AlertScreen.kt
@@ -1,20 +1,23 @@
-@file:Suppress("DEPRECATION")
+// @file:Suppress("DEPRECATION")
 
 package com.squareup.workflow1.ui.modal
 
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
 /**
+ * **This will be deprecated in favor of
+ * [AlertOverlay][com.squareup.workflow1.ui.container.AlertOverlay] very soon.**
+ *
  * Models a typical "You sure about that?" alert box.
  */
 @WorkflowUiExperimentalApi
-@Deprecated(
-  "Use AlertOverlay",
-  ReplaceWith(
-    "AlertOverlay(buttons, message, title, cancelable, onEvent)",
-    "com.squareup.workflow1.ui.container.AlertOverlay"
-  )
-)
+// @Deprecated(
+//   "Use AlertOverlay",
+//   ReplaceWith(
+//     "AlertOverlay(buttons, message, title, cancelable, onEvent)",
+//     "com.squareup.workflow1.ui.container.AlertOverlay"
+//   )
+// )
 public data class AlertScreen(
   val buttons: Map<Button, String> = emptyMap(),
   val message: String = "",

--- a/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/modal/HasModals.kt
+++ b/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/modal/HasModals.kt
@@ -3,6 +3,10 @@ package com.squareup.workflow1.ui.modal
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
 /**
+ * **This will be deprecated in favor of
+ * [BodyAndModalsScreen][com.squareup.workflow1.ui.container.BodyAndModalsScreen]
+ * very soon.**
+ *
  * Interface implemented by screen classes that represent a stack of
  * zero or more [modal][M] screens above a [base screen][beneathModals].
  *
@@ -10,7 +14,7 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
  * like `ModalContainer` in the `workflow-ui:core-android` module.
  */
 @WorkflowUiExperimentalApi
-@Deprecated("Use BodyAndModalsScreen")
+// @Deprecated("Use BodyAndModalsScreen")
 public interface HasModals<out B : Any, out M : Any> {
   public val beneathModals: B
   public val modals: List<M>

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
@@ -1,4 +1,4 @@
-@file:Suppress("DEPRECATION")
+// @file:Suppress("DEPRECATION")
 
 package com.squareup.workflow1.ui
 
@@ -10,7 +10,25 @@ import com.squareup.workflow1.ui.container.EnvironmentScreen
 import com.squareup.workflow1.ui.container.EnvironmentScreenLegacyViewFactory
 import kotlin.reflect.KClass
 
-@Deprecated("Use ScreenViewFactoryFinder.getViewFactoryForRendering()")
+/**
+ * **This will be deprecated in favor of
+ * [ScreenViewFactoryFinder.getViewFactoryForRendering]
+ * very soon.**
+ *
+ * It is usually more convenient to use [WorkflowViewStub] or [DecorativeViewFactory]
+ * than to call this method directly.
+ *
+ * Returns the [ViewFactory] that builds [View] instances suitable to display the given [rendering],
+ * via subsequent calls to [View.showRendering].
+ *
+ * Prefers factories found via [ViewRegistry.getFactoryFor]. If that returns null, falls
+ * back to the factory provided by the rendering's implementation of
+ * [AndroidViewRendering.viewFactory], if there is one. Note that this means that a
+ * compile time [AndroidViewRendering.viewFactory] binding can be overridden at runtime.
+ *
+ * @throws IllegalArgumentException if no factory can be find for type [RenderingT]
+ */
+// @Deprecated("Use ScreenViewFactoryFinder.getViewFactoryForRendering()")
 @WorkflowUiExperimentalApi
 public fun <RenderingT : Any> ViewRegistry.getFactoryForRendering(
   rendering: RenderingT
@@ -32,10 +50,18 @@ public fun <RenderingT : Any> ViewRegistry.getFactoryForRendering(
     )
 }
 
-@Deprecated(
-  "Use getEntryFor()",
-  ReplaceWith("getEntryFor(renderingType)")
-)
+/**
+ * **This will be deprecated in favor of [ViewRegistry.getEntryFor] very soon.**
+ *
+ * This method is not for general use, use [WorkflowViewStub] instead.
+ *
+ * Returns the [ViewFactory] that was registered for the given [renderingType], or null
+ * if none was found.
+ */
+// @Deprecated(
+//   "Use getEntryFor()",
+//   ReplaceWith("getEntryFor(renderingType)")
+// )
 @WorkflowUiExperimentalApi
 public fun <RenderingT : Any> ViewRegistry.getFactoryFor(
   renderingType: KClass<out RenderingT>
@@ -43,7 +69,27 @@ public fun <RenderingT : Any> ViewRegistry.getFactoryFor(
   return getEntryFor(renderingType) as? ViewFactory<RenderingT>
 }
 
-@Deprecated("Use ScreenViewFactory.startShowing")
+/**
+ * **This will be deprecated in favor of [ScreenViewFactory.startShowing] very soon.**
+ *
+ * It is usually more convenient to use [WorkflowViewStub] or [DecorativeViewFactory]
+ * than to call this method directly.
+ *
+ * Finds a [ViewFactory] to create a [View] ready to display [initialRendering]. The caller
+ * is responsible for calling [View.start] on the new [View]. After that,
+ * [View.showRendering] can be used to update it with new renderings that
+ * are [compatible] with [initialRendering].
+ *
+ * @param viewStarter An optional wrapper for the function invoked when [View.start]
+ * is called, allowing for last second initialization of a newly built [View].
+ * See [ViewStarter] for details.
+ *
+ * @throws IllegalArgumentException if no factory can be found for type [RenderingT]
+ *
+ * @throws IllegalStateException if the matching [ViewFactory] fails to call
+ * [View.bindShowRendering] when constructing the view
+ */
+// @Deprecated("Use ScreenViewFactory.startShowing")
 @WorkflowUiExperimentalApi
 public fun <RenderingT : Any> ViewRegistry.buildView(
   initialRendering: RenderingT,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRendering.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRendering.kt
@@ -1,7 +1,36 @@
 package com.squareup.workflow1.ui
 
-@Suppress("DEPRECATION")
-@Deprecated("Use AndroidScreen")
+/**
+ * **This will be deprecated in favor of [AndroidScreen] very soon.**
+ *
+ * Interface implemented by a rendering class to allow it to drive an Android UI
+ * via an appropriate [ViewFactory] implementation.
+ *
+ * You will rarely, if ever, write a [ViewFactory] yourself.  Instead
+ * use [LayoutRunner.bind] to work with XML layout resources, or
+ * [BuilderViewFactory] to create views from code.  See [LayoutRunner] for more
+ * details.
+ *
+ *     @OptIn(WorkflowUiExperimentalApi::class)
+ *     data class HelloView(
+ *       val message: String,
+ *       val onClick: () -> Unit
+ *     ) : AndroidViewRendering<HelloView> {
+ *       override val viewFactory: ViewFactory<HelloView> =
+ *         LayoutRunner.bind(HelloGoodbyeLayoutBinding::inflate) { r, _ ->
+ *           helloMessage.text = r.message
+ *           helloMessage.setOnClickListener { r.onClick() }
+ *         }
+ *     }
+ *
+ * This is the simplest way to bridge the gap between your workflows and the UI,
+ * but using it requires your workflows code to reside in Android modules, instead
+ * of pure Kotlin. If this is a problem, or you need more flexibility for any other
+ * reason, you can use [ViewRegistry] to bind your renderings to [ViewFactory]
+ * implementations at runtime.
+ */
+// @Suppress("DEPRECATION")
+// @Deprecated("Use AndroidScreen")
 @WorkflowUiExperimentalApi
 public interface AndroidViewRendering<V : AndroidViewRendering<V>> {
   /**

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BackButtonScreen.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BackButtonScreen.kt
@@ -1,11 +1,29 @@
 package com.squareup.workflow1.ui
 
-@Suppress("DEPRECATION")
+/**
+ * **This will be deprecated in favor of
+ * [com.squareup.workflow1.ui.container.BackButtonScreen] very soon.**
+ *
+ * Adds optional back button handling to a [wrapped] rendering, possibly overriding that
+ * the wrapped rendering's own back button handler.
+ *
+ * @param shadow If `true`, [onBackPressed] is set as the
+ * [backPressedHandler][android.view.View.backPressedHandler] after
+ * the [wrapped] rendering's view is built / updated, effectively overriding it.
+ * If false (the default), [onBackPressed] is set afterward, to allow the wrapped rendering to
+ * take precedence if it sets a `backPressedHandler` of its own -- the handler provided
+ * here serves as a default.
+ *
+ * @param onBackPressed The function to fire when the device back button
+ * is pressed, or null to set no handler -- or clear a handler that was set previously.
+ * Defaults to `null`.
+ */
+// @Suppress("DEPRECATION")
 @WorkflowUiExperimentalApi
-@Deprecated(
-  "Use com.squareup.workflow1.ui.container.BackButtonScreen",
-  ReplaceWith("BackButtonScreen", "com.squareup.workflow1.ui.container.BackButtonScreen")
-)
+// @Deprecated(
+//   "Use com.squareup.workflow1.ui.container.BackButtonScreen",
+//   ReplaceWith("BackButtonScreen", "com.squareup.workflow1.ui.container.BackButtonScreen")
+// )
 public class BackButtonScreen<W : Any>(
   public val wrapped: W,
   public val shadow: Boolean = false,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BuilderViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BuilderViewFactory.kt
@@ -5,8 +5,29 @@ import android.view.View
 import android.view.ViewGroup
 import kotlin.reflect.KClass
 
-@Suppress("DEPRECATION")
-@Deprecated("Use ScreenViewFactory.forBuiltView")
+/**
+ * **This will be deprecated in favor of [ScreenViewFactory.fromCode] very soon.**
+ *
+ * A [ViewFactory] that creates [View]s that need to be generated from code.
+ * (Use [LayoutRunner] to work with XML layout resources.)
+ *
+ *    data class MyView(): AndroidViewRendering<MyView> {
+ *      val viewFactory = BuilderViewFactory(
+ *          type = MyScreen::class,
+ *          viewConstructor = { initialRendering, _, context, _ ->
+ *            MyFrame(context).apply {
+ *              layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+ *              bindShowRendering(initialRendering, ::update)
+ *            }
+ *      )
+ *    }
+ *
+ *    private class MyFrame(context: Context) : FrameLayout(context, attributeSet) {
+ *      private fun update(rendering:  MyView) { ... }
+ *    }
+ */
+// @Suppress("DEPRECATION")
+// @Deprecated("Use ScreenViewFactory.fromCode")
 @WorkflowUiExperimentalApi
 public class BuilderViewFactory<RenderingT : Any>(
   override val type: KClass<RenderingT>,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/DecorativeViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/DecorativeViewFactory.kt
@@ -5,8 +5,113 @@ import android.view.View
 import android.view.ViewGroup
 import kotlin.reflect.KClass
 
-@Suppress("DEPRECATION")
-@Deprecated("Use ScreenViewFactory.unwrapping")
+/**
+ * **This will be deprecated in favor of [ScreenViewFactory.toUnwrappingViewFactory] very soon.**
+ *
+ * A [ViewFactory] for [OuterT] that delegates view construction responsibilities
+ * to the factory registered for [InnerT]. Makes it convenient for [OuterT] to wrap
+ * instances of [InnerT] to add information or behavior, without requiring wasteful wrapping
+ * in the view system.
+ *
+ * One general note: when creating a wrapper rendering, you're very likely to want it
+ * to implement [Compatible], to ensure that checks made to update or replace a view
+ * are based on the wrapped item. Each example below illustrates this.
+ *
+ * ## Examples
+ *
+ * To make one rendering type an "alias" for another -- that is, to use the same [ViewFactory]
+ * to display it -- provide nothing but a single-arg mapping function:
+ *
+ *    class OriginalRendering(val data: String) : AndroidViewRendering<OriginalRendering> {...}
+ *    class AliasRendering(val similarData: String)
+ *
+ *    object DecorativeViewFactory : ViewFactory<AliasRendering>
+ *    by DecorativeViewFactory(
+ *      type = AliasRendering::class, map = { alias -> OriginalRendering(alias.similarData) }
+ *    )
+ *
+ * To make a decorator type that adds information to the [ViewEnvironment]:
+ *
+ *    class NeutronFlowPolarity(val reversed: Boolean) {
+ *      companion object : ViewEnvironmentKey<NeutronFlowPolarity>(NeutronFlowPolarity::class) {
+ *        override val default: NeutronFlowPolarity = NeutronFlowPolarity(reversed = false)
+ *      }
+ *    }
+ *
+ *    class NeutronFlowPolarityOverride<W>(
+ *      val wrapped: W,
+ *      val polarity: NeutronFlowPolarity
+ *    ) : Compatible {
+ *      override val compatibilityKey: String = Compatible.keyFor(wrapped)
+ *    }
+ *
+ *    object NeutronFlowPolarityViewFactory : ViewFactory<NeutronFlowPolarityOverride<*>>
+ *    by DecorativeViewFactory(
+ *        type = NeutronFlowPolarityOverride::class,
+ *        map = { override, env ->
+ *          Pair(override.wrapped, env + (NeutronFlowPolarity to override.polarity))
+ *        }
+ *    )
+ *
+ * To make a decorator type that customizes [View] initialization:
+ *
+ *    class WithTutorialTips<W>(val wrapped: W) : Compatible {
+ *      override val compatibilityKey: String = Compatible.keyFor(wrapped)
+ *    }
+ *
+ *    object WithTutorialTipsViewFactory : ViewFactory<WithTutorialTips<*>>
+ *    by DecorativeViewFactory(
+ *        type = WithTutorialTips::class,
+ *        map = { withTips -> withTips.wrapped },
+ *        viewStarter = { view, doStart ->
+ *          TutorialTipRunner.run(view)
+ *          doStart()
+ *        }
+ *    )
+ *
+ * To make a decorator type that adds pre- or post-processing to [View] updates:
+ *
+ *    class BackButtonScreen<W : Any>(
+ *       val wrapped: W,
+ *       val override: Boolean = false,
+ *       val onBackPressed: (() -> Unit)? = null
+ *    ) : Compatible {
+ *      override val compatibilityKey: String = Compatible.keyFor(wrapped)
+ *    }
+ *
+ *    object BackButtonViewFactory : ViewFactory<BackButtonScreen<*>>
+ *    by DecorativeViewFactory(
+ *        type = BackButtonScreen::class,
+ *        map = { outer -> outer.wrapped },
+ *        doShowRendering = { view, innerShowRendering, outerRendering, viewEnvironment ->
+ *          if (!outerRendering.override) {
+ *            // Place our handler before invoking innerShowRendering, so that
+ *            // its later calls to view.backPressedHandler will take precedence
+ *            // over ours.
+ *            view.backPressedHandler = outerRendering.onBackPressed
+ *          }
+ *
+ *          innerShowRendering.invoke(outerRendering.wrapped, viewEnvironment)
+ *
+ *          if (outerRendering.override) {
+ *            // Place our handler after invoking innerShowRendering, so that ours wins.
+ *            view.backPressedHandler = outerRendering.onBackPressed
+ *          }
+ *        })
+ *
+ * @param map called to convert instances of [OuterT] to [InnerT], and to
+ * allow [ViewEnvironment] to be transformed.
+ *
+ * @param viewStarter An optional wrapper for the function invoked when [View.start]
+ * is called, allowing for last second initialization of a newly built [View].
+ * See [ViewStarter] for details.
+ *
+ * @param doShowRendering called to apply the [ViewShowRendering] function for
+ * [InnerT], allowing pre- and post-processing. Default implementation simply
+ * uses [map] to extract the [InnerT] instance from [OuterT] and makes the function call.
+ */
+// @Suppress("DEPRECATION")
+// @Deprecated("Use ScreenViewFactory.toUnwrappingViewFactory")
 @WorkflowUiExperimentalApi
 public class DecorativeViewFactory<OuterT : Any, InnerT : Any>(
   override val type: KClass<OuterT>,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunner.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunner.kt
@@ -1,12 +1,23 @@
+// @file:Suppress("DEPRECATION")
 package com.squareup.workflow1.ui
 
 import android.view.View
 import androidx.annotation.LayoutRes
 import androidx.viewbinding.ViewBinding
 
-@Suppress("DEPRECATION")
-@Deprecated("Use ScreenViewRunner")
+/**
+ * **This will be deprecated in favor of [ScreenViewRunner] very soon.**
+ *
+ * A delegate that implements a [showRendering] method to be called when a workflow rendering
+ * of type [RenderingT] is ready to be displayed in a view inflated from a layout resource
+ * by a [ViewRegistry]. (Use [BuilderViewFactory] if you want to build views from code rather
+ * than layouts.)
+ *
+ * If you're using [AndroidX ViewBinding][ViewBinding] you likely won't need to
+ * implement this interface at all. For details, see the three overloads of [LayoutRunner.bind].
+ */
 @WorkflowUiExperimentalApi
+// @Deprecated("Use ScreenViewRunner")
 public fun interface LayoutRunner<RenderingT : Any> {
   public fun showRendering(
     rendering: RenderingT,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewFactory.kt
@@ -4,7 +4,23 @@ import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 
-@Deprecated("Use ScreenViewFactory")
+/**
+ * **This will be deprecated in favor of [ScreenViewFactory] very soon.**
+ *
+ * Factory for [View] instances that can show renderings of type[RenderingT].
+ *
+ * Two concrete [ViewFactory] implementations are provided:
+ *
+ *  - The various [bind][LayoutRunner.bind] methods on [LayoutRunner] allow easy use of
+ *    Android XML layout resources and [AndroidX ViewBinding][androidx.viewbinding.ViewBinding].
+ *
+ *  - [BuilderViewFactory] allows views to be built from code.
+ *
+ * It's simplest to have your rendering classes implement [AndroidViewRendering] to associate
+ * them with appropriate an appropriate [ViewFactory]. For more flexibility, and to
+ * avoid coupling your workflow directly to the Android runtime, see [ViewRegistry].
+ */
+// @Deprecated("Use ScreenViewFactory")
 @WorkflowUiExperimentalApi
 public interface ViewFactory<in RenderingT : Any> : ViewRegistry.Entry<RenderingT> {
   /**

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
@@ -16,6 +16,8 @@ public typealias ViewShowRendering<RenderingT> =
 // declare variance on a typealias. If I recall correctly.
 
 /**
+ * **This will be deprecated in favor of [ScreenViewHolder] very soon.**
+ *
  * For use by implementations of [ViewFactory.buildView]. Establishes [showRendering]
  * as the implementation of [View.showRendering] for the receiver, possibly replacing
  * the existing one.
@@ -30,7 +32,7 @@ public typealias ViewShowRendering<RenderingT> =
  * @see DecorativeViewFactory
  */
 @WorkflowUiExperimentalApi
-@Deprecated("Replaced by ScreenViewHolder")
+// @Deprecated("Replaced by ScreenViewHolder")
 public fun <RenderingT : Any> View.bindShowRendering(
   initialRendering: RenderingT,
   initialViewEnvironment: ViewEnvironment,
@@ -51,6 +53,8 @@ public fun <RenderingT : Any> View.bindShowRendering(
 }
 
 /**
+ * **This will be deprecated in favor of [ScreenViewFactory.startShowing] very soon.**
+ *
  * Note that [WorkflowViewStub] calls this method for you.
  *
  * Makes the initial call to [View.showRendering], along with any wrappers that have been
@@ -60,7 +64,7 @@ public fun <RenderingT : Any> View.bindShowRendering(
  * - It is an error to call [View.showRendering] without having called this method first.
  */
 @WorkflowUiExperimentalApi
-@Deprecated("Use ScreenViewFactory.startShowing to create a ScreenViewHolder")
+// @Deprecated("Use ScreenViewFactory.startShowing to create a ScreenViewHolder")
 public fun View.start() {
   val current = workflowViewStateAsNew
   workflowViewState = Started(current.showing, current.environment, current.showRendering)
@@ -68,6 +72,8 @@ public fun View.start() {
 }
 
 /**
+ * **This will be deprecated in favor of [ScreenViewHolder.canShow] very soon.**
+ *
  * Note that [WorkflowViewStub.showRendering] makes this check for you.
  *
  * True if this view is able to show [rendering].
@@ -77,13 +83,15 @@ public fun View.start() {
  * [View.getRendering] and the new one.
  */
 @WorkflowUiExperimentalApi
-@Deprecated("Replaced by ScreenViewHolder.canShow")
+// @Deprecated("Replaced by ScreenViewHolder.canShow")
 public fun View.canShowRendering(rendering: Any): Boolean {
   @Suppress("DEPRECATION")
   return getRendering<Any>()?.let { compatible(it, rendering) } == true
 }
 
 /**
+ * **This will be deprecated in favor of [ScreenViewHolder.show] very soon.**
+ *
  * It is usually more convenient to call [WorkflowViewStub.showRendering]
  * than to call this method directly.
  *
@@ -93,7 +101,7 @@ public fun View.canShowRendering(rendering: Any): Boolean {
  * @throws IllegalStateException if [bindShowRendering] has not been called.
  */
 @WorkflowUiExperimentalApi
-@Deprecated("Replaced by ScreenViewHolder.show")
+// @Deprecated("Replaced by ScreenViewHolder.show")
 public fun <RenderingT : Any> View.showRendering(
   rendering: RenderingT,
   viewEnvironment: ViewEnvironment
@@ -113,16 +121,18 @@ public fun <RenderingT : Any> View.showRendering(
 }
 
 /**
+ * **This will be deprecated in favor of [screenOrNull] very soon.**
+ *
  * Returns the most recent rendering shown by this view cast to [RenderingT],
  * or null if [bindShowRendering] has never been called.
  *
  * @throws ClassCastException if the current rendering is not of type [RenderingT]
  */
 @WorkflowUiExperimentalApi
-@Deprecated(
-  "Replaced by View.screenOrNull",
-  ReplaceWith("screenOrNull", "com.squareup.workflow1.ui.screenOrNull")
-)
+// @Deprecated(
+//   "Replaced by View.screenOrNull",
+//   ReplaceWith("screenOrNull", "com.squareup.workflow1.ui.screenOrNull")
+// )
 public inline fun <reified RenderingT : Any> View.getRendering(): RenderingT? {
   // Can't use a val because of the parameter type.
   return when (val showing = workflowViewStateOrNull?.showing) {
@@ -140,6 +150,8 @@ public val View.screenOrNull: Screen?
   get() = environmentOrNull?.get(Showing)
 
 /**
+ * **This will be deprecated in favor of [environmentOrNull] very soon.**
+ *
  * Returns the most recent [ViewEnvironment] applied to this view, or null if [bindShowRendering]
  * has never been called.
  */
@@ -161,11 +173,13 @@ public val View.environmentOrNull: ViewEnvironment?
     ?: getTag(R.id.workflow_environment) as? ViewEnvironment
 
 /**
+ * **This will be deprecated in favor of [ScreenViewHolder] very soon.**
+ *
  * Returns the function set by the most recent call to [bindShowRendering], or null
  * if that method has never been called.
  */
 @WorkflowUiExperimentalApi
-@Deprecated("Replaced by ScreenViewHolder")
+// @Deprecated("Replaced by ScreenViewHolder")
 public fun <RenderingT : Any> View.getShowRendering(): ViewShowRendering<RenderingT>? {
   return workflowViewStateOrNull?.showRendering
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
@@ -171,7 +171,13 @@ public class WorkflowViewStub @JvmOverloads constructor(
     }
   }
 
-  @Deprecated("Use show()", ReplaceWith("show(rendering, viewEnvironment)"))
+  @Deprecated(
+    "Use show()",
+    ReplaceWith(
+      "show(asScreen(rendering), viewEnvironment)",
+      "com.squareup.workflow1.ui.asScreen"
+    ),
+  )
   public fun update(
     rendering: Any,
     viewEnvironment: ViewEnvironment

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/AsScreen.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/AsScreen.kt
@@ -1,12 +1,9 @@
-@file:Suppress("DEPRECATION")
-
 package com.squareup.workflow1.ui
 
 /**
- * Provides backward compatibility for legacy non-[Screen] renderings based on
- * `ViewFactory` and `AndroidViewRendering`, now deprecated. Should be used only
- * as a stop gap until the wrapped [rendering] can be updated to implement [Screen],
- * since the deprecated interfaces will soon be deleted.
+ * Provides backward compatibility for legacy non-[Screen] renderings.
+ * This is a migration tool for code bases that are still adopting the `Screen` and
+ * `Overlay` interfaces, and will be deprecated and deleted sooner or later.
  */
 @WorkflowUiExperimentalApi
 public class AsScreen<W : Any>(
@@ -24,9 +21,10 @@ public class AsScreen<W : Any>(
 
 /**
  * Ensures [rendering] implements [Screen], wrapping it in an [AsScreen] if necessary.
+ *
+ * This is a migration tool for code bases that are still adopting the `Screen` and
+ * `Overlay` interfaces, and will be deprecated and deleted sooner or later.
  */
-@Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("Implement Screen directly.")
 @WorkflowUiExperimentalApi
 public fun asScreen(rendering: Any): Screen {
   return when (rendering) {

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Named.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Named.kt
@@ -1,12 +1,14 @@
 package com.squareup.workflow1.ui
 
 /**
+ * **This will be deprecated in favor of [NamedScreen] very soon.**
+ *
  * Allows renderings that do not implement [Compatible] themselves to be distinguished
  * by more than just their type. Instances are [compatible] if they have the same name
  * and have [compatible] [wrapped] fields.
  */
 @WorkflowUiExperimentalApi
-@Deprecated("Use NamedScreen")
+// @Deprecated("Use NamedScreen")
 public data class Named<W : Any>(
   val wrapped: W,
   val name: String


### PR DESCRIPTION
I think we should hold off on deprecating the old API for the first few pre-release drops, to give established code bases (like Square's) a chance to catch up before being flooded with warnings. Note that I've commented out the `@Deprecation` and `@Suppress` lines rather than deleting them, so that they'll be easier to bring back.

We keep the deprecations on `WorkflowLayout` and `WorkflowViewStub`, though, because they're so easy to honor.