### PR TITLE
Add KMP target for iosSimulatorArm64

### DIFF
--- a/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/KotlinMultiplatformExtensions.kt
+++ b/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/KotlinMultiplatformExtensions.kt
@@ -1,0 +1,18 @@
+package com.squareup.workflow1.buildsrc
+
+import org.gradle.kotlin.dsl.getValue
+import org.gradle.kotlin.dsl.getting
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+fun KotlinMultiplatformExtension.iosWithSimulatorArm64() {
+  ios()
+  iosSimulatorArm64()
+
+  val iosMain by sourceSets.getting
+  val iosSimulatorArm64Main by sourceSets.getting
+  iosSimulatorArm64Main.dependsOn(iosMain)
+
+  val iosTest by sourceSets.getting
+  val iosSimulatorArm64Test by sourceSets.getting
+  iosSimulatorArm64Test.dependsOn(iosTest)
+}

--- a/buildSrc/src/main/java/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/java/kotlin-multiplatform.gradle.kts
@@ -9,4 +9,14 @@ extensions.getByType(JavaPluginExtension::class).apply {
   targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+kotlin {
+  sourceSets {
+    all {
+      languageSettings.apply {
+        optIn("kotlin.RequiresOptIn")
+      }
+    }
+  }
+}
+
 project.kotlinCommonSettings(bomConfigurationName = "commonMainImplementation")

--- a/workflow-core/build.gradle.kts
+++ b/workflow-core/build.gradle.kts
@@ -1,32 +1,22 @@
+import com.squareup.workflow1.buildsrc.iosWithSimulatorArm64
+
 plugins {
   `kotlin-multiplatform`
   published
 }
 
 kotlin {
+  iosWithSimulatorArm64()
   jvm { withJava() }
-  ios()
+}
 
-  sourceSets {
-    all {
-      languageSettings.apply {
-        optIn("kotlin.RequiresOptIn")
-      }
-    }
-    val commonMain by getting {
-      dependencies {
-        api(libs.kotlin.jdk6)
-        api(libs.kotlinx.coroutines.core)
-        // For Snapshot.
-        api(libs.squareup.okio)
-      }
-    }
-    val commonTest by getting {
-      dependencies {
-        implementation(libs.kotlin.test.jdk)
-        implementation(libs.kotlinx.atomicfu)
-        implementation(libs.kotlinx.coroutines.test.common)
-      }
-    }
-  }
+dependencies {
+  commonMainApi(libs.kotlin.jdk6)
+  commonMainApi(libs.kotlinx.coroutines.core)
+  // For Snapshot.
+  commonMainApi(libs.squareup.okio)
+
+  commonTestImplementation(libs.kotlinx.atomicfu)
+  commonTestImplementation(libs.kotlinx.coroutines.test.common)
+  commonTestImplementation(libs.kotlin.test.jdk)
 }

--- a/workflow-runtime/build.gradle.kts
+++ b/workflow-runtime/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.squareup.workflow1.buildsrc.iosWithSimulatorArm64
 import kotlinx.benchmark.gradle.JvmBenchmarkTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -8,6 +9,7 @@ plugins {
 }
 
 kotlin {
+  iosWithSimulatorArm64()
   jvm {
     compilations {
       val main by getting
@@ -26,28 +28,14 @@ kotlin {
       }
     }
   }
-  ios()
+}
 
-  sourceSets {
-    all {
-      languageSettings.apply {
-        optIn("kotlin.RequiresOptIn")
-      }
-    }
-    val commonMain by getting {
-      dependencies {
-        api(libs.kotlinx.coroutines.core)
+dependencies {
+  commonMainApi(project(":workflow-core"))
+  commonMainApi(libs.kotlinx.coroutines.core)
 
-        api(project(":workflow-core"))
-      }
-    }
-    val commonTest by getting {
-      dependencies {
-        implementation(libs.kotlin.test.jdk)
-        implementation(libs.kotlinx.coroutines.test.common)
-      }
-    }
-  }
+  commonTestImplementation(libs.kotlinx.coroutines.test.common)
+  commonTestImplementation(libs.kotlin.test.jdk)
 }
 
 benchmark {


### PR DESCRIPTION
The coroutines bump to 1.6.4 lets us add the iosSimulatorArm64 target to run simulators on M1 macs.