### PR TITLE
`ViewStateRenderers.WorkflowViewRenderer` renamed.

### DIFF
--- a/workflow-ui/radiography/api/radiography.api
+++ b/workflow-ui/radiography/api/radiography.api
@@ -1,4 +1,5 @@
 public final class com/squareup/workflow1/ui/radiography/WorkflowViewRendererKt {
 	public static final fun getWorkflowViewRenderer (Lradiography/ViewStateRenderers;)Lradiography/ViewStateRenderer;
+	public static final fun getWorkflowViewStateRenderer ()Lradiography/ViewStateRenderer;
 }
 

--- a/workflow-ui/radiography/src/main/java/com/squareup/workflow1/ui/radiography/WorkflowViewRenderer.kt
+++ b/workflow-ui/radiography/src/main/java/com/squareup/workflow1/ui/radiography/WorkflowViewRenderer.kt
@@ -19,7 +19,11 @@ import radiography.ViewStateRenderers
  * that return non-null values from [getRendering] or [screenOrNull].
  */
 @Suppress("unused")
+@Deprecated("Use WorkflowViewStateRenderer", ReplaceWith("WorkflowViewStateRenderer"))
 public val ViewStateRenderers.WorkflowViewRenderer: ViewStateRenderer
+  get() = WorkflowViewStateRenderer
+
+public val WorkflowViewStateRenderer: ViewStateRenderer
   get() = WorkflowViewRendererImpl
 
 @OptIn(WorkflowUiExperimentalApi::class)


### PR DESCRIPTION
`ViewStateRenderers.WorkflowViewRenderer` is now `WorkflowViewStateRenderer`. Making it an extension on `ViewStateRenderers` confused Kotlin, and served no purpose.