### PR TITLE
Support late/lazy configuration creation in dependency guard

### DIFF
--- a/buildSrc/src/main/java/dependency-guard.gradle.kts
+++ b/buildSrc/src/main/java/dependency-guard.gradle.kts
@@ -1,31 +1,38 @@
 import com.android.build.gradle.TestedExtension
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPluginExtension
 
-val configurationNames = when {
-  // record the root project's *build* classpath
-  project == rootProject -> listOf("classpath")
-  // Android variants and their configurations are added later in the configuration phase,
-  // so we can't look them up now using the `configurations` property.
-  // Instead we can just hard-code "releaseRuntimeClasspath" for any module which has AGP applied.
-  // This is actually pretty robust, since if this configuration ever changes,
-  // dependency-guard will fail when trying to look it up.
-  extensions.findByType<TestedExtension>() != null -> listOf("releaseRuntimeClasspath")
-  // If we got here, we're either in an empty "parent" module without a build plugin
-  // (and no configurations), or we're in a vanilla Kotlin module.  In this case, we can just look
-  // at configuration names.
-  else -> configurations
-    .map { it.name }
-    // anything ending with 'runtimeClasspath' but not 'testRuntimeClasspath'
-    .filter { it.matches("^(?!test)\\w*[rR]untimeClasspath$".toRegex()) }
-}
+// We have to use `afterEvaluate { ... }` because both KMP and AGP create their configurations later
+// in the configuration phase.  If we were to try looking up those configurations eagerly as soon
+// as this convention plugin is applied, there would be nothing there.
+afterEvaluate {
+  val configurationNames = when {
+    // record the root project's *build* classpath
+    project == rootProject -> listOf("classpath")
 
-if (configurationNames.isNotEmpty()) {
-  apply(plugin = "com.dropbox.dependency-guard")
+    // For Android modules, just hard-code `releaseRuntimeClasspath` for the release variant.
+    // This is actually pretty robust, since if this configuration ever changes, dependency-guard
+    // will fail when trying to look it up.
+    extensions.findByType<TestedExtension>() != null -> listOf("releaseRuntimeClasspath")
 
-  configure<DependencyGuardPluginExtension> {
-    configurationNames.forEach { configName ->
-      // Tell dependency-guard to check the `configName` configuration's dependencies.
-      configuration(configName)
+    // If we got here, we're either in an empty "parent" module without a build plugin
+    // (and no configurations), or we're in a vanilla Kotlin module.  In this case, we can just look
+    // at configuration names.
+    else -> configurations
+      .map { it.name }
+      .filter {
+        it.endsWith("runtimeClasspath", ignoreCase = true) &&
+          !it.endsWith("testRuntimeClasspath", ignoreCase = true)
+      }
+  }
+
+  if (configurationNames.isNotEmpty()) {
+    apply(plugin = "com.dropbox.dependency-guard")
+
+    configure<DependencyGuardPluginExtension> {
+      configurationNames.forEach { configName ->
+        // Tell dependency-guard to check the `configName` configuration's dependencies.
+        configuration(configName)
+      }
     }
   }
 }


### PR DESCRIPTION
Wraps dependency guard configuration in `afterEvaluate { }`.  This ensures that configurations have been created before we look through the list for runtime classpaths.

Without this change, KMP modules get no dependency reports since they have no configurations when the convention plugin is applied.