### PR TITLE
Simplifies ScreenOverlayDialogFactory.

### DIFF
--- a/samples/containers/android/src/main/java/com/squareup/sample/container/panel/PanelOverlayDialogFactory.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/panel/PanelOverlayDialogFactory.kt
@@ -4,7 +4,8 @@ import android.app.Dialog
 import android.graphics.Rect
 import com.squareup.sample.container.R
 import com.squareup.workflow1.ui.Screen
-import com.squareup.workflow1.ui.ScreenViewHolder
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.container.ScreenOverlayDialogFactory
 import com.squareup.workflow1.ui.container.setContent
@@ -21,8 +22,11 @@ internal object PanelOverlayDialogFactory :
    * Forks the default implementation to apply [R.style.PanelDialog], for
    * enter and exit animation.
    */
-  override fun buildDialogWithContent(content: ScreenViewHolder<Screen>): Dialog {
-    return Dialog(content.view.context, R.style.PanelDialog).also {
+  override fun buildDialogWithContent(
+    content: WorkflowLayout,
+    environment: ViewEnvironment
+  ): Dialog {
+    return Dialog(content.context, R.style.PanelDialog).also {
       it.setContent(content)
     }
   }

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -32,6 +32,7 @@ import com.squareup.workflow1.ui.ScreenViewFactory
 import com.squareup.workflow1.ui.ScreenViewHolder
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewRegistry
+import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.container.AndroidOverlay
 import com.squareup.workflow1.ui.container.BackStackScreen
@@ -569,8 +570,11 @@ internal class ComposeViewTreeIntegrationTest {
     override val dialogFactory = object : ScreenOverlayDialogFactory<Screen, TestModal>(
       TestModal::class
     ) {
-      override fun buildDialogWithContent(content: ScreenViewHolder<Screen>): Dialog {
-        return Dialog(content.view.context).apply { setContentView(content.view) }
+      override fun buildDialogWithContent(
+        content: WorkflowLayout,
+        environment: ViewEnvironment
+      ): Dialog {
+        return Dialog(content.context).apply { setContentView(content) }
       }
     }
   }

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -293,7 +293,9 @@ public abstract interface class com/squareup/workflow1/ui/ViewStarter {
 public final class com/squareup/workflow1/ui/WorkflowLayout : android/widget/FrameLayout {
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun show (Lcom/squareup/workflow1/ui/Screen;)V
+	public final fun getEnvironmentOrNull ()Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public final fun show (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
+	public static synthetic fun show$default (Lcom/squareup/workflow1/ui/WorkflowLayout;Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;ILjava/lang/Object;)V
 	public final fun start (Landroidx/lifecycle/Lifecycle;Lkotlinx/coroutines/flow/Flow;Landroidx/lifecycle/Lifecycle$State;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
 	public final fun start (Landroidx/lifecycle/Lifecycle;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewRegistry;)V
 	public final fun start (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
@@ -614,7 +616,6 @@ public final class com/squareup/workflow1/ui/container/LayeredDialogSessions$Sav
 public abstract interface class com/squareup/workflow1/ui/container/ModalScreenOverlayBackButtonHelper {
 	public static final field Companion Lcom/squareup/workflow1/ui/container/ModalScreenOverlayBackButtonHelper$Companion;
 	public abstract fun onBackPressed (Landroid/view/View;)Z
-	public abstract fun onContentViewUpdate (Landroid/view/View;)V
 }
 
 public final class com/squareup/workflow1/ui/container/ModalScreenOverlayBackButtonHelper$Companion : com/squareup/workflow1/ui/ViewEnvironmentKey {
@@ -624,7 +625,6 @@ public final class com/squareup/workflow1/ui/container/ModalScreenOverlayBackBut
 
 public final class com/squareup/workflow1/ui/container/ModalScreenOverlayBackButtonHelper$DefaultImpls {
 	public static fun onBackPressed (Lcom/squareup/workflow1/ui/container/ModalScreenOverlayBackButtonHelper;Landroid/view/View;)Z
-	public static fun onContentViewUpdate (Lcom/squareup/workflow1/ui/container/ModalScreenOverlayBackButtonHelper;Landroid/view/View;)V
 }
 
 public final class com/squareup/workflow1/ui/container/ModalScreenOverlayBackButtonHelperKt {
@@ -704,16 +704,15 @@ public final class com/squareup/workflow1/ui/container/RealOverlayDialogHolder :
 
 public class com/squareup/workflow1/ui/container/ScreenOverlayDialogFactory : com/squareup/workflow1/ui/container/OverlayDialogFactory {
 	public fun <init> (Lkotlin/reflect/KClass;)V
-	public fun buildContent (Lcom/squareup/workflow1/ui/ScreenViewFactory;Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;)Lcom/squareup/workflow1/ui/ScreenViewHolder;
 	public synthetic fun buildDialog (Lcom/squareup/workflow1/ui/container/Overlay;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;)Lcom/squareup/workflow1/ui/container/OverlayDialogHolder;
 	public final fun buildDialog (Lcom/squareup/workflow1/ui/container/ScreenOverlay;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;)Lcom/squareup/workflow1/ui/container/OverlayDialogHolder;
-	public fun buildDialogWithContent (Lcom/squareup/workflow1/ui/ScreenViewHolder;)Landroid/app/Dialog;
+	public fun buildDialogWithContent (Lcom/squareup/workflow1/ui/WorkflowLayout;Lcom/squareup/workflow1/ui/ViewEnvironment;)Landroid/app/Dialog;
 	public fun getType ()Lkotlin/reflect/KClass;
 	public fun updateBounds (Landroid/app/Dialog;Landroid/graphics/Rect;)V
 }
 
 public final class com/squareup/workflow1/ui/container/ScreenOverlayDialogFactoryKt {
-	public static final fun setContent (Landroid/app/Dialog;Lcom/squareup/workflow1/ui/ScreenViewHolder;)V
+	public static final fun setContent (Landroid/app/Dialog;Lcom/squareup/workflow1/ui/WorkflowLayout;)V
 }
 
 public final class com/squareup/workflow1/ui/container/ViewStateCache {

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/DialogIntegrationTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/DialogIntegrationTest.kt
@@ -1,8 +1,6 @@
 package com.squareup.workflow1.ui.container
 
 import android.app.Dialog
-import android.content.Context
-import android.view.View
 import android.widget.EditText
 import androidx.activity.ComponentActivity
 import androidx.test.ext.junit.rules.ActivityScenarioRule
@@ -42,7 +40,7 @@ internal class DialogIntegrationTest {
       }
   }
 
-  private var latestContentView: View? = null
+  private var latestContent: WorkflowLayout? = null
   private var latestDialog: Dialog? = null
 
   private inner class DialogRendering(
@@ -55,19 +53,13 @@ internal class DialogIntegrationTest {
       object : ScreenOverlayDialogFactory<ContentRendering, DialogRendering>(
         type = DialogRendering::class
       ) {
-        override fun buildContent(
-          viewFactory: ScreenViewFactory<ContentRendering>,
-          initialContent: ContentRendering,
-          initialEnvironment: ViewEnvironment,
-          context: Context
-        ): ScreenViewHolder<ContentRendering> =
-          super.buildContent(viewFactory, initialContent, initialEnvironment, context).also {
-            latestContentView = it.view
-          }
-
         override fun buildDialogWithContent(
-          content: ScreenViewHolder<ContentRendering>
-        ) = super.buildDialogWithContent(content).also { latestDialog = it }
+          content: WorkflowLayout,
+          environment: ViewEnvironment
+        ) = super.buildDialogWithContent(content, ViewEnvironment.EMPTY).also {
+          latestContent = content
+          latestDialog = it
+        }
       }
   }
 
@@ -80,7 +72,7 @@ internal class DialogIntegrationTest {
       val root = WorkflowLayout(activity)
       root.show(screen)
 
-      assertThat(latestContentView).isNotNull()
+      assertThat(latestContent).isNotNull()
       assertThat(latestDialog).isNotNull()
       assertThat(latestDialog!!.isShowing).isTrue()
     }
@@ -107,7 +99,7 @@ internal class DialogIntegrationTest {
 
     scenario.onActivity {
       root.show(twoDialogs)
-      val lastOverlay = latestContentView?.environmentOrNull?.get(InOverlay)!!
+      val lastOverlay = latestContent?.environmentOrNull?.get(InOverlay)!!
       assertThat(lastOverlay).isEqualTo(dialog2)
     }
   }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewShowRendering.kt
@@ -175,8 +175,8 @@ public val View.environment: ViewEnvironment?
   get() = environmentOrNull
 
 /**
- * Returns the most recent [ViewEnvironment] applied to this view, or null if [bindShowRendering]
- * has never been called.
+ * Returns the most recent [ViewEnvironment] applied to this [View], or null if
+ * it is not managed by Workflow UI.
  */
 @WorkflowUiExperimentalApi
 public val View.environmentOrNull: ViewEnvironment?

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogSession.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogSession.kt
@@ -26,7 +26,7 @@ internal class DialogSession(
   index: Int,
   holder: OverlayDialogHolder<Overlay>
 ) {
-  // Note similar code in LayeredDialogs
+  // Note similar code in LayeredDialogSessions
   private var allowEvents = true
     set(value) {
       val was = field

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/LayeredDialogSessions.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/LayeredDialogSessions.kt
@@ -286,7 +286,7 @@ public class LayeredDialogSessions private constructor(
         context = view.context,
         bounds = bounds,
         cancelEvents = {
-          // Note similar code in DialogHolder.
+          // Note similar code in DialogSession.
 
           // https://stackoverflow.com/questions/2886407/dealing-with-rapid-tapping-on-buttons
           // If any motion events were enqueued on the main thread, cancel them.

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/ModalScreenOverlayBackButtonHelper.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/ModalScreenOverlayBackButtonHelper.kt
@@ -8,7 +8,7 @@ import com.squareup.workflow1.ui.backPressedHandler
 import com.squareup.workflow1.ui.onBackPressedDispatcherOwnerOrNull
 
 /**
- * Functions called to handle back button events in [Dialog][android.app.Dialog]s built
+ * Function called to handle back button events in [Dialog][android.app.Dialog]s built
  * by [ScreenOverlayDialogFactory] for renderings of type [ModalOverlay].
  * The default implementation uses the [Activity][android.app.Activity]'s
  * [OnBackPressedDispatcher][androidx.activity.OnBackPressedDispatcher],
@@ -20,23 +20,6 @@ import com.squareup.workflow1.ui.onBackPressedDispatcherOwnerOrNull
  */
 @WorkflowUiExperimentalApi
 public interface ModalScreenOverlayBackButtonHelper {
-  /**
-   * Called immediately after [ScreenViewHolder.show][com.squareup.workflow1.ui.show]
-   * for any [Dialog][android.app.Dialog] built by a [ScreenOverlayDialogFactory]
-   * to show [ModalOverlay] renderings.
-   *
-   * The default implementation ensures that [back press handlers][View.backPressedHandler]
-   * set in lower windows are blocked.
-   */
-  public fun onContentViewUpdate(contentView: View) {
-    // If the content view has no backPressedHandler, add a no-op one to
-    // ensure that the `onBackPressed` call below will not leak up to handlers
-    // that should be blocked by this modal session.
-    if (contentView.backPressedHandler == null) {
-      contentView.backPressedHandler = { }
-    }
-  }
-
   /**
    * Called when the device back button is pressed and a modal dialog built by a
    * [ScreenOverlayDialogFactory] has window focus.

--- a/workflow-ui/core-common/api/core-common.api
+++ b/workflow-ui/core-common/api/core-common.api
@@ -231,7 +231,6 @@ public final class com/squareup/workflow1/ui/container/EnvironmentScreenKt {
 
 public final class com/squareup/workflow1/ui/container/FullScreenOverlay : com/squareup/workflow1/ui/container/ScreenOverlay {
 	public fun <init> (Lcom/squareup/workflow1/ui/Screen;)V
-	public fun getCompatibilityKey ()Ljava/lang/String;
 	public fun getContent ()Lcom/squareup/workflow1/ui/Screen;
 }
 
@@ -241,12 +240,7 @@ public abstract interface class com/squareup/workflow1/ui/container/ModalOverlay
 public abstract interface class com/squareup/workflow1/ui/container/Overlay {
 }
 
-public abstract interface class com/squareup/workflow1/ui/container/ScreenOverlay : com/squareup/workflow1/ui/Compatible, com/squareup/workflow1/ui/container/Overlay {
-	public abstract fun getCompatibilityKey ()Ljava/lang/String;
+public abstract interface class com/squareup/workflow1/ui/container/ScreenOverlay : com/squareup/workflow1/ui/container/Overlay {
 	public abstract fun getContent ()Lcom/squareup/workflow1/ui/Screen;
-}
-
-public final class com/squareup/workflow1/ui/container/ScreenOverlay$DefaultImpls {
-	public static fun getCompatibilityKey (Lcom/squareup/workflow1/ui/container/ScreenOverlay;)Ljava/lang/String;
 }
 

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/container/ScreenOverlay.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/container/ScreenOverlay.kt
@@ -1,7 +1,5 @@
 package com.squareup.workflow1.ui.container
 
-import com.squareup.workflow1.ui.Compatible
-import com.squareup.workflow1.ui.Compatible.Companion.keyFor
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
@@ -9,9 +7,6 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
  * An [Overlay] built around a root [content] [Screen].
  */
 @WorkflowUiExperimentalApi
-public interface ScreenOverlay<ContentT : Screen> : Overlay, Compatible {
+public interface ScreenOverlay<ContentT : Screen> : Overlay {
   public val content: ContentT
-
-  override val compatibilityKey: String
-    get() = keyFor(content, this::class.simpleName ?: ScreenOverlay::class.simpleName!!)
 }


### PR DESCRIPTION
The old approach would force you to build an entire new `Dialog` if the content type changed, which is silly. Now we explicitly use `WorkflowLayout` as the content view, and eliminate the redundant code for dealing directly with `ScreenViewFactory`.

Also cleans up the unnecessary `.withEnvironment()` calls in `WorkflowLayout`, and makes its `show()` function more of a first class citizen.