### PR TITLE
Replaces `Showing` and `InOverlay` with `View` tags.

### DIFF
--- a/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
+++ b/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
@@ -42,7 +42,7 @@ import org.junit.runner.RunWith
 class TicTacToeEspressoTest {
 
   private val scenarioRule = ActivityScenarioRule(TicTacToeActivity::class.java)
-  @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
+  @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(scenarioRule)
     .around(IdlingDispatcherRule)
   private val scenario get() = scenarioRule.scenario

--- a/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/backstack/BackStackScreen.kt
+++ b/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/backstack/BackStackScreen.kt
@@ -8,9 +8,6 @@ import com.squareup.workflow1.ui.asScreen
 import com.squareup.workflow1.ui.container.BackStackScreen as NewBackStackScreen
 
 /**
- * **This will be deprecated in favor of
- * [com.squareup.workflow1.ui.container.BackStackScreen] very soon.**
- *
  * Represents an active screen ([top]), and a set of previously visited screens to which we may
  * return ([backStack]). By rendering the entire history we allow the UI to do things like maintain
  * cached view state, implement drag-back gestures without waiting for the workflow, etc.

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -191,23 +191,9 @@ public final class com/squareup/workflow1/ui/ScreenViewFactoryKt {
 }
 
 public abstract interface class com/squareup/workflow1/ui/ScreenViewHolder {
-	public static final field Companion Lcom/squareup/workflow1/ui/ScreenViewHolder$Companion;
 	public abstract fun getEnvironment ()Lcom/squareup/workflow1/ui/ViewEnvironment;
 	public abstract fun getRunner ()Lcom/squareup/workflow1/ui/ScreenViewRunner;
 	public abstract fun getView ()Landroid/view/View;
-}
-
-public final class com/squareup/workflow1/ui/ScreenViewHolder$Companion {
-}
-
-public final class com/squareup/workflow1/ui/ScreenViewHolder$Companion$Showing : com/squareup/workflow1/ui/ViewEnvironmentKey {
-	public static final field INSTANCE Lcom/squareup/workflow1/ui/ScreenViewHolder$Companion$Showing;
-	public fun getDefault ()Lcom/squareup/workflow1/ui/Screen;
-	public synthetic fun getDefault ()Ljava/lang/Object;
-}
-
-public final class com/squareup/workflow1/ui/ScreenViewHolder$Companion$ShowingNothing : com/squareup/workflow1/ui/Screen {
-	public static final field INSTANCE Lcom/squareup/workflow1/ui/ScreenViewHolder$Companion$ShowingNothing;
 }
 
 public final class com/squareup/workflow1/ui/ScreenViewHolderKt {
@@ -277,10 +263,12 @@ public final class com/squareup/workflow1/ui/ViewShowRenderingKt {
 	public static final fun getEnvironment (Landroid/view/View;)Lcom/squareup/workflow1/ui/ViewEnvironment;
 	public static final fun getEnvironmentOrNull (Landroid/view/View;)Lcom/squareup/workflow1/ui/ViewEnvironment;
 	public static final synthetic fun getRendering (Landroid/view/View;)Ljava/lang/Object;
+	public static final fun getScreen (Landroid/view/View;)Lcom/squareup/workflow1/ui/Screen;
 	public static final fun getScreenOrNull (Landroid/view/View;)Lcom/squareup/workflow1/ui/Screen;
 	public static final fun getShowRendering (Landroid/view/View;)Lkotlin/jvm/functions/Function2;
 	public static final fun getStarter (Landroid/view/View;)Lkotlin/jvm/functions/Function1;
 	public static final fun getStarterOrNull (Landroid/view/View;)Lkotlin/jvm/functions/Function1;
+	public static final fun setScreen (Landroid/view/View;Lcom/squareup/workflow1/ui/Screen;)V
 	public static final fun setStarter (Landroid/view/View;Lkotlin/jvm/functions/Function1;)V
 	public static final fun showRendering (Landroid/view/View;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
 	public static final fun start (Landroid/view/View;)V
@@ -536,8 +524,16 @@ public final class com/squareup/workflow1/ui/container/CoveredByModal : com/squa
 	public synthetic fun getDefault ()Ljava/lang/Object;
 }
 
+public final class com/squareup/workflow1/ui/container/DialogOverlayKt {
+	public static final fun getDecorView (Landroid/app/Dialog;)Landroid/view/View;
+	public static final fun getDecorViewOrNull (Landroid/app/Dialog;)Landroid/view/View;
+	public static final fun getOverlay (Landroid/app/Dialog;)Lcom/squareup/workflow1/ui/container/Overlay;
+	public static final fun getOverlayOrNull (Landroid/app/Dialog;)Lcom/squareup/workflow1/ui/container/Overlay;
+	public static final fun setOverlay (Landroid/app/Dialog;Lcom/squareup/workflow1/ui/container/Overlay;)V
+}
+
 public final class com/squareup/workflow1/ui/container/DialogSession {
-	public fun <init> (ILcom/squareup/workflow1/ui/container/OverlayDialogHolder;)V
+	public fun <init> (ILcom/squareup/workflow1/ui/container/Overlay;Lcom/squareup/workflow1/ui/container/OverlayDialogHolder;)V
 	public final fun dismiss ()V
 	public final fun getHolder ()Lcom/squareup/workflow1/ui/container/OverlayDialogHolder;
 	public final fun getSavedStateRegistryKey ()Ljava/lang/String;
@@ -653,25 +649,11 @@ public final class com/squareup/workflow1/ui/container/OverlayDialogFactoryKt {
 }
 
 public abstract interface class com/squareup/workflow1/ui/container/OverlayDialogHolder {
-	public static final field Companion Lcom/squareup/workflow1/ui/container/OverlayDialogHolder$Companion;
 	public abstract fun getDialog ()Landroid/app/Dialog;
 	public abstract fun getEnvironment ()Lcom/squareup/workflow1/ui/ViewEnvironment;
 	public abstract fun getOnBackPressed ()Lkotlin/jvm/functions/Function0;
 	public abstract fun getOnUpdateBounds ()Lkotlin/jvm/functions/Function1;
 	public abstract fun getRunner ()Lkotlin/jvm/functions/Function2;
-}
-
-public final class com/squareup/workflow1/ui/container/OverlayDialogHolder$Companion {
-}
-
-public final class com/squareup/workflow1/ui/container/OverlayDialogHolder$Companion$InOverlay : com/squareup/workflow1/ui/ViewEnvironmentKey {
-	public static final field INSTANCE Lcom/squareup/workflow1/ui/container/OverlayDialogHolder$Companion$InOverlay;
-	public fun getDefault ()Lcom/squareup/workflow1/ui/container/Overlay;
-	public synthetic fun getDefault ()Ljava/lang/Object;
-}
-
-public final class com/squareup/workflow1/ui/container/OverlayDialogHolder$Companion$NoOverlay : com/squareup/workflow1/ui/container/Overlay {
-	public static final field INSTANCE Lcom/squareup/workflow1/ui/container/OverlayDialogHolder$Companion$NoOverlay;
 }
 
 public final class com/squareup/workflow1/ui/container/OverlayDialogHolderKt {

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/DialogIntegrationTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/DialogIntegrationTest.kt
@@ -14,8 +14,6 @@ import com.squareup.workflow1.ui.ScreenViewHolder
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.container.OverlayDialogHolder.Companion.InOverlay
-import com.squareup.workflow1.ui.environmentOrNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -104,7 +102,7 @@ internal class DialogIntegrationTest {
 
     scenario.onActivity {
       root.show(twoDialogs)
-      val lastOverlay = latestContentView?.environmentOrNull?.get(InOverlay)!!
+      val lastOverlay = latestDialog?.overlay
       assertThat(lastOverlay).isEqualTo(dialog2)
     }
   }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
@@ -10,10 +10,6 @@ import com.squareup.workflow1.ui.container.EnvironmentScreenLegacyViewFactory
 import kotlin.reflect.KClass
 
 /**
- * **This will be deprecated in favor of
- * [ScreenViewFactoryFinder.getViewFactoryForRendering]
- * very soon.**
- *
  * It is usually more convenient to use [WorkflowViewStub] or [DecorativeViewFactory]
  * than to call this method directly.
  *
@@ -49,8 +45,6 @@ public fun <RenderingT : Any> ViewRegistry.getFactoryForRendering(
 }
 
 /**
- * **This will be deprecated in favor of [ViewRegistry.getEntryFor] very soon.**
- *
  * This method is not for general use, use [WorkflowViewStub] instead.
  *
  * Returns the [ViewFactory] that was registered for the given [renderingType], or null
@@ -68,8 +62,6 @@ public fun <RenderingT : Any> ViewRegistry.getFactoryFor(
 }
 
 /**
- * **This will be deprecated in favor of [ScreenViewFactory.startShowing] very soon.**
- *
  * It is usually more convenient to use [WorkflowViewStub] or [DecorativeViewFactory]
  * than to call this method directly.
  *

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRendering.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRendering.kt
@@ -1,8 +1,6 @@
 package com.squareup.workflow1.ui
 
 /**
- * **This will be deprecated in favor of [AndroidScreen] very soon.**
- *
  * Interface implemented by a rendering class to allow it to drive an Android UI
  * via an appropriate [ViewFactory] implementation.
  *

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BackButtonScreen.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BackButtonScreen.kt
@@ -1,9 +1,6 @@
 package com.squareup.workflow1.ui
 
 /**
- * **This will be deprecated in favor of
- * [com.squareup.workflow1.ui.container.BackButtonScreen] very soon.**
- *
  * Adds optional back button handling to a [wrapped] rendering, possibly overriding that
  * the wrapped rendering's own back button handler.
  *

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BuilderViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BuilderViewFactory.kt
@@ -6,8 +6,6 @@ import android.view.ViewGroup
 import kotlin.reflect.KClass
 
 /**
- * **This will be deprecated in favor of [ScreenViewFactory.fromCode] very soon.**
- *
  * A [ViewFactory] that creates [View]s that need to be generated from code.
  * (Use [LayoutRunner] to work with XML layout resources.)
  *

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/DecorativeViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/DecorativeViewFactory.kt
@@ -6,8 +6,6 @@ import android.view.ViewGroup
 import kotlin.reflect.KClass
 
 /**
- * **This will be deprecated in favor of [ScreenViewFactory.forWrapper] very soon.**
- *
  * A [ViewFactory] for [OuterT] that delegates view construction responsibilities
  * to the factory registered for [InnerT]. Makes it convenient for [OuterT] to wrap
  * instances of [InnerT] to add information or behavior, without requiring wasteful wrapping

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunner.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunner.kt
@@ -6,8 +6,6 @@ import androidx.annotation.LayoutRes
 import androidx.viewbinding.ViewBinding
 
 /**
- * **This will be deprecated in favor of [ScreenViewRunner] very soon.**
- *
  * A delegate that implements a [showRendering] method to be called when a workflow rendering
  * of type [RenderingT] is ready to be displayed in a view inflated from a layout resource
  * by a [ViewRegistry]. (Use [BuilderViewFactory] if you want to build views from code rather

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ViewFactory.kt
@@ -5,8 +5,6 @@ import android.view.View
 import android.view.ViewGroup
 
 /**
- * **This will be deprecated in favor of [ScreenViewFactory] very soon.**
- *
  * Factory for [View] instances that can show renderings of type[RenderingT].
  *
  * Two concrete [ViewFactory] implementations are provided:

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BackStackContainer.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BackStackContainer.kt
@@ -20,7 +20,6 @@ import com.squareup.workflow1.ui.Compatible.Companion.keyFor
 import com.squareup.workflow1.ui.NamedScreen
 import com.squareup.workflow1.ui.R
 import com.squareup.workflow1.ui.ScreenViewHolder
-import com.squareup.workflow1.ui.ScreenViewHolder.Companion.Showing
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.androidx.WorkflowAndroidXSupport.stateRegistryOwnerFromViewTreeOrContext
@@ -29,6 +28,7 @@ import com.squareup.workflow1.ui.canShow
 import com.squareup.workflow1.ui.compatible
 import com.squareup.workflow1.ui.container.BackStackConfig.First
 import com.squareup.workflow1.ui.container.BackStackConfig.Other
+import com.squareup.workflow1.ui.screen
 import com.squareup.workflow1.ui.show
 import com.squareup.workflow1.ui.startShowing
 import com.squareup.workflow1.ui.toViewFactory
@@ -66,7 +66,7 @@ public open class BackStackContainer @JvmOverloads constructor(
     newRendering: BackStackScreen<*>,
     newViewEnvironment: ViewEnvironment
   ) {
-    savedStateParentKey = keyFor(newViewEnvironment[Showing])
+    savedStateParentKey = keyFor(screen)
 
     val config = if (newRendering.backStack.isEmpty()) First else Other
     val environment = newViewEnvironment + config

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BodyAndOverlaysContainer.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BodyAndOverlaysContainer.kt
@@ -14,10 +14,10 @@ import com.squareup.workflow1.ui.Compatible
 import com.squareup.workflow1.ui.R
 import com.squareup.workflow1.ui.ScreenViewFactory
 import com.squareup.workflow1.ui.ScreenViewHolder
-import com.squareup.workflow1.ui.ScreenViewHolder.Companion.Showing
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.WorkflowViewStub
+import com.squareup.workflow1.ui.screen
 
 /**
  * Default container for [Overlay] renderings, providing support for
@@ -56,7 +56,7 @@ internal class BodyAndOverlaysContainer @JvmOverloads constructor(
     newScreen: BodyAndOverlaysScreen<*, *>,
     viewEnvironment: ViewEnvironment
   ) {
-    savedStateParentKey = Compatible.keyFor(viewEnvironment[Showing])
+    savedStateParentKey = Compatible.keyFor(screen)
 
     dialogs.update(newScreen.overlays, viewEnvironment) { env ->
       baseViewStub.show(newScreen.body, env)

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogOverlay.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogOverlay.kt
@@ -1,0 +1,35 @@
+package com.squareup.workflow1.ui.container
+
+import android.app.Dialog
+import android.view.View
+import com.squareup.workflow1.ui.R
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+
+/**
+ * Returns the most recent [Overlay] rendering [shown][OverlayDialogHolder.show] in this [Dialog],
+ * or throws a [NullPointerException] ` if the receiver was not created via
+ * [OverlayDialogFactory.buildDialog].
+ */
+@WorkflowUiExperimentalApi
+public var Dialog.overlay: Overlay
+  get() = checkNotNull(overlayOrNull) {
+    "Expected to find an Overlay in tag R.id.workflow_overlay on the decor view of $this"
+  }
+  internal set(value) = decorView.setTag(R.id.workflow_overlay, value)
+
+/**
+ * Returns the most recent [Overlay] rendering [shown][OverlayDialogHolder.show] in this [Dialog],
+ * or `null` if the receiver was not created via [OverlayDialogFactory.buildDialog].
+ */
+@WorkflowUiExperimentalApi
+public val Dialog.overlayOrNull: Overlay?
+  get() = decorViewOrNull?.getTag(R.id.workflow_overlay) as? Overlay
+
+internal val Dialog.decorView: View
+  get() {
+    val window = checkNotNull(window) { "Expected to find a window on $this" }
+    return window.decorView
+  }
+
+internal val Dialog.decorViewOrNull: View?
+  get() = window?.peekDecorView()

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogSession.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogSession.kt
@@ -27,6 +27,7 @@ import com.squareup.workflow1.ui.androidx.WorkflowSavedStateRegistryAggregator
 @WorkflowUiExperimentalApi
 internal class DialogSession(
   index: Int,
+  initialOverlay: Overlay,
   holder: OverlayDialogHolder<Overlay>
 ) {
   // Note similar code in LayeredDialogSessions
@@ -55,7 +56,7 @@ internal class DialogSession(
     holder.show(overlay, environment)
   }
 
-  val savedStateRegistryKey = Compatible.keyFor(holder.showing, index.toString())
+  val savedStateRegistryKey = Compatible.keyFor(initialOverlay, index.toString())
 
   private val KeyEvent.isBackPress: Boolean
     get() = (keyCode == KEYCODE_BACK || keyCode == KEYCODE_ESCAPE) && action == ACTION_UP
@@ -91,7 +92,7 @@ internal class DialogSession(
     }
 
     dialog.show()
-    dialog.window?.decorView?.also { decorView ->
+    dialog.decorView.also { decorView ->
       // Implementations of buildDialog may set their own WorkflowLifecycleOwner on the
       // content view, so to avoid interfering with them we also set it here. When the views
       // are attached, this will become the parent lifecycle of the one from buildDialog if
@@ -142,11 +143,11 @@ internal class DialogSession(
 
   internal fun save(): KeyAndBundle? {
     val saved = holder.dialog.window?.saveHierarchyState() ?: return null
-    return KeyAndBundle(Compatible.keyFor(holder.showing), saved)
+    return KeyAndBundle(savedStateRegistryKey, saved)
   }
 
   internal fun restore(keyAndBundle: KeyAndBundle) {
-    if (Compatible.keyFor(holder.showing) == keyAndBundle.compatibilityKey) {
+    if (savedStateRegistryKey == keyAndBundle.compatibilityKey) {
       holder.dialog.window?.restoreHierarchyState(keyAndBundle.bundle)
     }
   }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/LayeredDialogSessions.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/LayeredDialogSessions.kt
@@ -18,7 +18,6 @@ import com.squareup.workflow1.ui.androidx.WorkflowAndroidXSupport
 import com.squareup.workflow1.ui.androidx.WorkflowLifecycleOwner
 import com.squareup.workflow1.ui.androidx.WorkflowSavedStateRegistryAggregator
 import com.squareup.workflow1.ui.container.DialogSession.KeyAndBundle
-import com.squareup.workflow1.ui.container.OverlayDialogHolder.Companion.InOverlay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -142,13 +141,7 @@ public class LayeredDialogSessions private constructor(
 
     for ((i, overlay) in overlays.withIndex()) {
       val covered = i < modalIndex
-      // Seed InOverlay before the Dialog is created, so that it's available to
-      // DialogSession before the first call to OverlayDialogHolder.show (which is
-      // what normally sets it).
-      // https://github.com/square/workflow-kotlin/issues/825
-      val envPlusInOverlay = envPlusBounds + (InOverlay to overlay)
-      val dialogEnv =
-        if (covered) envPlusInOverlay + (CoveredByModal to true) else envPlusInOverlay
+      val dialogEnv = if (covered) envPlusBounds + (CoveredByModal to true) else envPlusBounds
 
       updatedSessions += if (i < sessions.size && sessions[i].holder.canShow(overlay)) {
         // There is already a dialog at this index, and it is compatible
@@ -162,7 +155,7 @@ public class LayeredDialogSessions private constructor(
               holder.dialog.maintainBounds(holder.environment) { b -> updateBounds(b) }
             }
 
-            DialogSession(i, holder).also { newSession ->
+            DialogSession(i, overlay, holder).also { newSession ->
               // Prime the pump, make the first call to OverlayDialog.show to update
               // the new dialog to reflect the first rendering.
               newSession.holder.show(overlay, dialogEnv)

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/OverlayDialogHolder.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/OverlayDialogHolder.kt
@@ -4,11 +4,8 @@ import android.app.Dialog
 import android.graphics.Rect
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ViewEnvironment
-import com.squareup.workflow1.ui.ViewEnvironmentKey
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compatible
-import com.squareup.workflow1.ui.container.OverlayDialogHolder.Companion.InOverlay
-import com.squareup.workflow1.ui.container.OverlayDialogHolder.Companion.NoOverlay
 import com.squareup.workflow1.ui.onBackPressedDispatcherOwnerOrNull
 import com.squareup.workflow1.ui.show
 
@@ -29,7 +26,7 @@ public interface OverlayDialogHolder<in OverlayT : Overlay> {
    * The function that is run by [show] to update [dialog] with a new [Screen] rendering and
    * [ViewEnvironment].
    *
-   * Prefer calling [show] to using this directly, to ensure that [InOverlay] is
+   * Prefer calling [show] to using this directly, to ensure that [overlayOrNull] is
    * maintained correctly, and [showing] keeps working.
    */
   public val runner: (rendering: OverlayT, environment: ViewEnvironment) -> Unit
@@ -58,24 +55,6 @@ public interface OverlayDialogHolder<in OverlayT : Overlay> {
    * method.
    */
   public val onBackPressed: (() -> Unit)?
-
-  public companion object {
-    /**
-     * Default value returned for the [InOverlay] [ViewEnvironmentKey], and therefore the
-     * default value returned by the [showing] method. Indicates that [show] has not yet
-     * been called, during the window between a [OverlayDialogHolder] being instantiated,
-     * and the first call to [show].
-     */
-    public object NoOverlay : Overlay
-
-    /**
-     * Provides access to the [Overlay] instance most recently shown in an
-     * [OverlayDialogHolder]'s [dialog] via [show]. Call [showing] for more convenient access.
-     */
-    public object InOverlay : ViewEnvironmentKey<Overlay>(Overlay::class) {
-      override val default: Overlay = NoOverlay
-    }
-  }
 }
 
 /**
@@ -84,15 +63,13 @@ public interface OverlayDialogHolder<in OverlayT : Overlay> {
  */
 @WorkflowUiExperimentalApi
 public fun OverlayDialogHolder<*>.canShow(overlay: Overlay): Boolean {
-  // The ShowingNothing case covers bootstrapping, during the first call to show()
-  // from OverlayDialogFactory.start().
-  return showing.let { it is NoOverlay || compatible(it, overlay) }
+  // The null case covers bootstrapping, during the first call to show().
+  return dialog.overlayOrNull?.let { compatible(it, overlay) } ?: true
 }
 
 /**
  * Updates the [dialog][OverlayDialogHolder.dialog] managed by the receiver to
  * display [overlay], and updates the receiver's [environment] as well.
- * The new [environment] will hold a reference to [overlay] with key [InOverlay].
  */
 @WorkflowUiExperimentalApi
 public fun <OverlayT : Overlay> OverlayDialogHolder<OverlayT>.show(
@@ -101,8 +78,9 @@ public fun <OverlayT : Overlay> OverlayDialogHolder<OverlayT>.show(
 ) {
   // Why is this an extension rather than part of the interface?
   // When wrapping, we need to prevent recursive calls from clobbering
-  // `environment[InOverlay]` with the nested rendering type.
-  runner(overlay, environment + (InOverlay to overlay))
+  // `overlayOrNull` with the nested rendering type.
+  dialog.overlay = overlay
+  runner(overlay, environment)
 }
 
 /**
@@ -114,7 +92,7 @@ public fun <OverlayT : Overlay> OverlayDialogHolder<OverlayT>.show(
  */
 @WorkflowUiExperimentalApi
 public val OverlayDialogHolder<*>.showing: Overlay
-  get() = environment[InOverlay]
+  get() = dialog.overlay
 
 @WorkflowUiExperimentalApi
 public fun <OverlayT : Overlay> OverlayDialogHolder(

--- a/workflow-ui/core-android/src/main/res/values/ids.xml
+++ b/workflow-ui/core-android/src/main/res/values/ids.xml
@@ -25,4 +25,8 @@
   <item name="workflow_layout" type="id"/>
   <!-- View Tag for the ViewEnvironment that last updated this view. -->
   <item name="workflow_environment" type="id"/>
+  <!-- View Tag for the Screen that last updated this view. -->
+  <item name="workflow_screen" type="id"/>
+  <!-- View Tag for the Overlay that last updated this Dialog, set on its decor view. -->
+  <item name="workflow_overlay" type="id"/>
 </resources>

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/LegacyAndroidViewRegistryTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/LegacyAndroidViewRegistryTest.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import com.google.common.truth.Truth.assertThat
-import com.squareup.workflow1.ui.ScreenViewHolder.Companion.Showing
 import com.squareup.workflow1.ui.ViewRegistry.Entry
 import com.squareup.workflow1.ui.container.mockView
 import org.junit.Test
@@ -126,21 +125,21 @@ internal class LegacyAndroidViewRegistryTest {
     assertThat(overrideViewRenderingFactory.called).isTrue()
   }
 
-  @Test fun `buildView auto converts unwrapped Screen and updates Showing correctly`() {
+  @Test fun `buildView auto converts unwrapped Screen and updates screenOrNull correctly`() {
     val registry = ViewRegistry()
     val view = registry.buildView(ScreenRendering)
     view.start()
     assertThat(view.getRendering<Any>()).isSameInstanceAs(ScreenRendering)
-    assertThat(view.environmentOrNull!![Showing]).isSameInstanceAs(ScreenRendering)
+    assertThat(view.screenOrNull).isSameInstanceAs(ScreenRendering)
   }
 
-  @Test fun `buildView auto converts wrapped Screen and updates Showing correctly`() {
+  @Test fun `buildView auto converts wrapped Screen and updates screen correctly`() {
     val registry = ViewRegistry()
     val rendering = Named(ScreenRendering, "fnord")
     val view = registry.buildView(rendering)
     view.start()
     assertThat(compatible(view.getRendering()!!, rendering)).isTrue()
-    assertThat(compatible(view.environmentOrNull!![Showing], asScreen(rendering))).isTrue()
+    assertThat(compatible(view.screen, asScreen(rendering))).isTrue()
   }
 
   @Test fun `ViewRegistry with no arguments infers type`() {

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Named.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Named.kt
@@ -1,8 +1,6 @@
 package com.squareup.workflow1.ui
 
 /**
- * **This will be deprecated in favor of [NamedScreen] very soon.**
- *
  * Allows renderings that do not implement [Compatible] themselves to be distinguished
  * by more than just their type. Instances are [compatible] if they have the same name
  * and have [compatible] [wrapped] fields.


### PR DESCRIPTION
Using the `ViewEnvironment` to hold the current `Screen` and `Overlay` was conceptually very clean, but was bad for performance in Compose, which would recompose too often when a new `ViewEnvironment` was not equal to the previous one -- all due to `Showing` being updated. We now store the canonical `Screen` rendering for each `View` in a tag, and the `Overlay` for each `Dialog` in a tag on its decorView.

Fixes #844