### PR TITLE
Long lived branch with `Overlay` refinements

### DIFF
--- a/benchmarks/performance-poetry/complex-poetry/src/androidTest/java/com/squareup/benchmarks/performance/complex/poetry/RenderPassTest.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/androidTest/java/com/squareup/benchmarks/performance/complex/poetry/RenderPassTest.kt
@@ -16,6 +16,7 @@ import com.squareup.benchmarks.performance.complex.poetry.cyborgs.waitForPoetry
 import com.squareup.benchmarks.performance.complex.poetry.instrumentation.RenderPassCountingInterceptor
 import org.junit.Assert.fail
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -75,6 +76,7 @@ class RenderPassTest {
     runRenderPassCounter(COMPLEX_NO_INITIALIZING, useFrameTimeout = true)
   }
 
+  @Ignore("#841")
   @Test fun renderPassCounterFrameTimeoutComplexNoInitializingStateHighFrequencyEvents() {
     runRenderPassCounter(COMPLEX_NO_INITIALIZING_HIGH_FREQUENCY, useFrameTimeout = true)
   }

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/panel/PanelOverlayDialogFactory.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/panel/PanelOverlayDialogFactory.kt
@@ -5,9 +5,13 @@ import android.graphics.Rect
 import com.squareup.sample.container.R
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ScreenViewHolder
+import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.container.OverlayDialogHolder
 import com.squareup.workflow1.ui.container.ScreenOverlayDialogFactory
+import com.squareup.workflow1.ui.container.setBounds
 import com.squareup.workflow1.ui.container.setContent
+import com.squareup.workflow1.ui.show
 
 /**
  * Android support for [PanelOverlay].
@@ -18,41 +22,48 @@ internal object PanelOverlayDialogFactory :
     type = PanelOverlay::class
   ) {
   /**
-   * Forks the default implementation to apply [R.style.PanelDialog], for
-   * enter and exit animation.
+   * Forks the default implementation to apply [R.style.PanelDialog] for
+   * enter and exit animation, and to customize [bounds][OverlayDialogHolder.onUpdateBounds].
    */
-  override fun buildDialogWithContent(content: ScreenViewHolder<Screen>): Dialog {
-    return Dialog(content.view.context, R.style.PanelDialog).also {
-      it.setContent(content)
-    }
-  }
+  override fun buildDialogWithContent(
+    initialRendering: PanelOverlay<Screen>,
+    initialEnvironment: ViewEnvironment,
+    content: ScreenViewHolder<Screen>
+  ): OverlayDialogHolder<PanelOverlay<Screen>> {
+    val dialog = Dialog(content.view.context, R.style.PanelDialog)
+    dialog.setContent(content)
 
-  override fun updateBounds(
-    dialog: Dialog,
-    bounds: Rect
-  ) {
-    val refinedBounds: Rect = if (!dialog.context.isTablet) {
-      // On a phone, fill the bounds entirely.
-      bounds
-    } else {
-      if (bounds.height() > bounds.width()) {
-        val margin = bounds.height() - bounds.width()
-        val topDelta = margin / 2
-        val bottomDelta = margin - topDelta
-        Rect(bounds).apply {
-          top = bounds.top + topDelta
-          bottom = bounds.bottom - bottomDelta
+    return OverlayDialogHolder(
+      initialEnvironment = initialEnvironment,
+      dialog = dialog,
+      onUpdateBounds = { bounds ->
+        val refinedBounds: Rect = if (!dialog.context.isTablet) {
+          // On a phone, fill the bounds entirely.
+          bounds
+        } else {
+          if (bounds.height() > bounds.width()) {
+            val margin = bounds.height() - bounds.width()
+            val topDelta = margin / 2
+            val bottomDelta = margin - topDelta
+            Rect(bounds).apply {
+              top = bounds.top + topDelta
+              bottom = bounds.bottom - bottomDelta
+            }
+          } else {
+            val margin = bounds.width() - bounds.height()
+            val leftDelta = margin / 2
+            val rightDelta = margin - leftDelta
+            Rect(bounds).apply {
+              left = bounds.left + leftDelta
+              right = bounds.right - rightDelta
+            }
+          }
         }
-      } else {
-        val margin = bounds.width() - bounds.height()
-        val leftDelta = margin / 2
-        val rightDelta = margin - leftDelta
-        Rect(bounds).apply {
-          left = bounds.left + leftDelta
-          right = bounds.right - rightDelta
-        }
+
+        dialog.setBounds(refinedBounds)
       }
+    ) { overlayRendering, environment ->
+      content.show(overlayRendering.content, environment)
     }
-    super.updateBounds(dialog, refinedBounds)
   }
 }

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -1,6 +1,5 @@
 package com.squareup.workflow1.ui.compose
 
-import android.app.Dialog
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
@@ -569,9 +568,6 @@ internal class ComposeViewTreeIntegrationTest {
     override val dialogFactory = object : ScreenOverlayDialogFactory<Screen, TestModal>(
       TestModal::class
     ) {
-      override fun buildDialogWithContent(content: ScreenViewHolder<Screen>): Dialog {
-        return Dialog(content.view.context).apply { setContentView(content.view) }
-      }
     }
   }
 

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -436,8 +436,8 @@ public class com/squareup/workflow1/ui/container/AlertOverlayDialogFactory : com
 }
 
 public final class com/squareup/workflow1/ui/container/AndroidDialogBoundsKt {
-	public static final fun maintainBounds (Landroid/app/Dialog;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)V
-	public static final fun maintainBounds (Landroid/app/Dialog;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function2;)V
+	public static final fun maintainBounds (Landroid/app/Dialog;Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function1;)V
+	public static final fun maintainBounds (Landroid/app/Dialog;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function1;)V
 	public static final fun setBounds (Landroid/app/Dialog;Landroid/graphics/Rect;)V
 }
 
@@ -672,6 +672,7 @@ public abstract interface class com/squareup/workflow1/ui/container/OverlayDialo
 	public static final field Companion Lcom/squareup/workflow1/ui/container/OverlayDialogHolder$Companion;
 	public abstract fun getDialog ()Landroid/app/Dialog;
 	public abstract fun getEnvironment ()Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public abstract fun getOnUpdateBounds ()Lkotlin/jvm/functions/Function1;
 	public abstract fun getRunner ()Lkotlin/jvm/functions/Function2;
 }
 
@@ -689,16 +690,18 @@ public final class com/squareup/workflow1/ui/container/OverlayDialogHolder$Compa
 }
 
 public final class com/squareup/workflow1/ui/container/OverlayDialogHolderKt {
-	public static final fun OverlayDialogHolder (Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/app/Dialog;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow1/ui/container/OverlayDialogHolder;
+	public static final fun OverlayDialogHolder (Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/app/Dialog;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow1/ui/container/OverlayDialogHolder;
+	public static synthetic fun OverlayDialogHolder$default (Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/app/Dialog;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/container/OverlayDialogHolder;
 	public static final fun canShow (Lcom/squareup/workflow1/ui/container/OverlayDialogHolder;Lcom/squareup/workflow1/ui/container/Overlay;)Z
 	public static final fun getShowing (Lcom/squareup/workflow1/ui/container/OverlayDialogHolder;)Lcom/squareup/workflow1/ui/container/Overlay;
 	public static final fun show (Lcom/squareup/workflow1/ui/container/OverlayDialogHolder;Lcom/squareup/workflow1/ui/container/Overlay;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
 }
 
 public final class com/squareup/workflow1/ui/container/RealOverlayDialogHolder : com/squareup/workflow1/ui/container/OverlayDialogHolder {
-	public fun <init> (Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/app/Dialog;Lkotlin/jvm/functions/Function2;)V
+	public fun <init> (Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/app/Dialog;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
 	public fun getDialog ()Landroid/app/Dialog;
 	public fun getEnvironment ()Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public fun getOnUpdateBounds ()Lkotlin/jvm/functions/Function1;
 	public fun getRunner ()Lkotlin/jvm/functions/Function2;
 }
 
@@ -707,9 +710,8 @@ public class com/squareup/workflow1/ui/container/ScreenOverlayDialogFactory : co
 	public fun buildContent (Lcom/squareup/workflow1/ui/ScreenViewFactory;Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;)Lcom/squareup/workflow1/ui/ScreenViewHolder;
 	public synthetic fun buildDialog (Lcom/squareup/workflow1/ui/container/Overlay;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;)Lcom/squareup/workflow1/ui/container/OverlayDialogHolder;
 	public final fun buildDialog (Lcom/squareup/workflow1/ui/container/ScreenOverlay;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;)Lcom/squareup/workflow1/ui/container/OverlayDialogHolder;
-	public fun buildDialogWithContent (Lcom/squareup/workflow1/ui/ScreenViewHolder;)Landroid/app/Dialog;
+	public fun buildDialogWithContent (Lcom/squareup/workflow1/ui/container/ScreenOverlay;Lcom/squareup/workflow1/ui/ViewEnvironment;Lcom/squareup/workflow1/ui/ScreenViewHolder;)Lcom/squareup/workflow1/ui/container/OverlayDialogHolder;
 	public fun getType ()Lkotlin/reflect/KClass;
-	public fun updateBounds (Landroid/app/Dialog;Landroid/graphics/Rect;)V
 }
 
 public final class com/squareup/workflow1/ui/container/ScreenOverlayDialogFactoryKt {

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -293,7 +293,8 @@ public abstract interface class com/squareup/workflow1/ui/ViewStarter {
 public final class com/squareup/workflow1/ui/WorkflowLayout : android/widget/FrameLayout {
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun show (Lcom/squareup/workflow1/ui/Screen;)V
+	public final fun show (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
+	public static synthetic fun show$default (Lcom/squareup/workflow1/ui/WorkflowLayout;Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;ILjava/lang/Object;)V
 	public final fun start (Landroidx/lifecycle/Lifecycle;Lkotlinx/coroutines/flow/Flow;Landroidx/lifecycle/Lifecycle$State;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
 	public final fun start (Landroidx/lifecycle/Lifecycle;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewRegistry;)V
 	public final fun start (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewEnvironment;)V

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/DialogIntegrationTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/DialogIntegrationTest.kt
@@ -66,8 +66,13 @@ internal class DialogIntegrationTest {
           }
 
         override fun buildDialogWithContent(
+          initialRendering: DialogRendering,
+          initialEnvironment: ViewEnvironment,
           content: ScreenViewHolder<ContentRendering>
-        ) = super.buildDialogWithContent(content).also { latestDialog = it }
+        ): OverlayDialogHolder<DialogRendering> =
+          super.buildDialogWithContent(initialRendering, initialEnvironment, content).also {
+            latestDialog = it.dialog
+          }
       }
   }
 

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
@@ -15,8 +15,6 @@ import androidx.lifecycle.Lifecycle.State
 import androidx.lifecycle.Lifecycle.State.STARTED
 import androidx.lifecycle.coroutineScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.squareup.workflow1.ui.container.EnvironmentScreen
-import com.squareup.workflow1.ui.container.withEnvironment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -28,7 +26,9 @@ import kotlinx.coroutines.launch
 
 /**
  * A view that can be driven by a stream of [Screen] renderings passed to its [take] method.
- * To configure the [ViewEnvironment] in play, use [EnvironmentScreen] as your root rendering type.
+ *
+ * Suitable for use as the content view of an [Activity][android.app.Activity.setContentView],
+ * or [Fragment][androidx.fragment.app.Fragment.onCreateView].
  *
  * [id][setId] defaults to [R.id.workflow_layout], as a convenience to ensure that
  * view persistence will work without requiring authors to be immersed in Android arcana.
@@ -60,8 +60,11 @@ public class WorkflowLayout(
    * [take] than to call this method directly. It is exposed to allow clients to
    * make their own choices about how exactly to consume a stream of renderings.
    */
-  public fun show(rootScreen: Screen) {
-    showing.show(rootScreen, rootScreen.withEnvironment().environment)
+  public fun show(
+    rootScreen: Screen,
+    environment: ViewEnvironment = ViewEnvironment.EMPTY
+  ) {
+    showing.show(rootScreen, environment)
     restoredChildState?.let { restoredState ->
       restoredChildState = null
       showing.actual.restoreHierarchyState(restoredState)
@@ -71,6 +74,12 @@ public class WorkflowLayout(
   /**
    * This is the most common way to bootstrap a [Workflow][com.squareup.workflow1.Workflow]
    * driven UI. Collects [renderings] and calls [show] with each one.
+   *
+   * To configure a root [ViewEnvironment], use
+   * [EnvironmentScreen][com.squareup.workflow1.ui.container.EnvironmentScreen] as your
+   * root rendering type, perhaps via
+   * [withEnvironment][com.squareup.workflow1.ui.container.withEnvironment] or
+   * [withRegistry][com.squareup.workflow1.ui.container.withRegistry].
    *
    * @param [lifecycle] the lifecycle that defines when and how this view should be updated.
    * Typically this comes from `ComponentActivity.lifecycle` or  `Fragment.lifecycle`.
@@ -85,7 +94,7 @@ public class WorkflowLayout(
     // Just like https://medium.com/androiddevelopers/a-safer-way-to-collect-flows-from-android-uis-23080b1f8bda
     lifecycle.coroutineScope.launch {
       lifecycle.repeatOnLifecycle(repeatOnLifecycle) {
-        renderings.collect { show(it.withEnvironment()) }
+        renderings.collect { show(it) }
       }
     }
   }
@@ -127,7 +136,7 @@ public class WorkflowLayout(
   public fun start(
     lifecycle: Lifecycle,
     renderings: Flow<Any>,
-    repeatOnLifecycle: Lifecycle.State = Lifecycle.State.STARTED,
+    repeatOnLifecycle: State = STARTED,
     environment: ViewEnvironment = ViewEnvironment.EMPTY
   ) {
     // Just like https://medium.com/androiddevelopers/a-safer-way-to-collect-flows-from-android-uis-23080b1f8bda

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/AlertOverlayDialogFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/AlertOverlayDialogFactory.kt
@@ -52,7 +52,11 @@ public open class AlertOverlayDialogFactory : OverlayDialogFactory<AlertOverlay>
           alertDialog.setButton(button.toId(), " ") { _, _ -> }
         }
 
-        OverlayDialogHolder(initialEnvironment, alertDialog) { rendering, _ ->
+        OverlayDialogHolder(
+          initialEnvironment = initialEnvironment,
+          dialog = alertDialog,
+          onUpdateBounds = null
+        ) { rendering, _ ->
           with(alertDialog) {
             if (rendering.cancelable) {
               setOnCancelListener { rendering.onEvent(Canceled) }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/AndroidDialogBounds.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/AndroidDialogBounds.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.onEach
  * [bounds] is expected to be in global display coordinates,
  * e.g. as returned from [View.getGlobalVisibleRect].
  *
- * @see ScreenOverlayDialogFactory.updateBounds
+ * @see OverlayDialogHolder.onUpdateBounds
  */
 @WorkflowUiExperimentalApi
 public fun Dialog.setBounds(bounds: Rect) {
@@ -37,7 +37,7 @@ public fun Dialog.setBounds(bounds: Rect) {
 @WorkflowUiExperimentalApi
 internal fun <D : Dialog> D.maintainBounds(
   environment: ViewEnvironment,
-  onBoundsChange: (D, Rect) -> Unit
+  onBoundsChange: (Rect) -> Unit
 ) {
   maintainBounds(environment[OverlayArea].bounds, onBoundsChange)
 }
@@ -45,7 +45,7 @@ internal fun <D : Dialog> D.maintainBounds(
 @WorkflowUiExperimentalApi
 internal fun <D : Dialog> D.maintainBounds(
   bounds: StateFlow<Rect>,
-  onBoundsChange: (D, Rect) -> Unit
+  onBoundsChange: (Rect) -> Unit
 ) {
   val window = requireNotNull(window) { "Dialog must be attached to a window." }
   window.callback = object : Window.Callback by window.callback {
@@ -53,7 +53,7 @@ internal fun <D : Dialog> D.maintainBounds(
 
     override fun onAttachedToWindow() {
       scope = CoroutineScope(Dispatchers.Main.immediate).also {
-        bounds.onEach { b -> onBoundsChange(this@maintainBounds, b) }
+        bounds.onEach { b -> onBoundsChange(b) }
           .launchIn(it)
       }
     }
@@ -65,5 +65,5 @@ internal fun <D : Dialog> D.maintainBounds(
   }
 
   // If already attached, set the bounds eagerly.
-  if (window.peekDecorView()?.isAttachedToWindow == true) onBoundsChange(this, bounds.value)
+  if (window.peekDecorView()?.isAttachedToWindow == true) onBoundsChange(bounds.value)
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogSession.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogSession.kt
@@ -26,7 +26,7 @@ internal class DialogSession(
   index: Int,
   holder: OverlayDialogHolder<Overlay>
 ) {
-  // Note similar code in LayeredDialogs
+  // Note similar code in LayeredDialogSessions
   private var allowEvents = true
     set(value) {
       val was = field

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/OverlayDialogHolder.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/OverlayDialogHolder.kt
@@ -1,6 +1,7 @@
 package com.squareup.workflow1.ui.container
 
 import android.app.Dialog
+import android.graphics.Rect
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewEnvironmentKey
@@ -28,6 +29,20 @@ public interface OverlayDialogHolder<in OverlayT : Overlay> {
    * [ViewEnvironment].
    */
   public val runner: (rendering: OverlayT, environment: ViewEnvironment) -> Unit
+
+  /**
+   * Optional function called to report the bounds of the managing container view,
+   * as reported by [OverlayArea]. Well behaved [Overlay] dialogs are expected to
+   * be restricted to those bounds, to the extent practical -- you probably want to ignore
+   * this for AlertDialog, e.g.
+   *
+   * Honoring this contract makes it easy to define areas of the display
+   * that are outside of the "shadow" of a modal dialog. Imagine an app
+   * with a status bar that should not be covered by modals.
+   *
+   * Default implementation provided by the factory function below calls [Dialog.setBounds].
+   */
+  public val onUpdateBounds: ((Rect) -> Unit)?
 
   public companion object {
     /**
@@ -87,7 +102,8 @@ public val OverlayDialogHolder<*>.showing: Overlay
 public fun <OverlayT : Overlay> OverlayDialogHolder(
   initialEnvironment: ViewEnvironment,
   dialog: Dialog,
+  onUpdateBounds: ((Rect) -> Unit)? = { dialog.setBounds(it) },
   runner: (rendering: OverlayT, environment: ViewEnvironment) -> Unit
 ): OverlayDialogHolder<OverlayT> {
-  return RealOverlayDialogHolder(initialEnvironment, dialog, runner)
+  return RealOverlayDialogHolder(initialEnvironment, dialog, onUpdateBounds, runner)
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/RealOverlayDialogHolder.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/RealOverlayDialogHolder.kt
@@ -1,6 +1,7 @@
 package com.squareup.workflow1.ui.container
 
 import android.app.Dialog
+import android.graphics.Rect
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
@@ -8,6 +9,7 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 internal class RealOverlayDialogHolder<OverlayT : Overlay>(
   initialEnvironment: ViewEnvironment,
   override val dialog: Dialog,
+  override val onUpdateBounds: ((Rect) -> Unit)?,
   runnerFunction: (rendering: OverlayT, environment: ViewEnvironment) -> Unit
 ) : OverlayDialogHolder<OverlayT> {
 


### PR DESCRIPTION
Holding off on merging into `main` until I have more confidence in the changes, which I'm getting by applying them across Square's flagship Android apps; and until I'm ready to deal with the recent coroutines version update (#817).

### Introduces `OverlayDialogHolder.onUpdateBounds`

`OverlayDialogHolder.onUpdateBounds` replaces `ScreenOverlayDialogFactory.updateBounds`.

I finally tried to use `ScreenOverlayDialogFactory.updateBounds` and was reminded once again why it's bad to create interfaces that build something and then take it back later to be updated. If you want the renderings to be involved in setting the bounds policy, there was no way to smuggle that information along with the Dialog returned from `buildDialogWithContent`, so that `updateBounds` could honor it. Also, it was always pretty ugly that the bounds hook was special to the `ScreenOverlay` world.

The fix is make bounds maintenance part of the job of the `OverlayDialogHolder` interface. Square reviewers will notice that we're now an even more faithful rip off of Mosaic's DialogRunner -- hi @helios175.

### No more hard coded EnvironmentScreen in WorkflowLayout.

WorkflowLayout was wrapping things in EnvironmentScreen for no real reason. No longer.