### PR TITLE
capture KMP publications in artifacts-check

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -51,6 +51,26 @@ jobs :
             siteDokka --build-cache --stacktrace
           cache-read-only: false
 
+  # the `artifactsCheck` task has to run on macOS in order to see the iOS KMP artifacts
+  artifacts-check :
+    name : ArtifactsCheck
+    runs-on : macos-latest
+    timeout-minutes : 20
+    steps :
+      - uses : actions/checkout@v3
+      - name : set up JDK 11
+        uses : actions/setup-java@v3
+        with :
+          distribution: 'zulu'
+          java-version : 11
+
+      ## Actual task
+      - uses: gradle/gradle-build-action@v2
+        name : check published artifacts
+        with :
+          arguments : artifactsCheck
+          cache-read-only: false
+
   # These are all pretty quick so we run them on a single shard. Fewer shards, less queueing.
   check :
     name : Check
@@ -70,7 +90,7 @@ jobs :
         name : Check with Gradle
         with :
           arguments : |
-            check apiCheck checkVersionIsSnapshot artifactsCheck dependencyGuard lint ktlintCheck jvmWorkflowNodeBenchmarkJar --stacktrace --continue
+            allTests test apiCheck checkVersionIsSnapshot dependencyGuard lint ktlintCheck jvmWorkflowNodeBenchmarkJar --stacktrace --continue
           cache-read-only: false
 
       # Report as Github Pull Request Check.

--- a/artifacts.json
+++ b/artifacts.json
@@ -5,7 +5,8 @@
     "artifactId": "workflow-internal-testing-utils",
     "description": "Workflow internal testing utilities",
     "packaging": "jar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
   },
   {
     "gradlePath": ":trace-encoder",
@@ -13,7 +14,35 @@
     "artifactId": "trace-encoder",
     "description": "Trace Encoder",
     "packaging": "jar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
+  },
+  {
+    "gradlePath": ":workflow-core",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-core-iosarm64",
+    "description": "Workflow Core",
+    "packaging": "klib",
+    "javaVersion": "1.8",
+    "publicationName": "iosArm64"
+  },
+  {
+    "gradlePath": ":workflow-core",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-core-iosx64",
+    "description": "Workflow Core",
+    "packaging": "klib",
+    "javaVersion": "1.8",
+    "publicationName": "iosX64"
+  },
+  {
+    "gradlePath": ":workflow-core",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-core-jvm",
+    "description": "Workflow Core",
+    "packaging": "jar",
+    "javaVersion": "1.8",
+    "publicationName": "jvm"
   },
   {
     "gradlePath": ":workflow-core",
@@ -21,7 +50,35 @@
     "artifactId": "workflow-core",
     "description": "Workflow Core",
     "packaging": "jar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "kotlinMultiplatform"
+  },
+  {
+    "gradlePath": ":workflow-runtime",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-runtime-iosarm64",
+    "description": "Workflow Runtime",
+    "packaging": "klib",
+    "javaVersion": "1.8",
+    "publicationName": "iosArm64"
+  },
+  {
+    "gradlePath": ":workflow-runtime",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-runtime-iosx64",
+    "description": "Workflow Runtime",
+    "packaging": "klib",
+    "javaVersion": "1.8",
+    "publicationName": "iosX64"
+  },
+  {
+    "gradlePath": ":workflow-runtime",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-runtime-jvm",
+    "description": "Workflow Runtime",
+    "packaging": "jar",
+    "javaVersion": "1.8",
+    "publicationName": "jvm"
   },
   {
     "gradlePath": ":workflow-runtime",
@@ -29,7 +86,8 @@
     "artifactId": "workflow-runtime",
     "description": "Workflow Runtime",
     "packaging": "jar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "kotlinMultiplatform"
   },
   {
     "gradlePath": ":workflow-rx2",
@@ -37,7 +95,8 @@
     "artifactId": "workflow-rx2",
     "description": "Workflow RxJava2",
     "packaging": "jar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
   },
   {
     "gradlePath": ":workflow-testing",
@@ -45,7 +104,8 @@
     "artifactId": "workflow-testing-jvm",
     "description": "Workflow Testing",
     "packaging": "jar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
   },
   {
     "gradlePath": ":workflow-tracing",
@@ -53,7 +113,8 @@
     "artifactId": "workflow-tracing",
     "description": "Workflow Tracing",
     "packaging": "jar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
   },
   {
     "gradlePath": ":workflow-config:config-android",
@@ -61,7 +122,8 @@
     "artifactId": "workflow-config-android",
     "description": "Workflow Runtime Android Configuration",
     "packaging": "aar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
   },
   {
     "gradlePath": ":workflow-config:config-jvm",
@@ -69,7 +131,8 @@
     "artifactId": "workflow-config-jvm",
     "description": "Workflow Runtime JVM Configuration",
     "packaging": "jar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
   },
   {
     "gradlePath": ":workflow-ui:compose",
@@ -77,7 +140,8 @@
     "artifactId": "workflow-ui-compose",
     "description": "Workflow UI Compose",
     "packaging": "aar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
   },
   {
     "gradlePath": ":workflow-ui:compose-tooling",
@@ -85,7 +149,8 @@
     "artifactId": "workflow-ui-compose-tooling",
     "description": "Workflow UI Compose Tooling",
     "packaging": "aar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
   },
   {
     "gradlePath": ":workflow-ui:container-android",
@@ -93,7 +158,8 @@
     "artifactId": "workflow-ui-container-android",
     "description": "Workflow UI Container Android",
     "packaging": "aar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
   },
   {
     "gradlePath": ":workflow-ui:container-common",
@@ -101,7 +167,8 @@
     "artifactId": "workflow-ui-container-common-jvm",
     "description": "Workflow UI Container",
     "packaging": "jar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
   },
   {
     "gradlePath": ":workflow-ui:core-android",
@@ -109,7 +176,8 @@
     "artifactId": "workflow-ui-core-android",
     "description": "Workflow UI Android",
     "packaging": "aar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
   },
   {
     "gradlePath": ":workflow-ui:core-common",
@@ -117,7 +185,8 @@
     "artifactId": "workflow-ui-core-common-jvm",
     "description": "Workflow UI Core",
     "packaging": "jar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
   },
   {
     "gradlePath": ":workflow-ui:radiography",
@@ -125,6 +194,7 @@
     "artifactId": "workflow-ui-radiography",
     "description": "Workflow UI Radiography Support",
     "packaging": "aar",
-    "javaVersion": "1.8"
+    "javaVersion": "1.8",
+    "publicationName": "maven"
   }
 ]

--- a/artifacts.json
+++ b/artifacts.json
@@ -29,6 +29,15 @@
   {
     "gradlePath": ":workflow-core",
     "group": "com.squareup.workflow1",
+    "artifactId": "workflow-core-iossimulatorarm64",
+    "description": "Workflow Core",
+    "packaging": "klib",
+    "javaVersion": "1.8",
+    "publicationName": "iosSimulatorArm64"
+  },
+  {
+    "gradlePath": ":workflow-core",
+    "group": "com.squareup.workflow1",
     "artifactId": "workflow-core-iosx64",
     "description": "Workflow Core",
     "packaging": "klib",
@@ -61,6 +70,15 @@
     "packaging": "klib",
     "javaVersion": "1.8",
     "publicationName": "iosArm64"
+  },
+  {
+    "gradlePath": ":workflow-runtime",
+    "group": "com.squareup.workflow1",
+    "artifactId": "workflow-runtime-iossimulatorarm64",
+    "description": "Workflow Runtime",
+    "packaging": "klib",
+    "javaVersion": "1.8",
+    "publicationName": "iosSimulatorArm64"
   },
   {
     "gradlePath": ":workflow-runtime",

--- a/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/artifacts/ArtifactConfig.kt
+++ b/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/artifacts/ArtifactConfig.kt
@@ -9,16 +9,17 @@ import java.io.Serializable
  * see (Niklas Baudy's
  * [gradle-maven-publish-plugin](https://github.com/vanniktech/gradle-maven-publish-plugin))
  *
- * @param gradlePath the path of the Gradle project, such as `:workflow-core`
- * @param group The maven "group", which should always be `com.squareup.workflow1`. This is the
+ * @property gradlePath the path of the Gradle project, such as `:workflow-core`
+ * @property group The maven "group", which should always be `com.squareup.workflow1`. This is the
  *   `GROUP` property in the Gradle plugin.
- * @param artifactId The maven "module", such as `workflow-core-jvm`. This is the
+ * @property artifactId The maven "module", such as `workflow-core-jvm`. This is the
  *   `POM_ARTIFACT_ID` property in the Gradle plugin.
- * @param description The description of this specific artifact, such as "Workflow Core". This is
+ * @property description The description of this specific artifact, such as "Workflow Core". This is
  *   the `POM_NAME` property in the Gradle plugin.
- * @param packaging `aar` or `jar`. This is the `POM_PACKAGING` property in the Gradle plugin.
- * @param javaVersion the java version of the artifact (typically 8 or 11). If not set
+ * @property packaging `aar` or `jar`. This is the `POM_PACKAGING` property in the Gradle plugin.
+ * @property javaVersion the java version of the artifact (typically 8 or 11). If not set
  *   explicitly, this defaults to the JDK version used to build the artifact.
+ * @property publicationName typically 'maven', but other things for KMP artifacts
  */
 @JsonClass(generateAdapter = true)
 data class ArtifactConfig(
@@ -27,5 +28,8 @@ data class ArtifactConfig(
   val artifactId: String,
   val description: String,
   val packaging: String,
-  val javaVersion: String
-) : Serializable
+  val javaVersion: String,
+  val publicationName: String
+) : Serializable {
+  val key = "$gradlePath+$publicationName"
+}


### PR DESCRIPTION
This adds all publications to the `artifactsCheck` task, instead of just looking at the standard jvm ones.

It also pulls this data directly from the Gradle Maven publish plugin's `Publication` object, instead of just looking at what's defined `gradle.properties`.  That `Publication` object is what's used to create the actual pom, so it's a more robust test.