### PR TITLE
update vanniktech publish plugin to `0.21.0` and use the new 'base' version

### DIFF
--- a/buildSrc/src/main/java/published.gradle.kts
+++ b/buildSrc/src/main/java/published.gradle.kts
@@ -1,21 +1,20 @@
-import com.android.build.gradle.TestedExtension
-import com.squareup.workflow1.library
-import com.squareup.workflow1.libsCatalog
+@file:Suppress("UnstableApiUsage")
+
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.KotlinJvm
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
   id("org.jetbrains.dokka")
-  id("com.vanniktech.maven.publish")
+  id("com.vanniktech.maven.publish.base")
   // track all runtime classpath dependencies for anything we ship
   id("dependency-guard")
 }
 
-group = project.property("GROUP") as String
 version = project.property("VERSION_NAME") as String
-
-mavenPublish {
-  sonatypeHost = SonatypeHost.S01
-}
 
 tasks.register("checkVersionIsSnapshot") {
   doLast {
@@ -25,4 +24,63 @@ tasks.register("checkVersionIsSnapshot") {
         " to the main branch, but instead it's `$version`."
     }
   }
+}
+
+configure<MavenPublishBaseExtension> {
+  publishToMavenCentral(SonatypeHost.S01)
+  // Will only apply to non snapshot builds.
+  signAllPublications()
+  // import all settings from root project and project-specific gradle.properties files
+  pomFromGradleProperties()
+
+  val artifactId = project.property("POM_ARTIFACT_ID") as String
+  val pomDescription = project.property("POM_NAME") as String
+
+  pluginManager.withPlugin("com.android.library") {
+    configure(AndroidSingleVariantLibrary(sourcesJar = true))
+    setPublicationProperties(pomDescription, artifactId)
+  }
+  pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+    configure(KotlinJvm(javadocJar = Dokka(taskName = "dokkaGfm"), sourcesJar = true))
+    setPublicationProperties(pomDescription, artifactId)
+  }
+  pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+    configure(KotlinMultiplatform(javadocJar = Dokka(taskName = "dokkaGfm")))
+    // don't set the artifactId for KMP, because this is handled by the KMP plugin itself
+    setPublicationProperties(pomDescription, artifactIdOrNull = null)
+  }
+}
+
+fun setPublicationProperties(
+  pomDescription: String,
+  artifactIdOrNull: String?
+) {
+  // This has to be inside an `afterEvaluate { }` because these publications are created lazily,
+  // using the project's `name`, which is just the directory name instead of the actual artifact id.
+  // We can't set `name` because it's immutable, so we have to wait until the publication is
+  // created, then overwrite the incorrect value.
+  afterEvaluate {
+    configure<PublishingExtension> {
+      publications.filterIsInstance<MavenPublication>()
+        .forEach { publication ->
+
+          if (artifactIdOrNull != null) {
+            publication.artifactId = artifactIdOrNull
+          }
+          publication.pom.description.set(pomDescription)
+
+          // Note that we're setting the `groupId` of this specific publication,
+          // and not `Project.group`.  By default, `Project.group` is a project's parent,
+          // so for example the group of `:workflow-ui:compose` is `workflow-ui`.  If we set every
+          // project's `group` to the group id, then we use the natural disambiguation of unique
+          // paths.  For instance, projects with paths of `:lib1:core` and `:lib2:core`
+          // and a group of `com.example` would both have the coordinates of `com.example:core`.
+          publication.groupId = project.property("GROUP") as String
+        }
+    }
+  }
+}
+
+tasks.withType(PublishToMavenRepository::class.java).configureEach {
+  notCompatibleWithConfigurationCache("See https://github.com/gradle/gradle/issues/13468")
 }

--- a/dependencies/classpath.txt
+++ b/dependencies/classpath.txt
@@ -66,7 +66,7 @@ com.google.testing.platform:core-proto:0.0.8-alpha07
 com.googlecode.java-diff-utils:diffutils:1.3.0
 com.googlecode.json-simple:json-simple:1.1
 com.googlecode.juniversalchardet:juniversalchardet:1.0.3
-com.squareup.moshi:moshi:1.12.0
+com.squareup.moshi:moshi:1.13.0
 com.squareup.okhttp3:okhttp:3.14.9
 com.squareup.okio:okio:2.10.0
 com.squareup.retrofit2:converter-moshi:2.9.0
@@ -77,7 +77,8 @@ com.squareup:kotlinpoet:1.3.0
 com.sun.activation:javax.activation:1.2.0
 com.sun.istack:istack-commons-runtime:3.0.8
 com.sun.xml.fastinfoset:FastInfoset:1.2.16
-com.vanniktech:gradle-maven-publish-plugin:0.18.0
+com.vanniktech:gradle-maven-publish-plugin:0.21.0
+com.vanniktech:nexus:0.21.0
 commons-codec:commons-codec:1.10
 commons-io:commons-io:2.4
 commons-logging:commons-logging:1.2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,7 +81,7 @@ squareup-workflow = "1.0.0"
 
 timber = "4.7.1"
 truth = "1.1.3"
-vanniktech-publish = "0.18.0"
+vanniktech-publish = "0.21.0"
 
 [plugins]
 


### PR DESCRIPTION
This takes care of publish-time warnings like this one:

> \> Configure project :workflow-config:config-android
WARNING:Software Components will not be created automatically for Maven publishing from Android Gradle Plugin 8.0. To opt-in to the future behavior, set the Gradle property android.disableAutomaticComponentCreation=true in the `gradle.properties` file or use the new publishing DSL.

Full changelog for the plugin: https://github.com/vanniktech/gradle-maven-publish-plugin/blob/master/CHANGELOG.md#version-0210-2022-07-11