### PR TITLE
always add the Kotlin bom dependency, and only add it once

### DIFF
--- a/buildSrc/src/main/java/kotlin-android.gradle.kts
+++ b/buildSrc/src/main/java/kotlin-android.gradle.kts
@@ -1,5 +1,4 @@
 import com.squareup.workflow1.buildsrc.kotlinCommonSettings
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   kotlin("android")
@@ -10,10 +9,4 @@ extensions.getByType(JavaPluginExtension::class).apply {
   targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-tasks.withType<KotlinCompile> {
-  kotlinOptions {
-    jvmTarget = "1.8"
-  }
-
-  project.kotlinCommonSettings(this)
-}
+project.kotlinCommonSettings(bomConfigurationName = "implementation")

--- a/buildSrc/src/main/java/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/java/kotlin-jvm.gradle.kts
@@ -1,5 +1,4 @@
 import com.squareup.workflow1.buildsrc.kotlinCommonSettings
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   kotlin("jvm")
@@ -10,10 +9,4 @@ extensions.getByType(JavaPluginExtension::class).apply {
   targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-tasks.withType<KotlinCompile> {
-  kotlinOptions {
-    jvmTarget = "1.8"
-  }
-
-  project.kotlinCommonSettings(this)
-}
+project.kotlinCommonSettings(bomConfigurationName = "implementation")

--- a/buildSrc/src/main/java/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/java/kotlin-multiplatform.gradle.kts
@@ -1,5 +1,4 @@
 import com.squareup.workflow1.buildsrc.kotlinCommonSettings
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   kotlin("multiplatform")
@@ -10,10 +9,4 @@ extensions.getByType(JavaPluginExtension::class).apply {
   targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-tasks.withType<KotlinCompile> {
-  kotlinOptions {
-    jvmTarget = "1.8"
-  }
-
-  project.kotlinCommonSettings(this, "commonMainImplementation")
-}
+project.kotlinCommonSettings(bomConfigurationName = "commonMainImplementation")


### PR DESCRIPTION
Android artifact pom files for `1.8.0-beta02` have a `kotlin-bom` dependency which does not include a version:

```xml
<dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-bom</artifactId>
      <type>pom</type>
      <scope>import</scope>
    </dependency>
  </dependencies>
</dependencyManagement>
```

Jvm artifacts still had the version specified, even though the `project(kotlin("bom"))` dependency was being added in the same way.

The problem is that we were adding the dependency _during_ the `KotlinCompile` task, so it wasn't guaranteed to be present while the publish plugins were determining the dependencies for the pom.  It also meant that the dependency was being added multiple times (once for each source set's compile task).

After moving the dependency outside of `tasks.withType {...}`, the pom includes the bom version.

```xml
<dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-bom</artifactId>
      <version>1.6.10</version>
      <type>pom</type>
      <scope>import</scope>
    </dependency>
  </dependencies>
</dependencyManagement>
```

I can't say why the bom was being added without a version, or why `1.8.0-beta01` didn't have this problem.