### PR TITLE
Update Kotlin Check task for Core/Runtime KMP

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -78,7 +78,7 @@ jobs :
           gradle-dependencies-cache-key : |
             gradle/libs.versions.toml
           arguments : |
-            test apiCheck artifactsCheck dependencyGuard lint ktlintCheck jvmWorkflowNodeBenchmarkJar --no-daemon --stacktrace --continue
+            test apiCheck artifactsCheck dependencyGuard lint ktlintCheck jvmWorkflowNodeBenchmarkJar :workflow-runtime:jvmTest :workflow-core:jvmTest --no-daemon --stacktrace --continue
           concurrent : true
           gradle-build-scan-report : false
           gradle-distribution-sha-256-sum-warning : false


### PR DESCRIPTION
This is a maintenance burden until we find a longer term solution.

Also note we will need to use a different Github Action runner for the ios tests.