### PR TITLE
[WIP] Add js target

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -144,6 +144,34 @@ jobs :
         with :
           report_paths : '**/build/test-results/test/TEST-*.xml'
 
+  js-tests :
+    name : JS Tests
+    runs-on : macos-latest
+    timeout-minutes : 30
+    steps :
+      - uses : actions/checkout@v3
+      - uses : gradle/wrapper-validation-action@v1
+      - name : set up JDK 11
+        uses : actions/setup-java@v3
+        with :
+          distribution : 'zulu'
+          java-version : 11
+
+      ## JS Specific Tests (for KMP js actuals in core and runtime).
+      - uses : gradle/gradle-build-action@v2
+        name : Check with Gradle
+        with :
+          arguments : |
+            jsTest --stacktrace
+          cache-read-only : false
+
+      # Report as Github Pull Request Check.
+      - name : Publish Test Report
+        uses : mikepenz/action-junit-report@v3
+        if : always() # always run even if the previous step fails
+        with :
+          report_paths : '**/build/test-results/test/TEST-*.xml'
+
   performance-tests :
     name : Performance tests
     runs-on : macos-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,4 @@ POM_DEVELOPER_NAME=Square, Inc.
 POM_DEVELOPER_URL=https://github.com/square/
 SONATYPE_STAGING_PROFILE=com.squareup
 
-# For KMP in the IDE, until we get to Kotlin version 1.6.20
-kotlin.mpp.enableGranularSourceSetsMetadata=true
-kotlin.native.enableDependencyPropagation=false
 kotlin.js.compiler=ir

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,4 @@ SONATYPE_STAGING_PROFILE=com.squareup
 # For KMP in the IDE, until we get to Kotlin version 1.6.20
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
+kotlin.js.compiler=ir

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ dependencyGuard = "0.1.0"
 
 google-accompanist = "0.18.0"
 google-dagger = "2.40.5"
-google-ksp = "1.6.10-1.0.2"
+google-ksp = "1.6.20-1.0.5"
 google-material = "1.4.0"
 
 groovy = "3.0.9"
@@ -46,7 +46,7 @@ jUnit = "4.13.2"
 javaParser = "3.24.0"
 jmh = "1.34"
 kotest = "5.1.0"
-kotlin = "1.6.10"
+kotlin = "1.6.20"
 
 kotlinx-binary-compatibility = "0.6.0"
 kotlinx-coroutines = "1.5.1"

--- a/workflow-core/build.gradle.kts
+++ b/workflow-core/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
 kotlin {
   jvm { withJava() }
   ios()
+  js {
+    browser()
+  }
 
   sourceSets {
     all {

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkerWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkerWorkflow.kt
@@ -89,7 +89,8 @@ private class EmitWorkerOutputAction<P, S, O>(
   private val output: O
 ) : WorkflowAction<P, S, O>() {
   override fun toString(): String =
-    "${EmitWorkerOutputAction::class.qualifiedName}(worker=$worker, key=\"$renderKey\")"
+    WorkflowIdentifierTypeNamer.uniqueName(EmitWorkerOutputAction::class) +
+    "(worker=$worker, key=\"$renderKey\")"
 
   override fun Updater.apply() {
     setOutput(output)

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowIdentifierType.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowIdentifierType.kt
@@ -24,7 +24,7 @@ public sealed class WorkflowIdentifierType {
     val kClass: KClass<*>? = null,
   ) : WorkflowIdentifierType() {
     public constructor(kClass: KClass<*>) : this(
-      kClass.qualifiedName ?: kClass.toString(), kClass
+      WorkflowIdentifierTypeNamer.uniqueName(kClass), kClass
     )
   }
 
@@ -43,4 +43,8 @@ public sealed class WorkflowIdentifierType {
 
     override val typeName: String = kType.toString()
   }
+}
+
+public expect object WorkflowIdentifierTypeNamer {
+  public fun uniqueName(kClass: KClass<*>): String
 }

--- a/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/SinkTest.kt
+++ b/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/SinkTest.kt
@@ -27,7 +27,7 @@ internal class SinkTest {
 
   private val sink = RecordingSink()
 
-  @Test fun `collectToSink sends action`() = runTest {
+  @Test fun collectToSink_sends_action() = runTest {
     val flow = MutableStateFlow(1)
     val collector = launch {
       flow.collectToSink(sink) {
@@ -61,7 +61,7 @@ internal class SinkTest {
     collector.cancel()
   }
 
-  @Test fun `collectToSink propagates backpressure`() {
+  @Test fun collectToSink_propagates_backpressure() {
     val channel = Channel<String>()
     val flow = channel.consumeAsFlow()
     // Used to assert ordering.
@@ -112,7 +112,7 @@ internal class SinkTest {
     }
   }
 
-  @Test fun `sendAndAwaitApplication applies action`() {
+  @Test fun sendAndAwaitApplication_applies_action() {
     var applications = 0
     val action = action<String, String, String> {
       applications++
@@ -132,7 +132,7 @@ internal class SinkTest {
     }
   }
 
-  @Test fun `sendAndAwaitApplication suspends until after applied`() = runTest {
+  @Test fun sendAndAwaitApplication_suspends_until_after_applied() = runTest {
     var resumed = false
     val action = action<String, String, String> {
       assertFalse(resumed)
@@ -156,7 +156,7 @@ internal class SinkTest {
     assertTrue(resumed)
   }
 
-  @Test fun `sendAndAwaitApplication doesn't apply action when cancelled while suspended`() =
+  @Test fun sendAndAwaitApplication_does_not_apply_action_when_cancelled_while_suspended() =
     runTest {
       var applied = false
       val action = action<String, String, String> {

--- a/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkerTest.kt
+++ b/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkerTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalStdlibApi::class)
 class WorkerTest {
 
-  @Test fun `timer returns equivalent workers keyed`() {
+  @Test fun timer_returns_equivalent_workers_keyed() {
     val worker1 = Worker.timer(1, "key")
     val worker2 = Worker.timer(1, "key")
 
@@ -25,21 +25,21 @@ class WorkerTest {
     assertTrue(worker1.doesSameWorkAs(worker2))
   }
 
-  @Test fun `timer returns non-equivalent workers based on key`() {
+  @Test fun timer_returns_non_equivalent_workers_based_on_key() {
     val worker1 = Worker.timer(1, "key1")
     val worker2 = Worker.timer(1, "key2")
 
     assertFalse(worker1.doesSameWorkAs(worker2))
   }
 
-  @Test fun `finished worker is equivalent to self`() {
+  @Test fun finished_worker_is_equivalent_to_self() {
     assertTrue(
       Worker.finished<Nothing>()
         .doesSameWorkAs(Worker.finished<Nothing>())
     )
   }
 
-  @Test fun `transformed workers are equivalent with equivalent source`() {
+  @Test fun transformed_workers_are_equivalent_with_equivalent_source() {
     val source = Worker.create<Unit> {}
     val transformed1 = source.transform { flow -> flow.buffer(1) }
     val transformed2 = source.transform { flow -> flow.conflate() }
@@ -47,7 +47,7 @@ class WorkerTest {
     assertTrue(transformed1.doesSameWorkAs(transformed2))
   }
 
-  @Test fun `transformed workers are not equivalent with nonequivalent source`() {
+  @Test fun transformed_workers_are_not_equivalent_with_nonequivalent_source() {
     val source1 = object : Worker<Unit> {
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = false
       override fun run(): Flow<Unit> = emptyFlow()
@@ -62,7 +62,7 @@ class WorkerTest {
     assertFalse(transformed1.doesSameWorkAs(transformed2))
   }
 
-  @Test fun `transformed workers transform flows`() {
+  @Test fun transformed_workers_transform_flows() {
     val source = flowOf(1, 2, 3).asWorker()
     val transformed = source.transform { flow -> flow.map { it.toString() } }
 

--- a/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkerTest.kt
+++ b/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkerTest.kt
@@ -1,5 +1,6 @@
 package com.squareup.workflow1
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.conflate
@@ -7,13 +8,14 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
 
+@ExperimentalCoroutinesApi
 @OptIn(ExperimentalStdlibApi::class)
 class WorkerTest {
 
@@ -62,14 +64,11 @@ class WorkerTest {
     assertFalse(transformed1.doesSameWorkAs(transformed2))
   }
 
-  @Test fun transformed_workers_transform_flows() {
+  @Test fun transformed_workers_transform_flows() = runTest {
     val source = flowOf(1, 2, 3).asWorker()
     val transformed = source.transform { flow -> flow.map { it.toString() } }
 
-    val transformedValues = runBlocking {
-      transformed.run()
-        .toList()
-    }
+    val transformedValues = transformed.run().toList()
 
     assertEquals(listOf("1", "2", "3"), transformedValues)
   }

--- a/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkerWorkflowTest.kt
+++ b/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkerWorkflowTest.kt
@@ -1,29 +1,29 @@
 package com.squareup.workflow1
 
 import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.coroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@ExperimentalCoroutinesApi
 class WorkerWorkflowTest {
 
-  @Test fun runWorker_coroutine_is_named_without_key() {
+  @Test fun runWorker_coroutine_is_named_without_key() = runTest {
     val worker = CoroutineNameWorker()
-    runBlocking {
-      runWorker(worker, renderKey = "", actionSink = NoopSink)
-    }
+
+    runWorker(worker, renderKey = "", actionSink = NoopSink)
 
     assertEquals("CoroutineNameWorker.toString", worker.recordedName)
   }
 
-  @Test fun runWorker_coroutine_is_named_with_key() {
+  @Test fun runWorker_coroutine_is_named_with_key() = runTest {
     val worker = CoroutineNameWorker()
-    runBlocking {
-      runWorker(worker, renderKey = "foo", actionSink = NoopSink)
-    }
+
+    runWorker(worker, renderKey = "foo", actionSink = NoopSink)
 
     assertEquals("CoroutineNameWorker.toString:foo", worker.recordedName)
   }

--- a/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkerWorkflowTest.kt
+++ b/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkerWorkflowTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertEquals
 
 class WorkerWorkflowTest {
 
-  @Test fun `runWorker coroutine is named without key`() {
+  @Test fun runWorker_coroutine_is_named_without_key() {
     val worker = CoroutineNameWorker()
     runBlocking {
       runWorker(worker, renderKey = "", actionSink = NoopSink)
@@ -19,7 +19,7 @@ class WorkerWorkflowTest {
     assertEquals("CoroutineNameWorker.toString", worker.recordedName)
   }
 
-  @Test fun `runWorker coroutine is named with key`() {
+  @Test fun runWorker_coroutine_is_named_with_key() {
     val worker = CoroutineNameWorker()
     runBlocking {
       runWorker(worker, renderKey = "foo", actionSink = NoopSink)

--- a/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkflowActionTest.kt
+++ b/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkflowActionTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertNull
 
 internal class WorkflowActionTest {
 
-  @Test fun `applyTo works when no output is set`() {
+  @Test fun applyTo_works_when_no_output_is_set() {
     val action = object : WorkflowAction<String, String, String?>() {
       override fun Updater.apply() {
         state = "state: $state, props: $props"
@@ -18,7 +18,7 @@ internal class WorkflowActionTest {
     assertNull(output)
   }
 
-  @Test fun `applyTo works when null output is set`() {
+  @Test fun applyTo_works_when_null_output_is_set() {
     val action = object : WorkflowAction<String, String, String?>() {
       override fun Updater.apply() {
         state = "state: $state, props: $props"
@@ -31,7 +31,7 @@ internal class WorkflowActionTest {
     assertNull(output.value)
   }
 
-  @Test fun `applyTo works when non-null output is set`() {
+  @Test fun applyTo_works_when_non_null_output_is_set() {
     val action = object : WorkflowAction<String, String, String?>() {
       override fun Updater.apply() {
         state = "state: $state, props: $props"

--- a/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkflowIdentifierTest.kt
+++ b/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkflowIdentifierTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertNull
 @OptIn(ExperimentalStdlibApi::class)
 internal class WorkflowIdentifierTest {
 
-  @Test fun `flat identifier toString`() {
+  @Test fun flat_identifier_toString() {
     val id = TestWorkflow1.identifier
     assertEquals(
       "WorkflowIdentifier(com.squareup.workflow1.WorkflowIdentifierTest.TestWorkflow1)",
@@ -23,7 +23,7 @@ internal class WorkflowIdentifierTest {
     )
   }
 
-  @Test fun `impostor identifier toString uses describeRealIdentifier when non-null`() {
+  @Test fun impostor_identifier_toString_uses_describeRealIdentifier_when_non_null() {
     class TestImpostor : Workflow<Nothing, Nothing, Nothing>, ImpostorWorkflow {
       override val realIdentifier: WorkflowIdentifier = TestWorkflow1.identifier
       override fun describeRealIdentifier(): String =
@@ -38,7 +38,7 @@ internal class WorkflowIdentifierTest {
   }
 
   @Test
-  fun `impostor identifier toString uses full chain when describeRealIdentifier returns null`() {
+  fun impostor_identifier_toString_uses_full_chain_when_describeRealIdentifier_returns_null() {
     class TestImpostor : Workflow<Nothing, Nothing, Nothing>, ImpostorWorkflow {
       override val realIdentifier: WorkflowIdentifier = TestWorkflow1.identifier
       override fun describeRealIdentifier(): String? = null
@@ -55,7 +55,7 @@ internal class WorkflowIdentifierTest {
     )
   }
 
-  @Test fun `impostor identifier description`() {
+  @Test fun impostor_identifier_description() {
     val id = TestImpostor1(TestWorkflow1).identifier
     assertEquals(
       "TestImpostor1(com.squareup.workflow1.WorkflowIdentifierTest.TestWorkflow1)",
@@ -63,46 +63,46 @@ internal class WorkflowIdentifierTest {
     )
   }
 
-  @Test fun `restored identifier toString`() {
+  @Test fun restored_identifier_toString() {
     val id = TestWorkflow1.identifier
     val serializedId = id.toByteStringOrNull()!!
     val restoredId = WorkflowIdentifier.parse(serializedId)
     assertEquals(id.toString(), restoredId.toString())
   }
 
-  @Test fun `flat identifiers for same class are equal`() {
+  @Test fun flat_identifiers_for_same_class_are_equal() {
     val id1 = TestWorkflow1.identifier
     val id2 = TestWorkflow1.identifier
     assertEquals(id1, id2)
     assertEquals(id1.hashCode(), id2.hashCode())
   }
 
-  @Test fun `flat identifiers for different classes are not equal`() {
+  @Test fun flat_identifiers_for_different_classes_are_not_equal() {
     val id1 = TestWorkflow1.identifier
     val id2 = TestWorkflow2.identifier
     assertNotEquals(id1, id2)
   }
 
-  @Test fun `impostor identifiers for same proxied class are equal`() {
+  @Test fun impostor_identifiers_for_same_proxied_class_are_equal() {
     val impostorId1 = TestImpostor1(TestWorkflow1).identifier
     val impostorId2 = TestImpostor1(TestWorkflow1).identifier
     assertEquals(impostorId1, impostorId2)
     assertEquals(impostorId1.hashCode(), impostorId2.hashCode())
   }
 
-  @Test fun `impostor identifiers for different proxied classes are not equal`() {
+  @Test fun impostor_identifiers_for_different_proxied_classes_are_not_equal() {
     val impostorId1 = TestImpostor1(TestWorkflow1).identifier
     val impostorId2 = TestImpostor1(TestWorkflow2).identifier
     assertNotEquals(impostorId1, impostorId2)
   }
 
-  @Test fun `different impostor identifiers for same proxied class are not equal`() {
+  @Test fun different_impostor_identifiers_for_same_proxied_class_are_not_equal() {
     val impostorId1 = TestImpostor1(TestWorkflow1).identifier
     val impostorId2 = TestImpostor2(TestWorkflow1).identifier
     assertNotEquals(impostorId1, impostorId2)
   }
 
-  @Test fun `identifier restored from source is equal to itself`() {
+  @Test fun identifier_restored_from_source_is_equal_to_itself() {
     val id = TestWorkflow1.identifier
     val serializedId = id.toByteStringOrNull()!!
     val restoredId = WorkflowIdentifier.parse(serializedId)
@@ -110,7 +110,7 @@ internal class WorkflowIdentifierTest {
     assertEquals(id.hashCode(), restoredId.hashCode())
   }
 
-  @Test fun `identifier restored from source is not equal to different identifier`() {
+  @Test fun identifier_restored_from_source_is_not_equal_to_different_identifier() {
     val id1 = TestWorkflow1.identifier
     val id2 = TestWorkflow2.identifier
     val serializedId = id1.toByteStringOrNull()!!
@@ -118,7 +118,7 @@ internal class WorkflowIdentifierTest {
     assertNotEquals(id2, restoredId)
   }
 
-  @Test fun `impostor identifier restored from source is equal to itself`() {
+  @Test fun impostor_identifier_restored_from_source_is_equal_to_itself() {
     val id = TestImpostor1(TestWorkflow1).identifier
     val serializedId = id.toByteStringOrNull()!!
     val restoredId = WorkflowIdentifier.parse(serializedId)
@@ -127,7 +127,7 @@ internal class WorkflowIdentifierTest {
   }
 
   @Test
-  fun `impostor identifier restored from source is not equal to impostor with different proxied class`() { // ktlint-disable max-line-length
+  fun impostor_identifier_restored_from_source_is_not_equal_to_impostor_with_different_proxied_class() { // ktlint-disable max-line-length
     val id1 = TestImpostor1(TestWorkflow1).identifier
     val id2 = TestImpostor1(TestWorkflow2).identifier
     val serializedId = id1.toByteStringOrNull()!!
@@ -136,7 +136,7 @@ internal class WorkflowIdentifierTest {
   }
 
   @Test
-  fun `impostor identifier restored from source is not equal to different impostor with same proxied class`() { // ktlint-disable max-line-length
+  fun impostor_identifier_restored_from_source_is_not_equal_to_different_impostor_with_same_proxied_class() { // ktlint-disable max-line-length
     val id1 = TestImpostor1(TestWorkflow1).identifier
     val id2 = TestImpostor2(TestWorkflow1).identifier
     val serializedId = id1.toByteStringOrNull()!!
@@ -144,13 +144,13 @@ internal class WorkflowIdentifierTest {
     assertNotEquals(id2, restoredId)
   }
 
-  @Test fun `read from empty source throws`() {
+  @Test fun read_from_empty_source_throws() {
     assertFailsWith<IllegalArgumentException> {
       WorkflowIdentifier.parse(ByteString.EMPTY)
     }
   }
 
-  @Test fun `read from invalid source throws`() {
+  @Test fun read_from_invalid_source_throws() {
     val source = Buffer().apply { writeUtf8("invalid data") }
       .readByteString()
     assertFailsWith<IllegalArgumentException> {
@@ -158,7 +158,7 @@ internal class WorkflowIdentifierTest {
     }
   }
 
-  @Test fun `read from corrupted source throws`() {
+  @Test fun read_from_corrupted_source_throws() {
     val source = TestWorkflow1.identifier.toByteStringOrNull()!!
       .toByteArray()
 
@@ -170,49 +170,49 @@ internal class WorkflowIdentifierTest {
     }
   }
 
-  @Test fun `unsnapshottable identifier returns null ByteString`() {
+  @Test fun unsnapshottable_identifier_returns_null_ByteString() {
     val id = unsnapshottableIdentifier(typeOf<TestWorkflow1>())
     assertNull(id.toByteStringOrNull())
   }
 
-  @Test fun `unsnapshottable identifiers for same class are equal`() {
+  @Test fun unsnapshottable_identifiers_for_same_class_are_equal() {
     val id1 = unsnapshottableIdentifier(typeOf<String>())
     val id2 = unsnapshottableIdentifier(typeOf<String>())
     assertEquals(id1, id2)
   }
 
-  @Test fun `unsnapshottable identifiers for different class are not equal`() {
+  @Test fun unsnapshottable_identifiers_for_different_class_are_not_equal() {
     val id1 = unsnapshottableIdentifier(typeOf<String>())
     val id2 = unsnapshottableIdentifier(typeOf<Int>())
     assertNotEquals(id1, id2)
   }
 
-  @Test fun `unsnapshottable impostor identifier returns null ByteString`() {
+  @Test fun unsnapshottable_impostor_identifier_returns_null_ByteString() {
     val id = TestUnsnapshottableImpostor(typeOf<String>()).identifier
     assertNull(id.toByteStringOrNull())
   }
 
-  @Test fun `impostor of unsnapshottable impostor identifier returns null ByteString`() {
+  @Test fun impostor_of_unsnapshottable_impostor_identifier_returns_null_ByteString() {
     val id = TestImpostor1(TestUnsnapshottableImpostor(typeOf<String>())).identifier
     assertNull(id.toByteStringOrNull())
   }
 
-  @Test fun `getRealIdentifierType returns self for non-impostor workflow`() {
+  @Test fun getRealIdentifierType_returns_self_for_non_impostor_workflow() {
     val id = TestWorkflow1.identifier
     assertEquals(Snapshottable(TestWorkflow1::class), id.getRealIdentifierType())
   }
 
-  @Test fun `getRealIdentifierType returns real identifier for impostor workflow`() {
+  @Test fun getRealIdentifierType_returns_real_identifier_for_impostor_workflow() {
     val id = TestImpostor1(TestWorkflow1).identifier
     assertEquals(Snapshottable(TestWorkflow1::class), id.getRealIdentifierType())
   }
 
-  @Test fun `getRealIdentifierType returns leaf real identifier for impostor workflow chain`() {
+  @Test fun getRealIdentifierType_returns_leaf_real_identifier_for_impostor_workflow_chain() {
     val id = TestImpostor2(TestImpostor1(TestWorkflow1)).identifier
     assertEquals(Snapshottable(TestWorkflow1::class), id.getRealIdentifierType())
   }
 
-  @Test fun `getRealIdentifierType returns KType of unsnapshottable identifier`() {
+  @Test fun getRealIdentifierType_returns_KType_of_unsnapshottable_identifier() {
     val id = TestUnsnapshottableImpostor(typeOf<List<String>>()).identifier
     assertEquals(Unsnapshottable(typeOf<List<String>>()), id.getRealIdentifierType())
   }

--- a/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkflowIdentifierTest.kt
+++ b/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/WorkflowIdentifierTest.kt
@@ -15,54 +15,6 @@ import kotlin.test.assertNull
 @OptIn(ExperimentalStdlibApi::class)
 internal class WorkflowIdentifierTest {
 
-  @Test fun flat_identifier_toString() {
-    val id = TestWorkflow1.identifier
-    assertEquals(
-      "WorkflowIdentifier(com.squareup.workflow1.WorkflowIdentifierTest.TestWorkflow1)",
-      id.toString()
-    )
-  }
-
-  @Test fun impostor_identifier_toString_uses_describeRealIdentifier_when_non_null() {
-    class TestImpostor : Workflow<Nothing, Nothing, Nothing>, ImpostorWorkflow {
-      override val realIdentifier: WorkflowIdentifier = TestWorkflow1.identifier
-      override fun describeRealIdentifier(): String =
-        "TestImpostor(${TestWorkflow1::class.simpleName})"
-
-      override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, Nothing, Nothing> =
-        throw NotImplementedError()
-    }
-
-    val id = TestImpostor().identifier
-    assertEquals("TestImpostor(TestWorkflow1)", id.toString())
-  }
-
-  @Test
-  fun impostor_identifier_toString_uses_full_chain_when_describeRealIdentifier_returns_null() {
-    class TestImpostor : Workflow<Nothing, Nothing, Nothing>, ImpostorWorkflow {
-      override val realIdentifier: WorkflowIdentifier = TestWorkflow1.identifier
-      override fun describeRealIdentifier(): String? = null
-
-      override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, Nothing, Nothing> =
-        throw NotImplementedError()
-    }
-
-    val id = TestImpostor().identifier
-    assertEquals(
-      "WorkflowIdentifier(${TestImpostor::class}, " +
-        "com.squareup.workflow1.WorkflowIdentifierTest.TestWorkflow1)",
-      id.toString()
-    )
-  }
-
-  @Test fun impostor_identifier_description() {
-    val id = TestImpostor1(TestWorkflow1).identifier
-    assertEquals(
-      "TestImpostor1(com.squareup.workflow1.WorkflowIdentifierTest.TestWorkflow1)",
-      id.toString()
-    )
-  }
-
   @Test fun restored_identifier_toString() {
     val id = TestWorkflow1.identifier
     val serializedId = id.toByteStringOrNull()!!
@@ -231,7 +183,8 @@ internal class WorkflowIdentifierTest {
     private val proxied: Workflow<*, *, *>
   ) : Workflow<Nothing, Nothing, Nothing>, ImpostorWorkflow {
     override val realIdentifier: WorkflowIdentifier = proxied.identifier
-    override fun describeRealIdentifier(): String = "TestImpostor1(${proxied::class.qualifiedName})"
+    override fun describeRealIdentifier(): String =
+      "TestImpostor1(${WorkflowIdentifierTypeNamer.uniqueName(proxied::class)})"
     override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, Nothing, Nothing> =
       throw NotImplementedError()
   }

--- a/workflow-core/src/iosMain/kotlin/com.squareup.workflow1/WorkflowIdentifierTypeNamer.kt
+++ b/workflow-core/src/iosMain/kotlin/com.squareup.workflow1/WorkflowIdentifierTypeNamer.kt
@@ -1,0 +1,9 @@
+package com.squareup.workflow1
+
+import kotlin.reflect.KClass
+
+public actual object WorkflowIdentifierTypeNamer {
+  public actual fun uniqueName(kClass: KClass<*>): String {
+    return kClass.qualifiedName ?: kClass.toString()
+  }
+}

--- a/workflow-core/src/iosTest/kotlin/com/squareup/workflow1/NativeWorkflowIdentifierTest.kt
+++ b/workflow-core/src/iosTest/kotlin/com/squareup/workflow1/NativeWorkflowIdentifierTest.kt
@@ -1,11 +1,47 @@
 package com.squareup.workflow1
 
+import com.squareup.workflow1.WorkflowIdentifierTest.TestImpostor1
 import com.squareup.workflow1.WorkflowIdentifierTest.TestUnsnapshottableImpostor
+import com.squareup.workflow1.WorkflowIdentifierTest.TestWorkflow1
 import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class NativeWorkflowIdentifierTest {
+
+  @Test fun `flat identifier toString`() {
+    val id = TestWorkflow1.identifier
+    assertEquals(
+      "WorkflowIdentifier(com.squareup.workflow1.WorkflowIdentifierTest.TestWorkflow1)",
+      id.toString()
+    )
+  }
+
+  @Test
+  fun `impostor identifier toString uses full chain when describeRealIdentifier returns null`() {
+    class TestImpostor : Workflow<Nothing, Nothing, Nothing>, ImpostorWorkflow {
+      override val realIdentifier: WorkflowIdentifier = TestWorkflow1.identifier
+      override fun describeRealIdentifier(): String? = null
+
+      override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, Nothing, Nothing> =
+        throw NotImplementedError()
+    }
+
+    val id = TestImpostor().identifier
+    assertEquals(
+      "WorkflowIdentifier(${TestImpostor::class}, " +
+        "com.squareup.workflow1.WorkflowIdentifierTest.TestWorkflow1)",
+      id.toString()
+    )
+  }
+
+  @Test fun `impostor identifier description`() {
+    val id = TestImpostor1(TestWorkflow1).identifier
+    assertEquals(
+      "TestImpostor1(com.squareup.workflow1.WorkflowIdentifierTest.TestWorkflow1)",
+      id.toString()
+    )
+  }
 
   @Test fun `unsnapshottable identifier toString`() {
     val id = unsnapshottableIdentifier(typeOf<String>())

--- a/workflow-core/src/jsMain/kotlin/com.squareup.workflow1/WorkflowIdentifierTypeNamer.kt
+++ b/workflow-core/src/jsMain/kotlin/com.squareup.workflow1/WorkflowIdentifierTypeNamer.kt
@@ -1,0 +1,23 @@
+package com.squareup.workflow1
+
+import kotlin.reflect.KClass
+
+public actual object WorkflowIdentifierTypeNamer {
+  // Stores mappings between KClass instances and their assigned names.
+  val mappings = mutableMapOf<KClass<*>,String>()
+
+  public actual fun uniqueName(kClass: KClass<*>): String {
+    // Note: `kClass.qualifiedName` cannot be used here like other platforms as it's not supported
+    // for JS. Therefore, we construct a unique name of each static KClass based on its simple name
+    // and an index of when it was encountered.
+
+    val mapping = mappings[kClass]
+    if (mapping != null) {
+      return mapping
+    }
+
+    val identifier = "${kClass.simpleName ?: kClass.hashCode()}(${mappings.size})"
+    mappings[kClass] = identifier
+    return identifier
+  }
+}

--- a/workflow-core/src/jsTest/kotlin/com.squareup.workflow1/JsWorkflowIdentifierTest.kt
+++ b/workflow-core/src/jsTest/kotlin/com.squareup.workflow1/JsWorkflowIdentifierTest.kt
@@ -1,0 +1,69 @@
+package com.squareup.workflow1
+
+import com.squareup.workflow1.WorkflowIdentifierTest.TestImpostor1
+import com.squareup.workflow1.WorkflowIdentifierTest.TestWorkflow1
+import com.squareup.workflow1.mocks.workflows1.JsMockWorkflow1
+import com.squareup.workflow1.mocks.workflows1.JsMockWorkflow2
+import kotlin.js.RegExp
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalStdlibApi::class)
+internal class JsWorkflowIdentifierTest {
+  @Test fun flat_identifier_toString() {
+    val id = JsMockWorkflow1().identifier
+
+    // Due to the dynamic naming of workflow identifiers (based on other identifiers that have been
+    // created so far), we can only verify the composition of the name.
+    // Expected value should be something like this: "WorkflowIdentifier(JsMockWorkflow1(7))"
+    val idStructure = RegExp("WorkflowIdentifier\\(JsMockWorkflow1\\((\\d)+\\)\\)")
+    assertTrue(idStructure.test(id.toString()))
+  }
+
+  @Test
+  fun impostor_identifier_toString_uses_full_chain_when_describeRealIdentifier_returns_null() {
+    class TestImpostor : Workflow<Nothing, Nothing, Nothing>, ImpostorWorkflow {
+      override val realIdentifier: WorkflowIdentifier = TestWorkflow1.identifier
+      override fun describeRealIdentifier(): String? = null
+
+      override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, Nothing, Nothing> =
+        throw NotImplementedError()
+    }
+
+    val id = TestImpostor().identifier
+
+    // Expected value should be something like this:
+    // "WorkflowIdentifier(TestImpostor(3), TestWorkflow1(1))"
+    val idStructure = RegExp(
+      "WorkflowIdentifier\\(TestImpostor\\((\\d)+\\), TestWorkflow1\\((\\d)+\\)\\)"
+    )
+    assertTrue(idStructure.test(id.toString()))
+  }
+
+  @Test fun impostor_identifier_description() {
+    // Expected value should be something like this: "WorkflowIdentifier(TestWorkflow1(1))"
+    val id = TestImpostor1(TestWorkflow1).identifier
+    val idStructure = RegExp("TestImpostor1\\(TestWorkflow1\\((\\d)+\\)\\)")
+    assertTrue(idStructure.test(id.toString()))
+  }
+
+  @Test fun same_workflow_returns_same_identifier() {
+    val id1 = JsMockWorkflow1().identifier
+    val id2 = JsMockWorkflow1().identifier
+    assertEquals(id1.toString(), id2.toString())
+  }
+
+  @Test fun different_workflows_same_namespace() {
+    val id1 = JsMockWorkflow1().identifier
+    val id2 = JsMockWorkflow2().identifier
+    assertNotEquals(id1.toString(), id2.toString())
+  }
+
+  @Test fun same_workflow_name_different_namespace() {
+    val id1 = JsMockWorkflow1().identifier
+    val id2 = com.squareup.workflow1.mocks.workflows2.JsMockWorkflow1().identifier
+    assertNotEquals(id1.toString(), id2.toString())
+  }
+}

--- a/workflow-core/src/jsTest/kotlin/com.squareup.workflow1/mocks.workflows1/JsMockWorkflows.kt
+++ b/workflow-core/src/jsTest/kotlin/com.squareup.workflow1/mocks.workflows1/JsMockWorkflows.kt
@@ -1,0 +1,14 @@
+package com.squareup.workflow1.mocks.workflows1
+
+import com.squareup.workflow1.StatefulWorkflow
+import com.squareup.workflow1.Workflow
+
+public class JsMockWorkflow1 : Workflow<Nothing, Nothing, Nothing> {
+  override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, Nothing, Nothing> =
+    throw NotImplementedError()
+}
+
+public class JsMockWorkflow2 : Workflow<Nothing, Nothing, Nothing> {
+  override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, Nothing, Nothing> =
+    throw NotImplementedError()
+}

--- a/workflow-core/src/jsTest/kotlin/com.squareup.workflow1/mocks.workflows2/JsMockWorkflows.kt
+++ b/workflow-core/src/jsTest/kotlin/com.squareup.workflow1/mocks.workflows2/JsMockWorkflows.kt
@@ -1,0 +1,11 @@
+package com.squareup.workflow1.mocks.workflows2
+
+import com.squareup.workflow1.StatefulWorkflow
+import com.squareup.workflow1.Workflow
+
+// This is purposely duplicated to be like com.squareup.workflow1.mocks.workflows1.JsMockWorkflow1,
+// but with a slightly different Output.
+public class JsMockWorkflow1 : Workflow<Nothing, String, Nothing> {
+  override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, String, Nothing> =
+    throw NotImplementedError()
+}

--- a/workflow-core/src/jvmMain/kotlin/com/squareup/workflow1/WorkflowIdentifierTypeNamer.kt
+++ b/workflow-core/src/jvmMain/kotlin/com/squareup/workflow1/WorkflowIdentifierTypeNamer.kt
@@ -1,0 +1,9 @@
+package com.squareup.workflow1
+
+import kotlin.reflect.KClass
+
+public actual object WorkflowIdentifierTypeNamer {
+  public actual fun uniqueName(kClass: KClass<*>): String {
+    return kClass.qualifiedName ?: kClass.toString()
+  }
+}

--- a/workflow-core/src/jvmTest/kotlin/com/squareup/workflow1/JvmWorkflowIdentifierTest.kt
+++ b/workflow-core/src/jvmTest/kotlin/com/squareup/workflow1/JvmWorkflowIdentifierTest.kt
@@ -12,6 +12,40 @@ import kotlin.test.assertNotEquals
 
 class JvmWorkflowIdentifierTest {
 
+  @Test fun `flat identifier toString`() {
+    val id = TestWorkflow1.identifier
+    assertEquals(
+      "WorkflowIdentifier(com.squareup.workflow1.WorkflowIdentifierTest.TestWorkflow1)",
+      id.toString()
+    )
+  }
+
+  @Test
+  fun `impostor identifier toString uses full chain when describeRealIdentifier returns null`() {
+    class TestImpostor : Workflow<Nothing, Nothing, Nothing>, ImpostorWorkflow {
+      override val realIdentifier: WorkflowIdentifier = TestWorkflow1.identifier
+      override fun describeRealIdentifier(): String? = null
+
+      override fun asStatefulWorkflow(): StatefulWorkflow<Nothing, *, Nothing, Nothing> =
+        throw NotImplementedError()
+    }
+
+    val id = TestImpostor().identifier
+    assertEquals(
+      "WorkflowIdentifier(${TestImpostor::class}, " +
+        "com.squareup.workflow1.WorkflowIdentifierTest.TestWorkflow1)",
+      id.toString()
+    )
+  }
+
+  @Test fun `impostor identifier description`() {
+    val id = TestImpostor1(TestWorkflow1).identifier
+    assertEquals(
+      "TestImpostor1(com.squareup.workflow1.WorkflowIdentifierTest.TestWorkflow1)",
+      id.toString()
+    )
+  }
+
   @Test fun `workflowIdentifier from Workflow class is equal to identifier from workflow`() {
     val instanceId = TestWorkflow1.identifier
     val classId = TestWorkflow1::class.workflowIdentifier

--- a/workflow-runtime/build.gradle.kts
+++ b/workflow-runtime/build.gradle.kts
@@ -26,6 +26,9 @@ kotlin {
     }
   }
   ios()
+  js {
+    browser()
+  }
 
   sourceSets {
     all {

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/ErrorLoggingInterceptor.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/ErrorLoggingInterceptor.kt
@@ -1,0 +1,13 @@
+package com.squareup.workflow1
+
+internal expect open class ErrorLoggingInterceptor() : SimpleLoggingWorkflowInterceptor {
+  val errors: MutableList<String>
+
+  override fun log(text: String)
+
+  override fun logError(text: String)
+
+  companion object {
+    val EXPECTED_ERRORS: List<String>
+  }
+}

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderWorkflowInTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderWorkflowInTest.kt
@@ -55,7 +55,7 @@ class RenderWorkflowInTest {
     testScope = TestScope(UnconfinedTestDispatcher())
   }
 
-  @Test fun `initial rendering is calculated synchronously`() {
+  @Test fun initial_rendering_is_calculated_synchronously() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -74,7 +74,7 @@ class RenderWorkflowInTest {
     }
   }
 
-  @Test fun `initial rendering is calculated when scope cancelled before start`() {
+  @Test fun initial_rendering_is_calculated_when_scope_cancelled_before_start() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -94,7 +94,7 @@ class RenderWorkflowInTest {
   }
 
   @Test
-  fun `side effects from initial rendering in root workflow are never started when scope cancelled before start`() {
+  fun side_effects_from_initial_rendering_in_root_workflow_are_never_started_when_scope_cancelled_before_start() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -120,7 +120,7 @@ class RenderWorkflowInTest {
   }
 
   @Test
-  fun `side effects from initial rendering in non-root workflow are never started when scope cancelled before start`() {
+  fun side_effects_from_initial_rendering_in_non_root_workflow_are_never_started_when_scope_cancelled_before_start() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -148,7 +148,7 @@ class RenderWorkflowInTest {
     }
   }
 
-  @Test fun `new renderings are emitted on update`() {
+  @Test fun new_renderings_are_emitted_on_update() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -179,7 +179,7 @@ class RenderWorkflowInTest {
   private val runtimeMatrixTestRunner =
     ParameterizedTestRunner<Pair<RuntimeConfig, RuntimeConfig>>()
 
-  @Test fun `saves to and restores from snapshot`() {
+  @Test fun saves_to_and_restores_from_snapshot() {
     runtimeMatrixTestRunner.runParametrizedTest(
       paramSource = runtimeMatrix,
       before = ::setup,
@@ -241,7 +241,7 @@ class RenderWorkflowInTest {
   }
 
   // https://github.com/square/workflow-kotlin/issues/223
-  @Test fun `snapshots are lazy`() {
+  @Test fun snapshots_are_lazy() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -303,7 +303,7 @@ class RenderWorkflowInTest {
     }
   }
 
-  @Test fun `onOutput called when output emitted`() {
+  @Test fun onOutput_called_when_output_emitted() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -334,7 +334,7 @@ class RenderWorkflowInTest {
     }
   }
 
-  @Test fun `onOutput is not called when no output emitted`() {
+  @Test fun onOutput_is_not_called_when_no_output_emitted() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -366,7 +366,7 @@ class RenderWorkflowInTest {
    * doesn't implicitly cancel the scope. If it did, the reception would be reported twice: once to
    * the caller, and once to the scope.
    */
-  @Test fun `exception from initial render doesn't fail parent scope`() {
+  @Test fun exception_from_initial_render_does_not_fail_parent_scope() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -387,7 +387,7 @@ class RenderWorkflowInTest {
   }
 
   @Test
-  fun `side effects from initial rendering in root workflow are never started when initial render of root workflow fails`() {
+  fun side_effects_from_initial_rendering_in_root_workflow_are_never_started_when_initial_render_of_root_workflow_fails() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -413,7 +413,7 @@ class RenderWorkflowInTest {
   }
 
   @Test
-  fun `side effects from initial rendering in non-root workflow are cancelled when initial render of root workflow fails`() {
+  fun side_effects_from_initial_rendering_in_non_root_workflow_are_cancelled_when_initial_render_of_root_workflow_fails() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -450,7 +450,7 @@ class RenderWorkflowInTest {
   }
 
   @Test
-  fun `side effects from initial rendering in non-root workflow are never started when initial render of non-root workflow fails`() {
+  fun side_effects_from_initial_rendering_in_non_root_workflow_are_never_started_when_initial_render_of_non_root_workflow_fails() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -478,7 +478,7 @@ class RenderWorkflowInTest {
     }
   }
 
-  @Test fun `exception from non-initial render fails parent scope`() {
+  @Test fun exception_from_non_initial_render_fails_parent_scope() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -511,7 +511,7 @@ class RenderWorkflowInTest {
     }
   }
 
-  @Test fun `exception from action fails parent scope`() {
+  @Test fun exception_from_action_fails_parent_scope() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -539,7 +539,7 @@ class RenderWorkflowInTest {
     }
   }
 
-  @Test fun `cancelling scope cancels runtime`() {
+  @Test fun cancelling_scope_cancels_runtime() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -567,7 +567,7 @@ class RenderWorkflowInTest {
     }
   }
 
-  @Test fun `cancelling scope in action cancels runtime and does not render again`() {
+  @Test fun cancelling_scope_in_action_cancels_runtime_and_does_not_render_again() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -602,7 +602,7 @@ class RenderWorkflowInTest {
     }
   }
 
-  @Test fun `failing scope cancels runtime`() {
+  @Test fun failing_scope_cancels_runtime() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -630,7 +630,7 @@ class RenderWorkflowInTest {
     }
   }
 
-  @Test fun `error from renderings collector doesn't fail parent scope`() {
+  @Test fun error_from_renderings_collector_does_not_fail_parent_scope() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -654,7 +654,7 @@ class RenderWorkflowInTest {
     }
   }
 
-  @Test fun `error from renderings collector cancels runtime`() {
+  @Test fun error_from_renderings_collector_cancels_runtime() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -687,7 +687,7 @@ class RenderWorkflowInTest {
     }
   }
 
-  @Test fun `exception from onOutput fails parent scope`() {
+  @Test fun exception_from_onOutput_fails_parent_scope() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -715,7 +715,7 @@ class RenderWorkflowInTest {
     }
   }
 
-  @Test fun `output is emitted before next render pass`() {
+  @Test fun output_is_emitted_before_next_render_pass() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -762,7 +762,7 @@ class RenderWorkflowInTest {
   }
 
   // https://github.com/square/workflow-kotlin/issues/224
-  @Test fun `exceptions from Snapshots don't fail runtime`() {
+  @Test fun exceptions_from_Snapshots_do_not_fail_runtime() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -799,7 +799,7 @@ class RenderWorkflowInTest {
   }
 
   // https://github.com/square/workflow-kotlin/issues/224
-  @Test fun `exceptions from renderings' equals methods don't fail runtime`() {
+  @Test fun exceptions_from_renderings_equals_methods_do_not_fail_runtime() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -842,7 +842,7 @@ class RenderWorkflowInTest {
   }
 
   // https://github.com/square/workflow-kotlin/issues/224
-  @Test fun `exceptions from renderings' hashCode methods don't fail runtime`() {
+  @Test fun exceptions_from_renderings_hashCode_methods_do_not_fail_runtime() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderingAndSnapshotTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderingAndSnapshotTest.kt
@@ -13,7 +13,7 @@ class RenderingAndSnapshotTest {
     assertSame(t, snapshot)
   }
 
-  @Test fun `identity equality`() {
+  @Test fun identity_equality() {
     val snapshot = TreeSnapshot(Snapshot.of(0)) { emptyMap() }
     val me = RenderingAndSnapshot("Rendering", snapshot)
     val you = RenderingAndSnapshot("Rendering", snapshot)

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/SimpleLoggingWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/SimpleLoggingWorkflowInterceptorTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.fail
 
 internal class SimpleLoggingWorkflowInterceptorTest {
 
-  @Test fun `onSessionStarted handles logging exceptions`() {
+  @Test fun onSessionStarted_handles_logging_exceptions() {
     val interceptor = ErrorLoggingInterceptor()
     val scope = CoroutineScope(EmptyCoroutineContext)
     interceptor.onSessionStarted(scope, TestWorkflowSession)
@@ -20,21 +20,21 @@ internal class SimpleLoggingWorkflowInterceptorTest {
     assertEquals(ErrorLoggingInterceptor.EXPECTED_ERRORS, interceptor.errors)
   }
 
-  @Test fun `onInitialState handles logging exceptions`() {
+  @Test fun onInitialState_handles_logging_exceptions() {
     val interceptor = ErrorLoggingInterceptor()
     interceptor.onInitialState(Unit, null, { _, _ -> }, TestWorkflowSession)
 
     assertEquals(ErrorLoggingInterceptor.EXPECTED_ERRORS, interceptor.errors)
   }
 
-  @Test fun `onPropsChanged handles logging exceptions`() {
+  @Test fun onPropsChanged_handles_logging_exceptions() {
     val interceptor = ErrorLoggingInterceptor()
     interceptor.onPropsChanged(Unit, Unit, Unit, { _, _, _ -> }, TestWorkflowSession)
 
     assertEquals(ErrorLoggingInterceptor.EXPECTED_ERRORS, interceptor.errors)
   }
 
-  @Test fun `onRender handles logging exceptions`() {
+  @Test fun onRender_handles_logging_exceptions() {
     val interceptor = ErrorLoggingInterceptor()
 
     interceptor.onRender<Unit, Unit, Nothing, Any>(
@@ -48,7 +48,7 @@ internal class SimpleLoggingWorkflowInterceptorTest {
     assertEquals(ErrorLoggingInterceptor.EXPECTED_ERRORS, interceptor.errors)
   }
 
-  @Test fun `onSnapshotState handles logging exceptions`() {
+  @Test fun onSnapshotState_handles_logging_exceptions() {
     val interceptor = ErrorLoggingInterceptor()
     interceptor.onSnapshotState(Unit, { null }, TestWorkflowSession)
 

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/SimpleLoggingWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/SimpleLoggingWorkflowInterceptorTest.kt
@@ -55,27 +55,6 @@ internal class SimpleLoggingWorkflowInterceptorTest {
     assertEquals(ErrorLoggingInterceptor.EXPECTED_ERRORS, interceptor.errors)
   }
 
-  private open class ErrorLoggingInterceptor : SimpleLoggingWorkflowInterceptor() {
-    val errors = mutableListOf<String>()
-
-    override fun log(text: String) {
-      throw IllegalArgumentException()
-    }
-
-    override fun logError(text: String) {
-      errors += text
-    }
-
-    companion object {
-      val EXPECTED_ERRORS = listOf(
-        "ErrorLoggingInterceptor.logBeforeMethod threw exception:\n" +
-          IllegalArgumentException::class.qualifiedName.toString(),
-        "ErrorLoggingInterceptor.logAfterMethod threw exception:\n" +
-          IllegalArgumentException::class.qualifiedName.toString()
-      )
-    }
-  }
-
   private object TestWorkflowSession : WorkflowSession {
     @OptIn(ExperimentalStdlibApi::class)
     override val identifier: WorkflowIdentifier = unsnapshottableIdentifier(typeOf<Unit>())

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/TreeSnapshotTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/TreeSnapshotTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.fail
 @OptIn(ExperimentalStdlibApi::class)
 internal class TreeSnapshotTest {
 
-  @Test fun `overrides equals`() {
+  @Test fun overrides_equals() {
     val snapshot1 = TreeSnapshot(
       workflowSnapshot = Snapshot.of("foo"),
       childTreeSnapshots = {
@@ -29,7 +29,7 @@ internal class TreeSnapshotTest {
     assertEquals(snapshot1, snapshot2)
   }
 
-  @Test fun `serialize and deserialize`() {
+  @Test fun serialize_and_deserialize() {
     val rootSnapshot = Snapshot.of("roo")
     val id1 = WorkflowNodeId(Workflow1)
     val id2 = WorkflowNodeId(Workflow2)
@@ -59,7 +59,7 @@ internal class TreeSnapshotTest {
     )
   }
 
-  @Test fun `serialize handles single unsnapshottable identifier`() {
+  @Test fun serialize_handles_single_unsnapshottable_identifier() {
     val rootSnapshot = Snapshot.of("roo")
     val id = WorkflowNodeId(UnsnapshottableWorkflow1)
     val childSnapshots = mapOf(id to TreeSnapshot.forRootOnly(Snapshot.of("one")))
@@ -71,7 +71,7 @@ internal class TreeSnapshotTest {
     assertTrue(treeSnapshot.childTreeSnapshots.isEmpty())
   }
 
-  @Test fun `serialize drops unsnapshottable identifiers`() {
+  @Test fun serialize_drops_unsnapshottable_identifiers() {
     val rootSnapshot = Snapshot.of("roo")
     val id1 = WorkflowNodeId(Workflow1)
     val id2 = WorkflowNodeId(UnsnapshottableWorkflow1)
@@ -101,7 +101,7 @@ internal class TreeSnapshotTest {
     )
   }
 
-  @Test fun `empty root is converted to null`() {
+  @Test fun empty_root_is_converted_to_null() {
     val rootSnapshot = Snapshot.of(ByteString.EMPTY)
     val treeSnapshot = TreeSnapshot(rootSnapshot, ::emptyMap)
 

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
@@ -21,7 +21,7 @@ import kotlin.test.fail
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class WorkflowInterceptorTest {
 
-  @Test fun `intercept returns workflow when Noop`() {
+  @Test fun intercept_returns_workflow_when_Noop() {
     val interceptor = NoopWorkflowInterceptor
     val workflow = Workflow.rendering("hello")
       .asStatefulWorkflow()
@@ -29,7 +29,7 @@ internal class WorkflowInterceptorTest {
     assertSame(workflow, intercepted)
   }
 
-  @Test fun `intercept intercepts calls to initialState`() {
+  @Test fun intercept_intercepts_calls_to_initialState() {
     val recorder = RecordingWorkflowInterceptor()
     val intercepted = recorder.intercept(TestWorkflow, TestWorkflow.session)
 
@@ -39,7 +39,7 @@ internal class WorkflowInterceptorTest {
     assertEquals(listOf("BEGIN|onInitialState", "END|onInitialState"), recorder.consumeEventNames())
   }
 
-  @Test fun `intercept intercepts calls to onPropsChanged`() {
+  @Test fun intercept_intercepts_calls_to_onPropsChanged() {
     val recorder = RecordingWorkflowInterceptor()
     val intercepted = recorder.intercept(TestWorkflow, TestWorkflow.session)
 
@@ -49,7 +49,7 @@ internal class WorkflowInterceptorTest {
     assertEquals(listOf("BEGIN|onPropsChanged", "END|onPropsChanged"), recorder.consumeEventNames())
   }
 
-  @Test fun `intercept intercepts calls to render`() {
+  @Test fun intercept_intercepts_calls_to_render() {
     val recorder = RecordingWorkflowInterceptor()
     val intercepted = recorder.intercept(TestWorkflow, TestWorkflow.session)
     val fakeContext = object : BaseRenderContext<String, String, String> {
@@ -74,7 +74,7 @@ internal class WorkflowInterceptorTest {
     assertEquals(listOf("BEGIN|onRender", "END|onRender"), recorder.consumeEventNames())
   }
 
-  @Test fun `intercept intercepts calls to snapshotState`() {
+  @Test fun intercept_intercepts_calls_to_snapshotState() {
     val recorder = RecordingWorkflowInterceptor()
     val intercepted = recorder.intercept(TestWorkflow, TestWorkflow.session)
 
@@ -86,7 +86,7 @@ internal class WorkflowInterceptorTest {
     )
   }
 
-  @Test fun `intercept intercepts calls to actionSink send`() {
+  @Test fun intercept_intercepts_calls_to_actionSink_send() {
     val recorder = RecordingWorkflowInterceptor()
     val intercepted = recorder.intercept(TestActionWorkflow, TestActionWorkflow.session)
     val actions = mutableListOf<WorkflowAction<String, String, String>>()
@@ -121,7 +121,7 @@ internal class WorkflowInterceptorTest {
     )
   }
 
-  @Test fun `intercept intercepts side effects`() {
+  @Test fun intercept_intercepts_side_effects() {
     val recorder = RecordingWorkflowInterceptor()
     val workflow = TestSideEffectWorkflow()
     val intercepted = recorder.intercept(workflow, workflow.session)
@@ -156,7 +156,7 @@ internal class WorkflowInterceptorTest {
     )
   }
 
-  @Test fun `intercept uses interceptor's context for side effect`() {
+  @Test fun intercept_uses_interceptors_context_for_side_effect() {
     val recorder = object : RecordingWorkflowInterceptor() {
       override fun <P, S, O, R> onRender(
         renderProps: P,

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
@@ -7,8 +7,9 @@ import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.CoroutineContext.Key
 import kotlin.test.Test
@@ -121,7 +122,7 @@ internal class WorkflowInterceptorTest {
     )
   }
 
-  @Test fun intercept_intercepts_side_effects() {
+  @Test fun intercept_intercepts_side_effects() = runTest {
     val recorder = RecordingWorkflowInterceptor()
     val workflow = TestSideEffectWorkflow()
     val intercepted = recorder.intercept(workflow, workflow.session)
@@ -139,7 +140,8 @@ internal class WorkflowInterceptorTest {
         key: String,
         sideEffect: suspend CoroutineScope.() -> Unit
       ) {
-        runBlocking { sideEffect() }
+        launch { sideEffect() }
+        advanceUntilIdle()
       }
     }
 
@@ -156,7 +158,7 @@ internal class WorkflowInterceptorTest {
     )
   }
 
-  @Test fun intercept_uses_interceptors_context_for_side_effect() {
+  @Test fun intercept_uses_interceptors_context_for_side_effect() = runTest {
     val recorder = object : RecordingWorkflowInterceptor() {
       override fun <P, S, O, R> onRender(
         renderProps: P,
@@ -198,7 +200,7 @@ internal class WorkflowInterceptorTest {
         key: String,
         sideEffect: suspend CoroutineScope.() -> Unit
       ) {
-        runBlocking { sideEffect() }
+        launch { sideEffect() }
       }
     }
 

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowOperatorsTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowOperatorsTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.fail
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalStdlibApi::class, FlowPreview::class)
 class WorkflowOperatorsTest {
 
-  @Test fun `mapRendering toString`() {
+  @Test fun mapRendering_toString() {
     val workflow = object : StatelessWorkflow<Unit, Nothing, Nothing>() {
       override fun toString(): String = "ChildWorkflow"
       override fun render(
@@ -32,7 +32,7 @@ class WorkflowOperatorsTest {
     assertEquals("ChildWorkflow.mapRendering()", mappedWorkflow.toString())
   }
 
-  @Test fun `mapRendering transforms rendering`() {
+  @Test fun mapRendering_transforms_rendering() {
     val trigger = MutableStateFlow("initial")
     val childWorkflow = object : StateFlowWorkflow<String>("child", trigger) {}
     val mappedWorkflow = childWorkflow.mapRendering { "mapped: $it" }
@@ -55,7 +55,7 @@ class WorkflowOperatorsTest {
     }
   }
 
-  @Test fun `mapRendering on two different upstream workflows both render`() {
+  @Test fun mapRendering_on_two_different_upstream_workflows_both_render() {
     val trigger1 = MutableStateFlow("initial1")
     val trigger2 = MutableStateFlow("initial2")
     val child1 = object : StateFlowWorkflow<String>("child1", trigger1) {}
@@ -103,7 +103,7 @@ class WorkflowOperatorsTest {
     }
   }
 
-  @Test fun `mapRendering with upstream workflow both render`() {
+  @Test fun mapRendering_with_upstream_workflow_both_render() {
     val trigger1 = MutableStateFlow("initial1")
     val trigger2 = MutableStateFlow("initial2")
     val child1 = object : StateFlowWorkflow<String>("child1", trigger1) {}
@@ -152,7 +152,7 @@ class WorkflowOperatorsTest {
   }
 
   @Test
-  fun `mapRendering with same upstream workflow in two different passes doesn't restart`() {
+  fun mapRendering_with_same_upstream_workflow_in_two_different_passes_does_not_restart() {
     val trigger = MutableStateFlow("initial")
     val childWorkflow = object : StateFlowWorkflow<String>("child", trigger) {}
     val parentWorkflow = Workflow.stateless<Int, Nothing, String> { props ->

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ActiveStagingListTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ActiveStagingListTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.fail
 
 internal class ActiveStagingListTest {
 
-  @Test fun `retainOrCreate on empty list creates new item`() {
+  @Test fun retainOrCreate_on_empty_list_creates_new_item() {
     val list = ActiveStagingList<Node>()
 
     list.retainOrCreate(predicate = { true }, create = { Node("foo") })
@@ -16,7 +16,7 @@ internal class ActiveStagingListTest {
     assertEquals(emptyList(), list.active())
   }
 
-  @Test fun `retainOrCreate with matching predicate moves item`() {
+  @Test fun retainOrCreate_with_matching_predicate_moves_item() {
     val list = ActiveStagingList<Node>()
     list.retainOrCreate(predicate = { true }, create = { Node("foo") })
     list.commitStaging { /* Noop */ }
@@ -27,7 +27,7 @@ internal class ActiveStagingListTest {
     assertEquals(emptyList(), list.active())
   }
 
-  @Test fun `retainOrCreate with no matching predicate creates item`() {
+  @Test fun retainOrCreate_with_no_matching_predicate_creates_item() {
     val list = ActiveStagingList<Node>()
     list.retainOrCreate(predicate = { true }, create = { Node("foo") })
     list.commitStaging { /* Noop */ }
@@ -38,13 +38,13 @@ internal class ActiveStagingListTest {
     assertEquals(listOf("foo"), list.active())
   }
 
-  @Test fun `commitStaging on empty lists`() {
+  @Test fun commitStaging_on_empty_lists() {
     val list = ActiveStagingList<Node>()
 
     list.commitStaging { /* Noop */ }
   }
 
-  @Test fun `commitStaging processes inactive items`() {
+  @Test fun commitStaging_processes_inactive_items() {
     val discardedItems = mutableListOf<String>()
     val list = ActiveStagingList<Node>()
     list.retainOrCreate(predicate = { false }, create = { Node("foo") })

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
@@ -18,6 +18,8 @@ import com.squareup.workflow1.rendering
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -54,7 +56,7 @@ internal class ChainedWorkflowInterceptorTest {
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
-  @Test fun chains_calls_to_onInstanceStarted_in_left_to_right_order() {
+  @Test fun chains_calls_to_onInstanceStarted_in_left_to_right_order() = runTest {
     val events = mutableListOf<String>()
     val interceptor1 = object : WorkflowInterceptor {
       override fun onSessionStarted(
@@ -80,9 +82,10 @@ internal class ChainedWorkflowInterceptorTest {
     }
     val chained = listOf(interceptor1, interceptor2).chained()
 
-    runTest {
+    launch {
       chained.onSessionStarted(this, TestSession)
     }
+    advanceUntilIdle()
 
     assertEquals(listOf("started1", "started2", "cancelled1", "cancelled2"), events)
   }

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
@@ -31,20 +31,20 @@ import kotlin.test.fail
  */
 internal class ChainedWorkflowInterceptorTest {
 
-  @Test fun `chained() returns Noop when list is empty`() {
+  @Test fun chained_returns_Noop_when_list_is_empty() {
     val list = emptyList<WorkflowInterceptor>()
     val chained = list.chained()
     assertSame(NoopWorkflowInterceptor, chained)
   }
 
-  @Test fun `chained() returns single element when list size is 1`() {
+  @Test fun chained_returns_single_element_when_list_size_is_1() {
     val interceptor = object : WorkflowInterceptor {}
     val list = listOf(interceptor)
     val chained = list.chained()
     assertSame(interceptor, chained)
   }
 
-  @Test fun `chained() returns chained element when list size is 2`() {
+  @Test fun chained_returns_chained_element_when_list_size_is_2() {
     val list = listOf(
       object : WorkflowInterceptor {},
       object : WorkflowInterceptor {}
@@ -54,7 +54,7 @@ internal class ChainedWorkflowInterceptorTest {
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
-  @Test fun `chains calls to onInstanceStarted() in left-to-right order`() {
+  @Test fun chains_calls_to_onInstanceStarted_in_left_to_right_order() {
     val events = mutableListOf<String>()
     val interceptor1 = object : WorkflowInterceptor {
       override fun onSessionStarted(
@@ -87,7 +87,7 @@ internal class ChainedWorkflowInterceptorTest {
     assertEquals(listOf("started1", "started2", "cancelled1", "cancelled2"), events)
   }
 
-  @Test fun `chains calls to onInitialState() in left-to-right order`() {
+  @Test fun chains_calls_to_onInitialState_in_left_to_right_order() {
     val interceptor1 = object : WorkflowInterceptor {
       override fun <P, S> onInitialState(
         props: P,
@@ -128,7 +128,7 @@ internal class ChainedWorkflowInterceptorTest {
     assertEquals("r1: r2: (props2: props1: props|snap2: snap1: snap)", finalState)
   }
 
-  @Test fun `chains calls to onPropsChanged() in left-to-right order`() {
+  @Test fun chains_calls_to_onPropsChanged_in_left_to_right_order() {
     val interceptor1 = object : WorkflowInterceptor {
       override fun <P, S> onPropsChanged(
         old: P,
@@ -173,7 +173,7 @@ internal class ChainedWorkflowInterceptorTest {
     assertEquals("s1: s2: (old2: old1: old|new2: new1: new|state2: state1: state)", finalState)
   }
 
-  @Test fun `chains calls to onRender() in left-to-right order`() {
+  @Test fun chains_calls_to_onRender_in_left_to_right_order() {
     val interceptor1 = object : WorkflowInterceptor {
       override fun <P, S, O, R> onRender(
         renderProps: P,
@@ -205,7 +205,7 @@ internal class ChainedWorkflowInterceptorTest {
     )
   }
 
-  @Test fun `chains calls with RenderContextInterceptor in left-to-right order`() {
+  @Test fun chains_calls_with_RenderContextInterceptor_in_left_to_right_order() {
     val transcript = mutableListOf<String>()
 
     class Labeler<P, S, O>(val label: String) : RenderContextInterceptor<P, S, O> {
@@ -269,7 +269,7 @@ internal class ChainedWorkflowInterceptorTest {
     assertEquals("START uno, START dos, END dos, END uno", transcript.joinToString(", "))
   }
 
-  @Test fun `chains calls to onSnapshotState() in left-to-right order`() {
+  @Test fun chains_calls_to_onSnapshotState_in_left_to_right_order() {
     val interceptor1 = object : WorkflowInterceptor {
       override fun <S> onSnapshotState(
         state: S,

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/InlineLinkedListTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/InlineLinkedListTest.kt
@@ -7,14 +7,14 @@ import kotlin.test.assertNull
 
 internal class InlineLinkedListTest {
 
-  @Test fun `forEach empty list`() {
+  @Test fun forEach_empty_list() {
     val list = InlineLinkedList<StringElement>()
     var count = 0
     list.forEach { count++ }
     assertEquals(0, count)
   }
 
-  @Test fun `plusAssign on empty list`() {
+  @Test fun plusAssign_on_empty_list() {
     val list = InlineLinkedList<StringElement>()
 
     list += StringElement("foo")
@@ -22,7 +22,7 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("foo"), list.toList())
   }
 
-  @Test fun `removeFirst on empty list`() {
+  @Test fun removeFirst_on_empty_list() {
     val list = InlineLinkedList<StringElement>()
 
     list.removeFirst { true }
@@ -30,7 +30,7 @@ internal class InlineLinkedListTest {
     assertEquals(emptyList(), list.toList())
   }
 
-  @Test fun `removeFirst on single-item list`() {
+  @Test fun removeFirst_on_single_item_list() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
 
@@ -39,7 +39,7 @@ internal class InlineLinkedListTest {
     assertEquals(emptyList(), list.toList())
   }
 
-  @Test fun `removeFirst head on list with 2 items`() {
+  @Test fun removeFirst_head_on_list_with_2_items() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list += StringElement("bar")
@@ -49,7 +49,7 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("bar"), list.toList())
   }
 
-  @Test fun `removeFirst tail on list with 2 items`() {
+  @Test fun removeFirst_tail_on_list_with_2_items() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list += StringElement("bar")
@@ -59,7 +59,7 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("foo"), list.toList())
   }
 
-  @Test fun `removeFirst head on list with 3 items`() {
+  @Test fun removeFirst_head_on_list_with_3_items() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list += StringElement("bar")
@@ -70,7 +70,7 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("bar", "baz"), list.toList())
   }
 
-  @Test fun `removeFirst middle on list with 3 items`() {
+  @Test fun removeFirst_middle_on_list_with_3_items() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list += StringElement("bar")
@@ -81,7 +81,7 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("foo", "baz"), list.toList())
   }
 
-  @Test fun `removeFirst tail on list with 3 items`() {
+  @Test fun removeFirst_tail_on_list_with_3_items() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list += StringElement("bar")
@@ -92,7 +92,7 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("foo", "bar"), list.toList())
   }
 
-  @Test fun `removeFirst when multiple matches`() {
+  @Test fun removeFirst_when_multiple_matches() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list += StringElement("foo")
@@ -103,7 +103,7 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("foo", "bar"), list.toList())
   }
 
-  @Test fun `removeFirst when no matches`() {
+  @Test fun removeFirst_when_no_matches() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list += StringElement("bar")
@@ -113,7 +113,7 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("foo", "bar"), list.toList())
   }
 
-  @Test fun `plusAssign on non-empty list`() {
+  @Test fun plusAssign_on_non_empty_list() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
 
@@ -122,7 +122,7 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("foo", "bar"), list.toList())
   }
 
-  @Test fun `plusAssign after remove head with 2 items`() {
+  @Test fun plusAssign_after_remove_head_with_2_items() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list += StringElement("bar")
@@ -133,7 +133,7 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("bar", "buzz"), list.toList())
   }
 
-  @Test fun `plusAssign after remove tail with 2 items`() {
+  @Test fun plusAssign_after_remove_tail_with_2_items() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list += StringElement("bar")
@@ -144,7 +144,7 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("foo", "buzz"), list.toList())
   }
 
-  @Test fun `plusAssign after remove head with 3 items`() {
+  @Test fun plusAssign_after_remove_head_with_3_items() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list += StringElement("bar")
@@ -156,7 +156,7 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("bar", "baz", "buzz"), list.toList())
   }
 
-  @Test fun `plusAssign after remove middle with 3 items`() {
+  @Test fun plusAssign_after_remove_middle_with_3_items() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list += StringElement("bar")
@@ -168,7 +168,7 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("foo", "baz", "buzz"), list.toList())
   }
 
-  @Test fun `plusAssign after remove tail with 3 items`() {
+  @Test fun plusAssign_after_remove_tail_with_3_items() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list += StringElement("bar")
@@ -180,20 +180,20 @@ internal class InlineLinkedListTest {
     assertEquals(listOf("foo", "bar", "buzz"), list.toList())
   }
 
-  @Test fun `clear empty list`() {
+  @Test fun clear_empty_list() {
     val list = InlineLinkedList<StringElement>()
     list.clear()
     assertEquals(emptyList(), list.toList())
   }
 
-  @Test fun `clear single-item list`() {
+  @Test fun clear_single_item_list() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list.clear()
     assertEquals(emptyList(), list.toList())
   }
 
-  @Test fun `clear multi-item list`() {
+  @Test fun clear_multi_item_list() {
     val list = InlineLinkedList<StringElement>()
     list += StringElement("foo")
     list += StringElement("bar")

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/RealRenderContextTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/RealRenderContextTest.kt
@@ -96,7 +96,7 @@ internal class RealRenderContextTest {
   private val eventActionsChannel =
     Channel<WorkflowAction<String, String, String>>(capacity = UNLIMITED)
 
-  @Test fun `send completes update`() {
+  @Test fun send_completes_update() {
     val context = createdPoisonedContext()
     val stringAction = action<String, String, String>({ "stringAction" }) { }
 
@@ -112,7 +112,7 @@ internal class RealRenderContextTest {
     assertSame(stringAction, actualAction)
   }
 
-  @Test fun `send allows multiple sends`() {
+  @Test fun send_allows_multiple_sends() {
     val context = createdPoisonedContext()
     val firstAction = object : WorkflowAction<String, String, String>() {
       override fun Updater.apply() = Unit
@@ -131,7 +131,7 @@ internal class RealRenderContextTest {
     context.actionSink.send(secondAction)
   }
 
-  @Test fun `send throws before render returns`() {
+  @Test fun send_throws_before_render_returns() {
     val context = createdPoisonedContext()
     val action = object : WorkflowAction<String, String, String>() {
       override fun Updater.apply() = Unit
@@ -147,7 +147,7 @@ internal class RealRenderContextTest {
     )
   }
 
-  @Test fun `eventHandler0 gets event`() {
+  @Test fun eventHandler0_gets_event() {
     val context = createdPoisonedContext()
     val sink: () -> Unit = context.eventHandler { setOutput("yay") }
     // Enable sink sends.
@@ -161,7 +161,7 @@ internal class RealRenderContextTest {
     assertEquals("yay", output?.value)
   }
 
-  @Test fun `eventHandler1 gets event`() {
+  @Test fun eventHandler1_gets_event() {
     val context = createdPoisonedContext()
     val sink = context.eventHandler { it: String -> setOutput(it) }
     // Enable sink sends.
@@ -175,7 +175,7 @@ internal class RealRenderContextTest {
     assertEquals("foo", output?.value)
   }
 
-  @Test fun `eventHandler2 gets event`() {
+  @Test fun eventHandler2_gets_event() {
     val context = createdPoisonedContext()
     val sink = context.eventHandler { a: String, b: String -> setOutput(a + b) }
     // Enable sink sends.
@@ -189,7 +189,7 @@ internal class RealRenderContextTest {
     assertEquals("foobar", output?.value)
   }
 
-  @Test fun `eventHandler3 gets event`() {
+  @Test fun eventHandler3_gets_event() {
     val context = createdPoisonedContext()
     val sink = context.eventHandler { a: String, b: String, c: String, d: String ->
       setOutput(a + b + c + d)
@@ -205,7 +205,7 @@ internal class RealRenderContextTest {
     assertEquals("foobarbazbang", output?.value)
   }
 
-  @Test fun `eventHandler4 gets event`() {
+  @Test fun eventHandler4_gets_event() {
     val context = createdPoisonedContext()
     val sink = context.eventHandler { a: String, b: String, c: String, d: String ->
       setOutput(a + b + c + d)
@@ -221,7 +221,7 @@ internal class RealRenderContextTest {
     assertEquals("foobarbazbang", output?.value)
   }
 
-  @Test fun `eventHandler5 gets event`() {
+  @Test fun eventHandler5_gets_event() {
     val context = createdPoisonedContext()
     val sink = context.eventHandler { a: String, b: String, c: String, d: String, e: String ->
       setOutput(a + b + c + d + e)
@@ -237,7 +237,7 @@ internal class RealRenderContextTest {
     assertEquals("foobarbazbangbuzz", output?.value)
   }
 
-  @Test fun `eventHandler6 gets event`() {
+  @Test fun eventHandler6_gets_event() {
     val context = createdPoisonedContext()
     val sink =
       context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String ->
@@ -254,7 +254,7 @@ internal class RealRenderContextTest {
     assertEquals("foobarbazbangbuzzqux", output?.value)
   }
 
-  @Test fun `eventHandler7 gets event`() {
+  @Test fun eventHandler7_gets_event() {
     val context = createdPoisonedContext()
     val sink =
       context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String,
@@ -272,7 +272,7 @@ internal class RealRenderContextTest {
     assertEquals("foobarbazbangbuzzquxcorge", output?.value)
   }
 
-  @Test fun `eventHandler8 gets event`() {
+  @Test fun eventHandler8_gets_event() {
     val context = createdPoisonedContext()
     val sink =
       context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String,
@@ -290,7 +290,7 @@ internal class RealRenderContextTest {
     assertEquals("foobarbazbangbuzzquxcorgefred", output?.value)
   }
 
-  @Test fun `eventHandler9 gets event`() {
+  @Test fun eventHandler9_gets_event() {
     val context = createdPoisonedContext()
     val sink =
       context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String,
@@ -308,7 +308,7 @@ internal class RealRenderContextTest {
     assertEquals("foobarbazbangbuzzquxcorgefredxyzzy", output?.value)
   }
 
-  @Test fun `eventHandler10 gets event`() {
+  @Test fun eventHandler10_gets_event() {
     val context = createdPoisonedContext()
     val sink =
       context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String,
@@ -326,7 +326,7 @@ internal class RealRenderContextTest {
     assertEquals("foobarbazbangbuzzquxcorgefredxyzzyplugh", output?.value)
   }
 
-  @Test fun `renderChild works`() {
+  @Test fun renderChild_works() {
     val context = createTestContext()
     val workflow = TestWorkflow()
 
@@ -344,7 +344,7 @@ internal class RealRenderContextTest {
     assertEquals("output:output", output?.value)
   }
 
-  @Test fun `all methods throw after freeze`() {
+  @Test fun all_methods_throw_after_freeze() {
     val context = createTestContext()
     context.freeze()
 

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/RealRenderContextTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/RealRenderContextTest.kt
@@ -14,6 +14,7 @@ import com.squareup.workflow1.internal.RealRenderContextTest.TestRenderer.Render
 import com.squareup.workflow1.renderChild
 import com.squareup.workflow1.stateless
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlin.test.Test
@@ -96,6 +97,7 @@ internal class RealRenderContextTest {
   private val eventActionsChannel =
     Channel<WorkflowAction<String, String, String>>(capacity = UNLIMITED)
 
+  @OptIn(ExperimentalCoroutinesApi::class)
   @Test fun send_completes_update() {
     val context = createdPoisonedContext()
     val stringAction = action<String, String, String>({ "stringAction" }) { }

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
@@ -90,7 +90,7 @@ internal class SubtreeManagerTest {
 
   private val context = Unconfined
 
-  @Test fun `render starts new child`() {
+  @Test fun render_starts_new_child() {
     val manager = subtreeManagerForTest<String, String, String>()
     val workflow = TestWorkflow()
 
@@ -98,7 +98,7 @@ internal class SubtreeManagerTest {
     assertEquals(1, workflow.started)
   }
 
-  @Test fun `render doesn't start existing child`() {
+  @Test fun render_does_not_start_existing_child() {
     val manager = subtreeManagerForTest<String, String, String>()
     val workflow = TestWorkflow()
     fun render() = manager.render(workflow, "props", key = "", handler = { fail() })
@@ -110,7 +110,7 @@ internal class SubtreeManagerTest {
     assertEquals(1, workflow.started)
   }
 
-  @Test fun `render restarts child after tearing down`() {
+  @Test fun render_restarts_child_after_tearing_down() {
     val manager = subtreeManagerForTest<String, String, String>()
     val workflow = TestWorkflow()
     fun render() = manager.render(workflow, "props", key = "", handler = { fail() })
@@ -126,7 +126,7 @@ internal class SubtreeManagerTest {
     assertEquals(2, workflow.started)
   }
 
-  @Test fun `render throws on duplicate key`() {
+  @Test fun render_throws_on_duplicate_key() {
     val manager = subtreeManagerForTest<String, String, String>()
     val workflow = TestWorkflow()
     manager.render(workflow, "props", "foo", handler = { fail() })
@@ -140,7 +140,7 @@ internal class SubtreeManagerTest {
     )
   }
 
-  @Test fun `render returns child rendering`() {
+  @Test fun render_returns_child_rendering() {
     val manager = subtreeManagerForTest<String, String, String>()
     val workflow = TestWorkflow()
 
@@ -151,7 +151,7 @@ internal class SubtreeManagerTest {
     assertEquals("initialState:props", composeState)
   }
 
-  @Test fun `tick children handles child output`() {
+  @Test fun tick_children_handles_child_output() {
     val manager = subtreeManagerForTest<String, String, String>()
     val workflow = TestWorkflow()
     val handler: StringHandler = { output ->
@@ -175,7 +175,7 @@ internal class SubtreeManagerTest {
     }
   }
 
-  @Test fun `render updates child's output handler`() {
+  @Test fun render_updates_childs_output_handler() {
     val manager = subtreeManagerForTest<String, String, String>()
     val workflow = TestWorkflow()
     fun render(handler: StringHandler) =
@@ -204,7 +204,7 @@ internal class SubtreeManagerTest {
   }
 
   // See https://github.com/square/workflow/issues/404
-  @Test fun `createChildSnapshot snapshots eagerly`() {
+  @Test fun createChildSnapshot_snapshots_eagerly() {
     val manager = subtreeManagerForTest<Unit, Unit, Nothing>()
     val workflow = SnapshotTestWorkflow()
     assertEquals(0, workflow.snapshots)
@@ -217,7 +217,7 @@ internal class SubtreeManagerTest {
   }
 
   // See https://github.com/square/workflow/issues/404
-  @Test fun `createChildSnapshot serializes lazily`() {
+  @Test fun createChildSnapshot_serializes_lazily() {
     val manager = subtreeManagerForTest<Unit, Unit, Nothing>()
     val workflow = SnapshotTestWorkflow()
     assertEquals(0, workflow.serializes)
@@ -233,7 +233,7 @@ internal class SubtreeManagerTest {
     assertEquals(1, workflow.serializes)
   }
 
-  @Test fun `snapshots applied on first render only`() {
+  @Test fun snapshots_applied_on_first_render_only() {
     val manager1 = subtreeManagerForTest<Unit, Unit, Nothing>()
     val workflowAble = SnapshotTestWorkflow()
     val workflowBaker = SnapshotTestWorkflow()

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -96,7 +96,7 @@ internal class WorkflowNodeTest {
     context.cancel()
   }
 
-  @Test fun `onPropsChanged is called when props change`() {
+  @Test fun onPropsChanged_is_called_when_props_change() {
     val oldAndNewProps = mutableListOf<Pair<String, String>>()
     val workflow = PropsRenderingWorkflow { old, new, state ->
       oldAndNewProps += old to new
@@ -109,7 +109,7 @@ internal class WorkflowNodeTest {
     assertEquals(listOf("old" to "new"), oldAndNewProps)
   }
 
-  @Test fun `onPropsChanged is not called when props are equal`() {
+  @Test fun onPropsChanged_is_not_called_when_props_are_equal() {
     val oldAndNewProps = mutableListOf<Pair<String, String>>()
     val workflow = PropsRenderingWorkflow { old, new, state ->
       oldAndNewProps += old to new
@@ -122,7 +122,7 @@ internal class WorkflowNodeTest {
     assertTrue(oldAndNewProps.isEmpty())
   }
 
-  @Test fun `props are rendered`() {
+  @Test fun props_are_rendered() {
     val workflow = PropsRenderingWorkflow { old, new, _ ->
       "$old->$new"
     }
@@ -149,7 +149,7 @@ internal class WorkflowNodeTest {
     )
   }
 
-  @Test fun `accepts event`() {
+  @Test fun accepts_event() {
     val workflow = object : StringEventWorkflow() {
       override fun initialState(
         props: String,
@@ -183,7 +183,7 @@ internal class WorkflowNodeTest {
     assertEquals("tick:event", result?.value)
   }
 
-  @Test fun `accepts events sent to stale renderings`() {
+  @Test fun accepts_events_sent_to_stale_renderings() {
     val workflow = object : StringEventWorkflow() {
       override fun initialState(
         props: String,
@@ -222,7 +222,7 @@ internal class WorkflowNodeTest {
     assertEquals(listOf("tick:event", "tick:event2"), result.map { it?.value })
   }
 
-  @Test fun `send allows subsequent events on same rendering`() {
+  @Test fun send_allows_subsequent_events_on_same_rendering() {
     lateinit var sink: Sink<WorkflowAction<String, String, String>>
     val workflow = object : StringWorkflow() {
       override fun initialState(
@@ -251,7 +251,7 @@ internal class WorkflowNodeTest {
     sink.send(action { setOutput("event2") })
   }
 
-  @Test fun `sideEffect is not started until after render completes`() {
+  @Test fun sideEffect_is_not_started_until_after_render_completes() {
     var started = false
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningSideEffect("key") {
@@ -270,7 +270,7 @@ internal class WorkflowNodeTest {
     }
   }
 
-  @Test fun `sideEffect coroutine is named`() {
+  @Test fun sideEffect_coroutine_is_named() {
     var contextFromWorker: CoroutineContext? = null
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningSideEffect("the key") {
@@ -290,7 +290,7 @@ internal class WorkflowNodeTest {
     )
   }
 
-  @Test fun `sideEffect can send to actionSink`() {
+  @Test fun sideEffect_can_send_to_actionSink() {
     val workflow = Workflow.stateless<Unit, String, Unit> {
       runningSideEffect("key") {
         actionSink.send(action { setOutput("result") })
@@ -314,7 +314,7 @@ internal class WorkflowNodeTest {
     assertEquals("result", result?.value)
   }
 
-  @Test fun `sideEffect is cancelled when stops being ran`() {
+  @Test fun sideEffect_is_cancelled_when_stops_being_ran() {
     val isRunning = MutableStateFlow(true)
     var cancellationException: Throwable? = null
     val workflow = Workflow.stateless<Boolean, Nothing, Unit> { props ->
@@ -343,7 +343,7 @@ internal class WorkflowNodeTest {
     }
   }
 
-  @Test fun `sideEffect is cancelled when workflow is torn down`() {
+  @Test fun sideEffect_is_cancelled_when_workflow_is_torn_down() {
     var cancellationException: Throwable? = null
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningSideEffect("key") {
@@ -367,7 +367,7 @@ internal class WorkflowNodeTest {
     }
   }
 
-  @Test fun `sideEffect with matching key lives across render passes`() {
+  @Test fun sideEffect_with_matching_key_lives_across_render_passes() {
     var renderPasses = 0
     var cancelled = false
     val workflow = Workflow.stateless<Int, Nothing, Unit> {
@@ -394,7 +394,7 @@ internal class WorkflowNodeTest {
     }
   }
 
-  @Test fun `sideEffect isn't restarted on next render pass after finishing`() {
+  @Test fun sideEffect_is_not_restarted_on_next_render_pass_after_finishing() {
     val seenProps = mutableListOf<Int>()
     var renderPasses = 0
     val workflow = Workflow.stateless<Int, Nothing, Unit> { props ->
@@ -419,7 +419,7 @@ internal class WorkflowNodeTest {
     }
   }
 
-  @Test fun `multiple sideEffects with same key throws`() {
+  @Test fun multiple_sideEffects_with_same_key_throws() {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningSideEffect("same") { fail() }
       runningSideEffect("same") { fail() }
@@ -435,7 +435,7 @@ internal class WorkflowNodeTest {
     assertEquals("Expected side effect keys to be unique: \"same\"", error.message)
   }
 
-  @Test fun `staggered sideEffects`() {
+  @Test fun staggered_sideEffects() {
     val events1 = mutableListOf<String>()
     val events2 = mutableListOf<String>()
     val events3 = mutableListOf<String>()
@@ -478,7 +478,7 @@ internal class WorkflowNodeTest {
     assertEquals(listOf("started", "cancelled"), events3)
   }
 
-  @Test fun `multiple sideEffects started in same pass are both launched`() {
+  @Test fun multiple_sideEffects_started_in_same_pass_are_both_launched() {
     var started1 = false
     var started2 = false
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
@@ -497,7 +497,7 @@ internal class WorkflowNodeTest {
     assertTrue(started2)
   }
 
-  @Test fun `snapshots non-empty without children`() {
+  @Test fun snapshots_non_empty_without_children() {
     val workflow = Workflow.stateful<String, String, Nothing, String>(
       initialState = { props, snapshot ->
         snapshot?.bytes?.parse {
@@ -535,7 +535,7 @@ internal class WorkflowNodeTest {
     assertEquals("initial props", restoredNode.render(workflow, "foo"))
   }
 
-  @Test fun `snapshots empty without children`() {
+  @Test fun snapshots_empty_without_children() {
     val workflow = Workflow.stateful<String, String, Nothing, String>(
       initialState = { props, snapshot -> snapshot?.bytes?.utf8() ?: props },
       render = { _, state -> state },
@@ -564,7 +564,7 @@ internal class WorkflowNodeTest {
     assertEquals("restored", restoredNode.render(workflow, "foo"))
   }
 
-  @Test fun `snapshots non-empty with children`() {
+  @Test fun snapshots_non_empty_with_children() {
     var restoredChildState: String? = null
     var restoredParentState: String? = null
     val childWorkflow = Workflow.stateful<String, String, Nothing, String>(
@@ -623,7 +623,7 @@ internal class WorkflowNodeTest {
     assertEquals("initial props", restoredParentState)
   }
 
-  @Test fun `snapshot counts`() {
+  @Test fun snapshot_counts() {
     var snapshotCalls = 0
     var restoreCalls = 0
     // Track the number of times the snapshot is actually serialized, not snapshotState is called.
@@ -666,7 +666,7 @@ internal class WorkflowNodeTest {
     assertEquals(1, restoreCalls)
   }
 
-  @Test fun `restore gets props`() {
+  @Test fun restore_gets_props() {
     val workflow = Workflow.stateful<String, String, Nothing, String>(
       initialState = { props, snapshot ->
         snapshot?.bytes?.parse {
@@ -700,7 +700,7 @@ internal class WorkflowNodeTest {
     assertEquals("props:new props|state:initial props", restoredNode.render(workflow, "foo"))
   }
 
-  @Test fun `toString() formats as WorkflowInstance without parent`() {
+  @Test fun toString_formats_as_WorkflowInstance_without_parent() {
     val workflow = Workflow.rendering(Unit)
     val node = WorkflowNode(
       id = workflow.id(key = "foo"),
@@ -718,7 +718,7 @@ internal class WorkflowNodeTest {
     )
   }
 
-  @Test fun `toString() formats as WorkflowInstance with parent`() {
+  @Test fun toString_formats_as_WorkflowInstance_with_parent() {
     val workflow = Workflow.rendering(Unit)
     val node = WorkflowNode(
       id = workflow.id(key = "foo"),
@@ -736,7 +736,7 @@ internal class WorkflowNodeTest {
     )
   }
 
-  @Test fun `interceptor handles scope start and cancellation`() {
+  @Test fun interceptor_handles_scope_start_and_cancellation() {
     lateinit var interceptedScope: CoroutineScope
     lateinit var interceptedSession: WorkflowSession
     lateinit var cancellationException: Throwable
@@ -774,7 +774,7 @@ internal class WorkflowNodeTest {
     assertSame(cause, cancellationException)
   }
 
-  @Test fun `interceptor handles initialState()`() {
+  @Test fun interceptor_handles_initialState() {
     lateinit var interceptedProps: String
     lateinit var interceptedSnapshot: Snapshot
     lateinit var interceptedState: String
@@ -816,7 +816,7 @@ internal class WorkflowNodeTest {
     assertEquals(42, interceptedSession.parent!!.sessionId)
   }
 
-  @Test fun `interceptor handles onPropsChanged()`() {
+  @Test fun interceptor_handles_onPropsChanged() {
     lateinit var interceptedOld: String
     lateinit var interceptedNew: String
     lateinit var interceptedState: String
@@ -865,7 +865,7 @@ internal class WorkflowNodeTest {
     assertEquals(42, interceptedSession.parent!!.sessionId)
   }
 
-  @Test fun `interceptor handles render()`() {
+  @Test fun interceptor_handles_render() {
     lateinit var interceptedProps: String
     lateinit var interceptedState: String
     lateinit var interceptedRendering: String
@@ -910,7 +910,7 @@ internal class WorkflowNodeTest {
     assertEquals(42, interceptedSession.parent!!.sessionId)
   }
 
-  @Test fun `interceptor handles snapshotState()`() {
+  @Test fun interceptor_handles_snapshotState() {
     lateinit var interceptedState: String
     var interceptedSnapshot: Snapshot? = null
     lateinit var interceptedSession: WorkflowSession
@@ -951,7 +951,7 @@ internal class WorkflowNodeTest {
     assertEquals(42, interceptedSession.parent!!.sessionId)
   }
 
-  @Test fun `interceptor handles snapshotState() returning null`() {
+  @Test fun interceptor_handles_snapshotState_returning_null() {
     lateinit var interceptedState: String
     var interceptedSnapshot: Snapshot? = null
     lateinit var interceptedSession: WorkflowSession
@@ -992,7 +992,7 @@ internal class WorkflowNodeTest {
     assertEquals(42, interceptedSession.parent!!.sessionId)
   }
 
-  @Test fun `interceptor is propagated to children`() {
+  @Test fun interceptor_is_propagated_to_children() {
     val interceptor = object : WorkflowInterceptor {
       @Suppress("UNCHECKED_CAST")
       override fun <P, S, O, R> onRender(
@@ -1028,7 +1028,7 @@ internal class WorkflowNodeTest {
     assertEquals("[root([leaf([[props]], [[props]])])]", rendering)
   }
 
-  @Test fun `eventSink send fails before render pass completed`() {
+  @Test fun eventSink_send_fails_before_render_pass_completed() {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       val sink = eventHandler { _: String -> fail("Expected handler to fail.") }
       sink("Foo")
@@ -1052,7 +1052,7 @@ internal class WorkflowNodeTest {
     )
   }
 
-  @Test fun `send fails before render pass completed`() {
+  @Test fun send_fails_before_render_pass_completed() {
     class TestAction : WorkflowAction<Unit, Nothing, Nothing>() {
       override fun Updater.apply() = fail("Expected sink send to fail.")
       override fun toString(): String = "TestAction()"
@@ -1079,7 +1079,7 @@ internal class WorkflowNodeTest {
     )
   }
 
-  @Test fun `actionSink action changes state`() {
+  @Test fun actionSink_action_changes_state() {
     val workflow = Workflow.stateful<Unit, String, Nothing, Pair<String, Sink<String>>>(
       initialState = { "initial" },
       render = { _, renderState ->
@@ -1109,7 +1109,7 @@ internal class WorkflowNodeTest {
     assertEquals("initial->hello", state)
   }
 
-  @Test fun `actionSink action emits output`() {
+  @Test fun actionSink_action_emits_output() {
     val workflow = Workflow.stateless<Unit, String, Sink<String>> {
       actionSink.contraMap { action { setOutput(it) } }
     }
@@ -1134,7 +1134,7 @@ internal class WorkflowNodeTest {
     assertEquals("output:hello", output?.value)
   }
 
-  @Test fun `actionSink action allows null output`() {
+  @Test fun actionSink_action_allows_null_output() {
     val workflow = Workflow.stateless<Unit, String?, Sink<String?>> {
       actionSink.contraMap { action { setOutput(null) } }
     }
@@ -1159,7 +1159,7 @@ internal class WorkflowNodeTest {
     assertNull(output?.value)
   }
 
-  @Test fun `child action changes state`() {
+  @Test fun child_action_changes_state() {
     val workflow = Workflow.stateful<Unit, String, Nothing, String>(
       initialState = { "initial" },
       render = { _, renderState ->
@@ -1188,7 +1188,7 @@ internal class WorkflowNodeTest {
     assertEquals("initial->hello", state)
   }
 
-  @Test fun `child action emits output`() {
+  @Test fun child_action_emits_output() {
     val workflow = Workflow.stateless<Unit, String, Unit> {
       runningSideEffect("test") {
         actionSink.send(action { setOutput("child:hello") })
@@ -1213,7 +1213,7 @@ internal class WorkflowNodeTest {
     assertEquals("output:child:hello", output?.value)
   }
 
-  @Test fun `child action allows null output`() {
+  @Test fun child_action_allows_null_output() {
     val workflow = Workflow.stateless<Unit, String?, Unit> {
       runningSideEffect("test") {
         actionSink.send(action { setOutput(null) })

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowRunnerTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowRunnerTest.kt
@@ -45,7 +45,7 @@ internal class WorkflowRunnerTest {
 
   private val runtimeTestRunner = ParameterizedTestRunner<RuntimeConfig>()
 
-  @Test fun `initial nextRendering returns initial rendering`() {
+  @Test fun initial_nextRendering_returns_initial_rendering() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -63,7 +63,7 @@ internal class WorkflowRunnerTest {
     }
   }
 
-  @Test fun `initial nextRendering uses initial props`() {
+  @Test fun initial_nextRendering_uses_initial_props() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -81,7 +81,7 @@ internal class WorkflowRunnerTest {
     }
   }
 
-  @Test fun `initial processActions does not handle initial props`() {
+  @Test fun initial_processActions_does_not_handle_initial_props() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -104,7 +104,7 @@ internal class WorkflowRunnerTest {
     }
   }
 
-  @Test fun `initial processActions handles props changed after initialization`() {
+  @Test fun initial_processActions_handles_props_changed_after_initialization() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -139,7 +139,7 @@ internal class WorkflowRunnerTest {
     }
   }
 
-  @Test fun `processActions handles workflow update`() {
+  @Test fun processActions_handles_workflow_update() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -172,7 +172,7 @@ internal class WorkflowRunnerTest {
     }
   }
 
-  @Test fun `processActions handles concurrent props change and workflow update`() {
+  @Test fun processActions_handles_concurrent_props_change_and_workflow_update() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -212,7 +212,7 @@ internal class WorkflowRunnerTest {
     }
   }
 
-  @Test fun `cancelRuntime does not interrupt processActions`() {
+  @Test fun cancelRuntime_does_not_interrupt_processActions() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -235,7 +235,7 @@ internal class WorkflowRunnerTest {
     }
   }
 
-  @Test fun `cancelRuntime cancels runtime`() {
+  @Test fun cancelRuntime_cancels_runtime() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -265,7 +265,7 @@ internal class WorkflowRunnerTest {
     }
   }
 
-  @Test fun `cancelling scope interrupts processActions`() {
+  @Test fun cancelling_scope_interrupts_processActions() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,
@@ -289,7 +289,7 @@ internal class WorkflowRunnerTest {
     }
   }
 
-  @Test fun `cancelling scope cancels runtime`() {
+  @Test fun cancelling_scope_cancels_runtime() {
     runtimeTestRunner.runParametrizedTest(
       paramSource = runtimeOptions,
       before = ::setup,

--- a/workflow-runtime/src/iosTest/kotlin/com/squareup/workflow1/ErrorLoggingInterceptor.kt
+++ b/workflow-runtime/src/iosTest/kotlin/com/squareup/workflow1/ErrorLoggingInterceptor.kt
@@ -1,0 +1,22 @@
+package com.squareup.workflow1
+
+internal actual open class ErrorLoggingInterceptor : SimpleLoggingWorkflowInterceptor() {
+  actual val errors = mutableListOf<String>()
+
+  actual override fun log(text: String) {
+    throw IllegalArgumentException()
+  }
+
+  actual override fun logError(text: String) {
+    errors += text
+  }
+
+  actual companion object {
+    actual val EXPECTED_ERRORS = listOf(
+      "ErrorLoggingInterceptor.logBeforeMethod threw exception:\n" +
+        IllegalArgumentException::class.qualifiedName.toString(),
+      "ErrorLoggingInterceptor.logAfterMethod threw exception:\n" +
+        IllegalArgumentException::class.qualifiedName.toString()
+    )
+  }
+}

--- a/workflow-runtime/src/jsMain/kotlin/com.squareup.workflow1.internal/SystemUtils.kt
+++ b/workflow-runtime/src/jsMain/kotlin/com.squareup.workflow1.internal/SystemUtils.kt
@@ -1,0 +1,5 @@
+package com.squareup.workflow1.internal
+
+import kotlin.js.Date
+
+actual fun currentTimeMillis(): Long = Date.now().toLong()

--- a/workflow-runtime/src/jsTest/kotlin/com/squareup/workflow1/ErrorLoggingInterceptor.kt
+++ b/workflow-runtime/src/jsTest/kotlin/com/squareup/workflow1/ErrorLoggingInterceptor.kt
@@ -1,0 +1,22 @@
+package com.squareup.workflow1
+
+internal actual open class ErrorLoggingInterceptor : SimpleLoggingWorkflowInterceptor() {
+  actual val errors = mutableListOf<String>()
+
+  actual override fun log(text: String) {
+    throw IllegalArgumentException()
+  }
+
+  actual override fun logError(text: String) {
+    errors += text
+  }
+
+  actual companion object {
+    actual val EXPECTED_ERRORS = listOf(
+      "ErrorLoggingInterceptor.logBeforeMethod threw exception:\n" +
+        IllegalArgumentException::class.simpleName.toString(),
+      "ErrorLoggingInterceptor.logAfterMethod threw exception:\n" +
+        IllegalArgumentException::class.simpleName.toString()
+    )
+  }
+}

--- a/workflow-runtime/src/jvmTest/kotlin/com/squareup/workflow1/ErrorLoggingInterceptor.kt
+++ b/workflow-runtime/src/jvmTest/kotlin/com/squareup/workflow1/ErrorLoggingInterceptor.kt
@@ -1,0 +1,22 @@
+package com.squareup.workflow1
+
+internal actual open class ErrorLoggingInterceptor : SimpleLoggingWorkflowInterceptor() {
+  actual val errors = mutableListOf<String>()
+
+  actual override fun log(text: String) {
+    throw IllegalArgumentException()
+  }
+
+  actual override fun logError(text: String) {
+    errors += text
+  }
+
+  actual companion object {
+    actual val EXPECTED_ERRORS = listOf(
+      "ErrorLoggingInterceptor.logBeforeMethod threw exception:\n" +
+        IllegalArgumentException::class.qualifiedName.toString(),
+      "ErrorLoggingInterceptor.logAfterMethod threw exception:\n" +
+        IllegalArgumentException::class.qualifiedName.toString()
+    )
+  }
+}


### PR DESCRIPTION
Ready for a pass as the changes are non-trivial.
Reviewing by may should help.

1. Add JS target.
2. Fix test names to non back-ticks for common tests can't have them for JS test support.
3. Updated to use new coroutine testing library methods.
4. Handle different results ErrorLoggingInterceptor for jsTargets in tests.
5. Add JS WorkflowIdentifierTypeNamer to handle JS class comparison.

Will clean up commits when ready