### PR TITLE
Brings back the convenience overload of toUnwrappingViewFactory.

### DIFF
--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -184,6 +184,7 @@ public final class com/squareup/workflow1/ui/ScreenViewFactoryFinder$DefaultImpl
 public final class com/squareup/workflow1/ui/ScreenViewFactoryKt {
 	public static final fun startShowing (Lcom/squareup/workflow1/ui/ScreenViewFactory;Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;Lcom/squareup/workflow1/ui/ViewStarter;)Lcom/squareup/workflow1/ui/ScreenViewHolder;
 	public static synthetic fun startShowing$default (Lcom/squareup/workflow1/ui/ScreenViewFactory;Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;Lcom/squareup/workflow1/ui/ViewStarter;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/ScreenViewHolder;
+	public static final synthetic fun toUnwrappingViewFactory (Lcom/squareup/workflow1/ui/ScreenViewFactory;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/ScreenViewFactory;
 	public static final synthetic fun toUnwrappingViewFactory (Lcom/squareup/workflow1/ui/ScreenViewFactory;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;)Lcom/squareup/workflow1/ui/ScreenViewFactory;
 	public static final fun toViewFactory (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/ScreenViewFactory;
 	public static final fun viewBindingLayoutInflater (Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/LayoutInflater;

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewFactory.kt
@@ -377,7 +377,25 @@ public fun interface ViewStarter {
  * Transforms a [ScreenViewFactory] of [WrappedT] into one that can handle
  * instances of [WrapperT].
  *
- * It is usually more convenient to call [ScreenViewFactory.forWrapper].
+ * @see [ScreenViewFactory.forWrapper].
+ */
+@WorkflowUiExperimentalApi
+public inline fun <
+  reified WrapperT : Screen,
+  WrappedT : Screen
+  > ScreenViewFactory<WrappedT>.toUnwrappingViewFactory(
+  crossinline unwrap: (wrapperScreen: WrapperT) -> WrappedT
+): ScreenViewFactory<WrapperT> {
+  return toUnwrappingViewFactory(unwrap) { _, wrapperScreen, environment, showUnwrappedScreen ->
+    showUnwrappedScreen(unwrap(wrapperScreen), environment)
+  }
+}
+
+/**
+ * Transforms a [ScreenViewFactory] of [WrappedT] into one that can handle
+ * instances of [WrapperT].
+ *
+ * @see [ScreenViewFactory.forWrapper].
  */
 @WorkflowUiExperimentalApi
 public inline fun <


### PR DESCRIPTION
Turns out there are still a decent number of use cases for this.