### PR TITLE
Deprecates old view building API.

### DIFF
--- a/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/backstack/BackStackScreen.kt
+++ b/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/backstack/BackStackScreen.kt
@@ -1,4 +1,4 @@
-// @file:Suppress("DEPRECATION")
+@file:Suppress("DEPRECATION")
 
 package com.squareup.workflow1.ui.backstack
 
@@ -26,7 +26,7 @@ import com.squareup.workflow1.ui.container.BackStackScreen as NewBackStackScreen
  * @param rest the rest of the stack, empty by default
  */
 @WorkflowUiExperimentalApi
-// @Deprecated("Use com.squareup.workflow1.ui.container.BackStackScreen")
+@Deprecated("Use com.squareup.workflow1.ui.container.BackStackScreen")
 public class BackStackScreen<StackedT : Any>(
   bottom: StackedT,
   rest: List<StackedT>

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
@@ -1,4 +1,4 @@
-// @file:Suppress("DEPRECATION")
+@file:Suppress("DEPRECATION")
 
 package com.squareup.workflow1.ui
 
@@ -27,7 +27,7 @@ import kotlin.reflect.KClass
  *
  * @throws IllegalArgumentException if no factory can be find for type [RenderingT]
  */
-// @Deprecated("Use ScreenViewFactoryFinder.getViewFactoryForRendering()")
+@Deprecated("Use ScreenViewFactoryFinder.getViewFactoryForRendering()")
 @WorkflowUiExperimentalApi
 public fun <RenderingT : Any> ViewRegistry.getFactoryForRendering(
   rendering: RenderingT
@@ -56,10 +56,10 @@ public fun <RenderingT : Any> ViewRegistry.getFactoryForRendering(
  * Returns the [ViewFactory] that was registered for the given [renderingType], or null
  * if none was found.
  */
-// @Deprecated(
-//   "Use getEntryFor()",
-//   ReplaceWith("getEntryFor(renderingType)")
-// )
+@Deprecated(
+  "Use getEntryFor()",
+  ReplaceWith("getEntryFor(renderingType)")
+)
 @WorkflowUiExperimentalApi
 public fun <RenderingT : Any> ViewRegistry.getFactoryFor(
   renderingType: KClass<out RenderingT>
@@ -87,7 +87,7 @@ public fun <RenderingT : Any> ViewRegistry.getFactoryFor(
  * @throws IllegalStateException if the matching [ViewFactory] fails to call
  * [View.bindShowRendering] when constructing the view
  */
-// @Deprecated("Use ScreenViewFactory.startShowing")
+@Deprecated("Use ScreenViewFactory.startShowing")
 @WorkflowUiExperimentalApi
 public fun <RenderingT : Any> ViewRegistry.buildView(
   initialRendering: RenderingT,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRendering.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRendering.kt
@@ -29,8 +29,8 @@ package com.squareup.workflow1.ui
  * reason, you can use [ViewRegistry] to bind your renderings to [ViewFactory]
  * implementations at runtime.
  */
-// @Suppress("DEPRECATION")
-// @Deprecated("Use AndroidScreen")
+@Suppress("DEPRECATION")
+@Deprecated("Use AndroidScreen")
 @WorkflowUiExperimentalApi
 public interface AndroidViewRendering<V : AndroidViewRendering<V>> {
   /**

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BackButtonScreen.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BackButtonScreen.kt
@@ -18,12 +18,12 @@ package com.squareup.workflow1.ui
  * is pressed, or null to set no handler -- or clear a handler that was set previously.
  * Defaults to `null`.
  */
-// @Suppress("DEPRECATION")
+@Suppress("DEPRECATION")
 @WorkflowUiExperimentalApi
-// @Deprecated(
-//   "Use com.squareup.workflow1.ui.container.BackButtonScreen",
-//   ReplaceWith("BackButtonScreen", "com.squareup.workflow1.ui.container.BackButtonScreen")
-// )
+@Deprecated(
+  "Use com.squareup.workflow1.ui.container.BackButtonScreen",
+  ReplaceWith("BackButtonScreen", "com.squareup.workflow1.ui.container.BackButtonScreen")
+)
 public class BackButtonScreen<W : Any>(
   public val wrapped: W,
   public val shadow: Boolean = false,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BuilderViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BuilderViewFactory.kt
@@ -26,8 +26,8 @@ import kotlin.reflect.KClass
  *      private fun update(rendering:  MyView) { ... }
  *    }
  */
-// @Suppress("DEPRECATION")
-// @Deprecated("Use ScreenViewFactory.fromCode")
+@Suppress("DEPRECATION")
+@Deprecated("Use ScreenViewFactory.fromCode")
 @WorkflowUiExperimentalApi
 public class BuilderViewFactory<RenderingT : Any>(
   override val type: KClass<RenderingT>,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/DecorativeViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/DecorativeViewFactory.kt
@@ -110,8 +110,8 @@ import kotlin.reflect.KClass
  * [InnerT], allowing pre- and post-processing. Default implementation simply
  * uses [map] to extract the [InnerT] instance from [OuterT] and makes the function call.
  */
-// @Suppress("DEPRECATION")
-// @Deprecated("Use ScreenViewFactory.toUnwrappingViewFactory")
+@Suppress("DEPRECATION")
+@Deprecated("Use ScreenViewFactory.toUnwrappingViewFactory")
 @WorkflowUiExperimentalApi
 public class DecorativeViewFactory<OuterT : Any, InnerT : Any>(
   override val type: KClass<OuterT>,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunner.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunner.kt
@@ -1,4 +1,4 @@
-// @file:Suppress("DEPRECATION")
+@file:Suppress("DEPRECATION")
 package com.squareup.workflow1.ui
 
 import android.view.View
@@ -17,7 +17,7 @@ import androidx.viewbinding.ViewBinding
  * implement this interface at all. For details, see the three overloads of [LayoutRunner.bind].
  */
 @WorkflowUiExperimentalApi
-// @Deprecated("Use ScreenViewRunner")
+@Deprecated("Use ScreenViewRunner")
 public fun interface LayoutRunner<RenderingT : Any> {
   public fun showRendering(
     rendering: RenderingT,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LegacyFactoryForScreenType.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LegacyFactoryForScreenType.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow1.ui
 
 import android.content.Context

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewFactory.kt
@@ -20,7 +20,7 @@ import android.view.ViewGroup
  * them with appropriate an appropriate [ViewFactory]. For more flexibility, and to
  * avoid coupling your workflow directly to the Android runtime, see [ViewRegistry].
  */
-// @Deprecated("Use ScreenViewFactory")
+@Deprecated("Use ScreenViewFactory")
 @WorkflowUiExperimentalApi
 public interface ViewFactory<in RenderingT : Any> : ViewRegistry.Entry<RenderingT> {
   /**

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
@@ -31,8 +31,9 @@ public typealias ViewShowRendering<RenderingT> =
  * @see ViewFactory
  * @see DecorativeViewFactory
  */
+@Suppress("DeprecatedCallableAddReplaceWith")
 @WorkflowUiExperimentalApi
-// @Deprecated("Replaced by ScreenViewHolder")
+@Deprecated("Replaced by ScreenViewHolder")
 public fun <RenderingT : Any> View.bindShowRendering(
   initialRendering: RenderingT,
   initialViewEnvironment: ViewEnvironment,
@@ -64,7 +65,7 @@ public fun <RenderingT : Any> View.bindShowRendering(
  * - It is an error to call [View.showRendering] without having called this method first.
  */
 @WorkflowUiExperimentalApi
-// @Deprecated("Use ScreenViewFactory.startShowing to create a ScreenViewHolder")
+@Deprecated("Use ScreenViewFactory.startShowing to create a ScreenViewHolder")
 public fun View.start() {
   val current = workflowViewStateAsNew
   workflowViewState = Started(current.showing, current.environment, current.showRendering)
@@ -83,7 +84,7 @@ public fun View.start() {
  * [View.getRendering] and the new one.
  */
 @WorkflowUiExperimentalApi
-// @Deprecated("Replaced by ScreenViewHolder.canShow")
+@Deprecated("Replaced by ScreenViewHolder.canShow")
 public fun View.canShowRendering(rendering: Any): Boolean {
   @Suppress("DEPRECATION")
   return getRendering<Any>()?.let { compatible(it, rendering) } == true
@@ -101,7 +102,7 @@ public fun View.canShowRendering(rendering: Any): Boolean {
  * @throws IllegalStateException if [bindShowRendering] has not been called.
  */
 @WorkflowUiExperimentalApi
-// @Deprecated("Replaced by ScreenViewHolder.show")
+@Deprecated("Replaced by ScreenViewHolder.show")
 public fun <RenderingT : Any> View.showRendering(
   rendering: RenderingT,
   viewEnvironment: ViewEnvironment
@@ -188,8 +189,9 @@ public val View.environmentOrNull: ViewEnvironment?
  * Returns the function set by the most recent call to [bindShowRendering], or null
  * if that method has never been called.
  */
+@Suppress("DeprecatedCallableAddReplaceWith")
 @WorkflowUiExperimentalApi
-// @Deprecated("Replaced by ScreenViewHolder")
+@Deprecated("Replaced by ScreenViewHolder")
 public fun <RenderingT : Any> View.getShowRendering(): ViewShowRendering<RenderingT>? {
   return workflowViewStateOrNull?.showRendering
 }

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Named.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Named.kt
@@ -8,7 +8,7 @@ package com.squareup.workflow1.ui
  * and have [compatible] [wrapped] fields.
  */
 @WorkflowUiExperimentalApi
-// @Deprecated("Use NamedScreen")
+@Deprecated("Use NamedScreen")
 public data class Named<W : Any>(
   val wrapped: W,
   val name: String


### PR DESCRIPTION
I'm now confident that it's practical to migrate to Screen et al, so I've uncommented the related deprecation annotations. Note that this commit does not deprecate the old dialog building code, still kicking the tires on that.