### PR TITLE
Sets the intial value of `InOverlay` before the Dialog is built.

### DIFF
--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/BackStackContainerTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/BackStackContainerTest.kt
@@ -8,7 +8,6 @@ import android.util.SparseArray
 import android.widget.EditText
 import androidx.activity.ComponentActivity
 import androidx.test.ext.junit.rules.ActivityScenarioRule
-import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
 import com.squareup.workflow1.ui.AndroidScreen
 import com.squareup.workflow1.ui.Compatible
@@ -16,7 +15,6 @@ import com.squareup.workflow1.ui.NamedScreen
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ScreenViewFactory
 import com.squareup.workflow1.ui.ScreenViewHolder
-import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewEnvironment.Companion.EMPTY
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.show
@@ -32,7 +30,7 @@ internal class BackStackContainerTest {
   private data class Rendering(val name: String) : Compatible, AndroidScreen<Rendering> {
     override val compatibilityKey = name
     override val viewFactory: ScreenViewFactory<Rendering>
-      get() = ScreenViewFactory.fromCode<Rendering> { _, initialRendering, context, _ ->
+      get() = ScreenViewFactory.fromCode { _, initialRendering, context, _ ->
         ScreenViewHolder(
           initialRendering,
           EditText(context).apply {
@@ -103,7 +101,7 @@ internal class BackStackContainerTest {
 
       holder.show(BackStackScreen(Rendering("able")), EMPTY)
       val showing = view.visibleRendering as Rendering
-      Truth.assertThat(showing).isEqualTo(Rendering("able"))
+      assertThat(showing).isEqualTo(Rendering("able"))
     }
   }
 
@@ -117,7 +115,7 @@ internal class BackStackContainerTest {
       holder.show(BackStackScreen(Rendering("able")), EMPTY)
       holder.show(BackStackScreen(Rendering("baker")), EMPTY)
       val showing = view.visibleRendering as Rendering
-      Truth.assertThat(showing).isEqualTo(Rendering("baker"))
+      assertThat(showing).isEqualTo(Rendering("baker"))
     }
   }
 
@@ -132,7 +130,7 @@ internal class BackStackContainerTest {
       holder.show(BackStackScreen(Rendering("baker")), EMPTY)
       holder.show(BackStackScreen(Rendering("charlie")), EMPTY)
       val showing = view.visibleRendering as Rendering
-      Truth.assertThat(showing).isEqualTo(Rendering("charlie"))
+      assertThat(showing).isEqualTo(Rendering("charlie"))
 
       // This used to fail because of our naive use of TransitionManager. The
       // transition from baker view to charlie view was dropped because the
@@ -152,18 +150,14 @@ internal class BackStackContainerTest {
       holder.show(BackStackScreen(Rendering("able")), EMPTY)
       holder.show(BackStackScreen(Rendering("able")), EMPTY)
 
-      Truth.assertThat(view.transitionCount).isEqualTo(1)
+      assertThat(view.transitionCount).isEqualTo(1)
     }
   }
 
   private class VisibleBackStackContainer(context: Context) : BackStackContainer(context) {
     var transitionCount = 0
-    @Suppress("UNCHECKED_CAST") val visibleRendering: Screen?
+    @Suppress("UNCHECKED_CAST") val visibleRendering: Screen
       get() = (getChildAt(0)?.tag as NamedScreen<*>).wrapped
-
-    fun show(rendering: BackStackScreen<*>) {
-      update(rendering, ViewEnvironment.EMPTY)
-    }
 
     override fun performTransition(
       oldHolderMaybe: ScreenViewHolder<NamedScreen<*>>?,

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/DialogIntegrationTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/DialogIntegrationTest.kt
@@ -1,0 +1,114 @@
+package com.squareup.workflow1.ui.container
+
+import android.app.Dialog
+import android.content.Context
+import android.view.View
+import android.widget.EditText
+import androidx.activity.ComponentActivity
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.squareup.workflow1.ui.AndroidScreen
+import com.squareup.workflow1.ui.Compatible
+import com.squareup.workflow1.ui.ScreenViewFactory
+import com.squareup.workflow1.ui.ScreenViewHolder
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.WorkflowLayout
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.container.OverlayDialogHolder.Companion.InOverlay
+import com.squareup.workflow1.ui.environmentOrNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(WorkflowUiExperimentalApi::class)
+@RunWith(AndroidJUnit4::class)
+internal class DialogIntegrationTest {
+  @get:Rule val scenarioRule = ActivityScenarioRule(ComponentActivity::class.java)
+  private val scenario get() = scenarioRule.scenario
+
+  private data class ContentRendering(val name: String) :
+    Compatible, AndroidScreen<ContentRendering> {
+    override val compatibilityKey = name
+    override val viewFactory: ScreenViewFactory<ContentRendering>
+      get() = ScreenViewFactory.fromCode { _, initialRendering, context, _ ->
+        ScreenViewHolder(
+          initialRendering,
+          EditText(context).apply {
+            // Must have an id to participate in view persistence.
+            id = 65
+          }
+        ) { _, _ -> /* Noop */ }
+      }
+  }
+
+  private var latestContentView: View? = null
+  private var latestDialog: Dialog? = null
+
+  private inner class DialogRendering(
+    name: String,
+    override val content: ContentRendering
+  ) :
+    Compatible, AndroidOverlay<DialogRendering>, ScreenOverlay<ContentRendering> {
+    override val compatibilityKey = name
+    override val dialogFactory =
+      object : ScreenOverlayDialogFactory<ContentRendering, DialogRendering>(
+        type = DialogRendering::class
+      ) {
+        override fun buildContent(
+          viewFactory: ScreenViewFactory<ContentRendering>,
+          initialContent: ContentRendering,
+          initialEnvironment: ViewEnvironment,
+          context: Context
+        ): ScreenViewHolder<ContentRendering> =
+          super.buildContent(viewFactory, initialContent, initialEnvironment, context).also {
+            latestContentView = it.view
+          }
+
+        override fun buildDialogWithContent(
+          content: ScreenViewHolder<ContentRendering>
+        ) = super.buildDialogWithContent(content).also { latestDialog = it }
+      }
+  }
+
+  @Test fun showOne() {
+    val screen = BodyAndOverlaysScreen(
+      ContentRendering("body"), DialogRendering("dialog", ContentRendering("content"))
+    )
+
+    scenario.onActivity { activity ->
+      val root = WorkflowLayout(activity)
+      root.show(screen)
+
+      assertThat(latestContentView).isNotNull()
+      assertThat(latestDialog).isNotNull()
+      assertThat(latestDialog!!.isShowing).isTrue()
+    }
+  }
+
+  /** https://github.com/square/workflow-kotlin/issues/825 */
+  @Test fun showASecondDialog() {
+    val oneDialog = BodyAndOverlaysScreen(
+      ContentRendering("body"), DialogRendering("dialog", ContentRendering("content"))
+    )
+    lateinit var root: WorkflowLayout
+
+    scenario.onActivity { activity ->
+      root = WorkflowLayout(activity)
+      root.show(oneDialog)
+    }
+
+    val dialog2 = DialogRendering("dialog2", ContentRendering("content2"))
+    val twoDialogs = BodyAndOverlaysScreen(
+      ContentRendering("body"),
+      DialogRendering("dialog1", ContentRendering("content1")),
+      dialog2
+    )
+
+    scenario.onActivity {
+      root.show(twoDialogs)
+      val lastOverlay = latestContentView?.environmentOrNull?.get(InOverlay)!!
+      assertThat(lastOverlay).isEqualTo(dialog2)
+    }
+  }
+}


### PR DESCRIPTION
Necessary because we use `OverlayDialogHolder.showing` to get a unique name for the `stateRegistryAggregator.installChildRegistryOwnerOn` call in `DialogSession`. (`OverlayDialogHolder.showing` relies on `InOverlay`.)
That call has to happen before the first call to `OverlayDialogHolder.show`, which is what normally sets the value. Chicken and egg type of situation.

Fixes #825