### PR TITLE
No more hard coded EnvironmentScreen in WorkflowLayout.

### DIFF
--- a/benchmarks/performance-poetry/complex-poetry/src/androidTest/java/com/squareup/benchmarks/performance/complex/poetry/RenderPassTest.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/androidTest/java/com/squareup/benchmarks/performance/complex/poetry/RenderPassTest.kt
@@ -16,6 +16,7 @@ import com.squareup.benchmarks.performance.complex.poetry.cyborgs.waitForPoetry
 import com.squareup.benchmarks.performance.complex.poetry.instrumentation.RenderPassCountingInterceptor
 import org.junit.Assert.fail
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -75,6 +76,7 @@ class RenderPassTest {
     runRenderPassCounter(COMPLEX_NO_INITIALIZING, useFrameTimeout = true)
   }
 
+  @Ignore("#841")
   @Test fun renderPassCounterFrameTimeoutComplexNoInitializingStateHighFrequencyEvents() {
     runRenderPassCounter(COMPLEX_NO_INITIALIZING_HIGH_FREQUENCY, useFrameTimeout = true)
   }

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -293,7 +293,8 @@ public abstract interface class com/squareup/workflow1/ui/ViewStarter {
 public final class com/squareup/workflow1/ui/WorkflowLayout : android/widget/FrameLayout {
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun show (Lcom/squareup/workflow1/ui/Screen;)V
+	public final fun show (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
+	public static synthetic fun show$default (Lcom/squareup/workflow1/ui/WorkflowLayout;Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;ILjava/lang/Object;)V
 	public final fun start (Landroidx/lifecycle/Lifecycle;Lkotlinx/coroutines/flow/Flow;Landroidx/lifecycle/Lifecycle$State;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
 	public final fun start (Landroidx/lifecycle/Lifecycle;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewRegistry;)V
 	public final fun start (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/ui/ViewEnvironment;)V

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
@@ -15,8 +15,6 @@ import androidx.lifecycle.Lifecycle.State
 import androidx.lifecycle.Lifecycle.State.STARTED
 import androidx.lifecycle.coroutineScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.squareup.workflow1.ui.container.EnvironmentScreen
-import com.squareup.workflow1.ui.container.withEnvironment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -28,7 +26,9 @@ import kotlinx.coroutines.launch
 
 /**
  * A view that can be driven by a stream of [Screen] renderings passed to its [take] method.
- * To configure the [ViewEnvironment] in play, use [EnvironmentScreen] as your root rendering type.
+ *
+ * Suitable for use as the content view of an [Activity][android.app.Activity.setContentView],
+ * or [Fragment][androidx.fragment.app.Fragment.onCreateView].
  *
  * [id][setId] defaults to [R.id.workflow_layout], as a convenience to ensure that
  * view persistence will work without requiring authors to be immersed in Android arcana.
@@ -60,8 +60,11 @@ public class WorkflowLayout(
    * [take] than to call this method directly. It is exposed to allow clients to
    * make their own choices about how exactly to consume a stream of renderings.
    */
-  public fun show(rootScreen: Screen) {
-    showing.show(rootScreen, rootScreen.withEnvironment().environment)
+  public fun show(
+    rootScreen: Screen,
+    environment: ViewEnvironment = ViewEnvironment.EMPTY
+  ) {
+    showing.show(rootScreen, environment)
     restoredChildState?.let { restoredState ->
       restoredChildState = null
       showing.actual.restoreHierarchyState(restoredState)
@@ -71,6 +74,12 @@ public class WorkflowLayout(
   /**
    * This is the most common way to bootstrap a [Workflow][com.squareup.workflow1.Workflow]
    * driven UI. Collects [renderings] and calls [show] with each one.
+   *
+   * To configure a root [ViewEnvironment], use
+   * [EnvironmentScreen][com.squareup.workflow1.ui.container.EnvironmentScreen] as your
+   * root rendering type, perhaps via
+   * [withEnvironment][com.squareup.workflow1.ui.container.withEnvironment] or
+   * [withRegistry][com.squareup.workflow1.ui.container.withRegistry].
    *
    * @param [lifecycle] the lifecycle that defines when and how this view should be updated.
    * Typically this comes from `ComponentActivity.lifecycle` or  `Fragment.lifecycle`.
@@ -85,7 +94,7 @@ public class WorkflowLayout(
     // Just like https://medium.com/androiddevelopers/a-safer-way-to-collect-flows-from-android-uis-23080b1f8bda
     lifecycle.coroutineScope.launch {
       lifecycle.repeatOnLifecycle(repeatOnLifecycle) {
-        renderings.collect { show(it.withEnvironment()) }
+        renderings.collect { show(it) }
       }
     }
   }
@@ -127,7 +136,7 @@ public class WorkflowLayout(
   public fun start(
     lifecycle: Lifecycle,
     renderings: Flow<Any>,
-    repeatOnLifecycle: Lifecycle.State = Lifecycle.State.STARTED,
+    repeatOnLifecycle: State = STARTED,
     environment: ViewEnvironment = ViewEnvironment.EMPTY
   ) {
     // Just like https://medium.com/androiddevelopers/a-safer-way-to-collect-flows-from-android-uis-23080b1f8bda


### PR DESCRIPTION
WorkflowLayout was wrapping things in EnvironmentScreen for no real reason. No longer.