### PR TITLE
replace use of `SendChannel.offer` with `SendChannel.trySend`

### DIFF
--- a/workflow-runtime/src/main/java/com/squareup/workflow1/internal/RealRenderContext.kt
+++ b/workflow-runtime/src/main/java/com/squareup/workflow1/internal/RealRenderContext.kt
@@ -48,7 +48,7 @@ internal class RealRenderContext<out PropsT, StateT, OutputT>(
         "Expected sink to not be sent to until after the render pass. Received action: $value"
       )
     }
-    eventActionsChannel.offer(value)
+    eventActionsChannel.trySend(value)
   }
 
   override fun <ChildPropsT, ChildOutputT, ChildRenderingT> renderChild(


### PR DESCRIPTION
This is necessary for compatibility with coroutines 1.6.x, where `offer` has a hard deprecation.