### PR TITLE
Add Simultaneous Worker Listener Actions

### DIFF
--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemWorkflow.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemWorkflow.kt
@@ -63,6 +63,7 @@ class PerformancePoemWorkflow(
 ) : PoemWorkflow, StatefulWorkflow<Poem, State, ClosePoem, OverviewDetailScreen>() {
 
   sealed class State {
+    val isLoading: Boolean = false
     // N.B. This state is a smell. We include it to be able to mimic smells
     // we encounter in real life. Best practice would be to fold it
     // into [Selected(NO_SELECTED_STANZA)] at the very least.
@@ -95,6 +96,16 @@ class PerformancePoemWorkflow(
     renderState: State,
     context: RenderContext
   ): OverviewDetailScreen {
+    if (simulatedPerfConfig.simultaneousActions > 0) {
+      repeat(simulatedPerfConfig.simultaneousActions) { index ->
+        context.runningWorker(
+          worker = isLoading.asTraceableWorker("SimultaneousSubscribePoem-$index"),
+          key = "Poem-$index"
+        ) {
+          noAction()
+        }
+      }
+    }
     return when (renderState) {
       Initializing -> {
         // Again, the entire `Initializing` state is a smell, which is most obvious from the

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemsBrowserWorkflow.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemsBrowserWorkflow.kt
@@ -8,6 +8,7 @@ import com.squareup.benchmarks.performance.complex.poetry.PerformancePoemsBrowse
 import com.squareup.benchmarks.performance.complex.poetry.instrumentation.ActionHandlingTracingInterceptor
 import com.squareup.benchmarks.performance.complex.poetry.instrumentation.SimulatedPerfConfig
 import com.squareup.benchmarks.performance.complex.poetry.instrumentation.TraceableWorker
+import com.squareup.benchmarks.performance.complex.poetry.instrumentation.asTraceableWorker
 import com.squareup.benchmarks.performance.complex.poetry.views.BlankScreen
 import com.squareup.sample.container.overviewdetail.OverviewDetailScreen
 import com.squareup.sample.poetry.PoemListScreen.Companion.NO_POEM_SELECTED
@@ -18,6 +19,7 @@ import com.squareup.sample.poetry.PoemsBrowserWorkflow
 import com.squareup.sample.poetry.model.Poem
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
+import com.squareup.workflow1.WorkflowAction.Companion.noAction
 import com.squareup.workflow1.action
 import com.squareup.workflow1.runningWorker
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
@@ -76,6 +78,16 @@ class PerformancePoemsBrowserWorkflow(
     renderState: State,
     context: RenderContext
   ): OverviewDetailScreen {
+    if (simulatedPerfConfig.simultaneousActions > 0) {
+      repeat(simulatedPerfConfig.simultaneousActions) { index ->
+        context.runningWorker(
+          worker = isLoading.asTraceableWorker("SimultaneousSubscribeBrowser-$index"),
+          key = "Browser-$index"
+        ) {
+          noAction()
+        }
+      }
+    }
     val poemListProps = Props(
       poems = renderProps,
       eventHandlerTag = ActionHandlingTracingInterceptor::keyForTrace

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoetryActivity.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoetryActivity.kt
@@ -66,6 +66,7 @@ class PerformancePoetryActivity : AppCompatActivity() {
       complexityDelay = intent.getLongExtra(EXTRA_PERF_CONFIG_DELAY, 200L),
       useInitializingState = intent.getBooleanExtra(EXTRA_PERF_CONFIG_INITIALIZING, false),
       repeatOnNext = intent.getIntExtra(EXTRA_PERF_CONFIG_REPEAT, 0),
+      simultaneousActions = intent.getIntExtra(EXTRA_PERF_CONFIG_SIMULTANEOUS, 0),
       traceFrameLatency = intent.getBooleanExtra(EXTRA_PERF_CONFIG_FRAME_LATENCY, false),
       traceEventLatency = intent.getBooleanExtra(EXTRA_PERF_CONFIG_ACTION_TRACING, false),
       traceRenderingPasses = intent.getBooleanExtra(EXTRA_PERF_CONFIG_RENDERING, false)
@@ -241,6 +242,7 @@ class PerformancePoetryActivity : AppCompatActivity() {
     const val EXTRA_PERF_CONFIG_RENDERING = "complex.poetry.performance.config.track.rendering"
     const val EXTRA_PERF_CONFIG_REPEAT = "complex.poetry.performance.config.repeat.amount"
     const val EXTRA_PERF_CONFIG_DELAY = "complex.poetry.performance.config.delay.length"
+    const val EXTRA_PERF_CONFIG_SIMULTANEOUS = "complex.poetry.performance.config.simultaneous"
     const val EXTRA_RUNTIME_FRAME_TIMEOUT =
       "complex.poetry.performance.config.runtime.frametimeout"
 

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/instrumentation/SimulatedPerfConfig.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/instrumentation/SimulatedPerfConfig.kt
@@ -17,6 +17,7 @@ data class SimulatedPerfConfig(
   val complexityDelay: Long,
   val useInitializingState: Boolean,
   val repeatOnNext: Int = 0,
+  val simultaneousActions: Int = 0,
   val traceRenderingPasses: Boolean = false,
   val traceFrameLatency: Boolean = false,
   val traceEventLatency: Boolean = false
@@ -27,6 +28,7 @@ data class SimulatedPerfConfig(
       complexityDelay = 0,
       useInitializingState = false,
       repeatOnNext = 0,
+      simultaneousActions = 0,
       traceRenderingPasses = false,
       traceFrameLatency = false,
       traceEventLatency = false


### PR DESCRIPTION
This reproduces the scenario where you have multiple Workers waiting for the same result and all produce an action. In the RenderPerAction (original runtime) this creates a lot of unnecessary renders.