### PR TITLE
publish snapshots using a `macos-latest` runner

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish-snapshot :
-    runs-on : ubuntu-latest
+    runs-on : macos-latest
     if : github.repository == 'square/workflow-kotlin'
     timeout-minutes : 25
 


### PR DESCRIPTION
We must use macOS in order to create the iOS artifacts.