### PR TITLE
ComposeViewTreeIntegrationTest clean up, fixes

### DIFF
--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -45,7 +45,6 @@ import com.squareup.workflow1.ui.internal.test.IdlingDispatcherRule
 import com.squareup.workflow1.ui.internal.test.WorkflowUiTestActivity
 import com.squareup.workflow1.ui.plus
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -606,11 +605,14 @@ internal class ComposeViewTreeIntegrationTest {
     }
   }
 
-  companion object {
-    // Use a ComposeView here because the Compose test infra doesn't like it if there are no
-    // Compose views at all. See https://issuetracker.google.com/issues/179455327.
-    val EmptyRendering: Screen = TestComposeRendering(compatibilityKey = "") {}
+  object EmptyRendering : AndroidScreen<EmptyRendering> {
+    override val viewFactory: ScreenViewFactory<EmptyRendering>
+      get() = ScreenViewFactory.fromCode { _, e, c, _ ->
+        ScreenViewHolder(e, View(c)) { _, _, -> }
+      }
+  }
 
+  companion object {
     const val CounterTag = "counter"
     const val CounterTag2 = "counter2"
     const val CounterTag3 = "counter3"

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -37,7 +37,6 @@ import com.squareup.workflow1.ui.container.AndroidOverlay
 import com.squareup.workflow1.ui.container.BackStackScreen
 import com.squareup.workflow1.ui.container.BodyAndModalsScreen
 import com.squareup.workflow1.ui.container.ModalScreenOverlayDialogFactory
-import com.squareup.workflow1.ui.container.Overlay
 import com.squareup.workflow1.ui.container.ScreenOverlay
 import com.squareup.workflow1.ui.internal.test.DetectLeaksAfterTestSuccess
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
@@ -372,7 +371,9 @@ internal class ComposeViewTreeIntegrationTest {
     // Show first screen to initialize state.
     scenario.onActivity {
       it.setRendering(
-        BodyAndModalsScreen<Screen, Overlay>(BackStackScreen(EmptyRendering, firstScreen))
+        BodyAndModalsScreen(
+          EmptyRendering, TestModal(BackStackScreen(EmptyRendering, firstScreen))
+        )
       )
     }
 
@@ -608,7 +609,7 @@ internal class ComposeViewTreeIntegrationTest {
   object EmptyRendering : AndroidScreen<EmptyRendering> {
     override val viewFactory: ScreenViewFactory<EmptyRendering>
       get() = ScreenViewFactory.fromCode { _, e, c, _ ->
-        ScreenViewHolder(e, View(c)) { _, _, -> }
+        ScreenViewHolder(e, View(c)) { _, _ -> }
       }
   }
 

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -45,6 +45,7 @@ import com.squareup.workflow1.ui.internal.test.IdlingDispatcherRule
 import com.squareup.workflow1.ui.internal.test.WorkflowUiTestActivity
 import com.squareup.workflow1.ui.plus
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -588,15 +589,19 @@ internal class ComposeViewTreeIntegrationTest {
       context: Context,
       container: ViewGroup?
     ): ScreenViewHolder<TestComposeRendering> {
-      val view = ComposeView(context)
-      return ScreenViewHolder(initialEnvironment, view) { rendering, _ ->
-        val lastCompositionStrategy = view.tag as? ViewCompositionStrategy
-        view.tag = rendering.disposeStrategy
-        if (rendering.disposeStrategy != lastCompositionStrategy) {
-          lastCompositionStrategy?.let { view.setViewCompositionStrategy(it) }
-        }
+      var lastCompositionStrategy = initialRendering.disposeStrategy
 
-        view.setContent(rendering.content)
+      return ComposeView(context).let { view ->
+        lastCompositionStrategy?.let(view::setViewCompositionStrategy)
+
+        ScreenViewHolder(initialEnvironment, view) { rendering, _ ->
+          if (rendering.disposeStrategy != lastCompositionStrategy) {
+            lastCompositionStrategy = rendering.disposeStrategy
+            lastCompositionStrategy?.let { view.setViewCompositionStrategy(it) }
+          }
+
+          view.setContent(rendering.content)
+        }
       }
     }
   }

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/LegacyComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/LegacyComposeViewTreeIntegrationTest.kt
@@ -26,8 +26,11 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
+import com.squareup.workflow1.ui.AndroidScreen
 import com.squareup.workflow1.ui.AndroidViewRendering
 import com.squareup.workflow1.ui.Compatible
+import com.squareup.workflow1.ui.ScreenViewFactory
+import com.squareup.workflow1.ui.ScreenViewHolder
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewFactory
 import com.squareup.workflow1.ui.ViewRegistry
@@ -615,11 +618,14 @@ internal class LegacyComposeViewTreeIntegrationTest {
     }
   }
 
-  companion object {
-    // Use a ComposeView here because the Compose test infra doesn't like it if there are no
-    // Compose views at all. See https://issuetracker.google.com/issues/179455327.
-    val EmptyRendering = TestComposeRendering(compatibilityKey = "") {}
+  object EmptyRendering : AndroidScreen<EmptyRendering> {
+    override val viewFactory: ScreenViewFactory<EmptyRendering>
+      get() = ScreenViewFactory.fromCode { _, e, c, _ ->
+        ScreenViewHolder(e, View(c)) { _, _, -> }
+      }
+  }
 
+  companion object {
     const val CounterTag = "counter"
     const val CounterTag2 = "counter2"
     const val CounterTag3 = "counter3"


### PR DESCRIPTION
Three commits:

### Undoes view tag wonkiness in ComposeViewTreeIntegrationTest
It was left over from an earlier draft of ScreenViewFactory.

### Eliminates workarounds for old Compose testing issue
https://issuetracker.google.com/issues/179455327 was fixed.

### Fixes botched test `composition_is_restored_in_modal_after_config_change`.

I converted it wrong, putting what was supposed to be the modal content into the body / activity instead. So the test was passing vaccuously, and even better, failing with an obscure `SavedStateRegistry.consumeRestoredStateForKey` exception on higher API levels.

Fixes #800.
