### PR TITLE
Remove FrameTimeout Runtime; Retry Espresso Tests.

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -100,34 +100,6 @@ jobs :
         with :
           report_paths : '**/build/test-results/test/TEST-*.xml'
 
-  jvm-timeout-runtime-test:
-    name: Frame Timeout Runtime JVM Tests
-    runs-on : ubuntu-latest
-    timeout-minutes : 20
-    steps :
-      - uses : actions/checkout@v3
-      - uses : gradle/wrapper-validation-action@v1
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
-        with :
-          distribution: 'zulu'
-          java-version : 11
-
-      ## Actual task
-      - uses: gradle/gradle-build-action@v2
-        name : Check with Gradle
-        with :
-          arguments : |
-            jvmTest --stacktrace --continue -Pworkflow.runtime=timeout
-          cache-read-only: false
-
-      # Report as Github Pull Request Check.
-      - name : Publish Test Report
-        uses : mikepenz/action-junit-report@v3
-        if : always() # always run even if the previous step fails
-        with :
-          report_paths : '**/build/test-results/test/TEST-*.xml'
-
   ios-tests :
     name : iOS Tests
     runs-on : macos-latest
@@ -255,55 +227,6 @@ jobs :
         with :
           name : instrumentation-test-results-${{ matrix.api-level }}
           path : ./**/build/reports/androidTests/connected/**
-
-  # Turned off due to #850 which re-uses RenderContext.
-  # frame-timeout-instrumentation-tests :
-  #   name : Frame Timeout Instrumentation tests
-  #   runs-on : macos-latest
-  #   timeout-minutes : 45
-  #   strategy :
-  #     # Allow tests to continue on other devices if they fail on one device.
-  #     fail-fast : false
-  #     matrix :
-  #       api-level :
-  #         - 29
-  #     # Unclear that older versions actually honor command to disable animation.
-  #     # Newer versions are reputed to be too slow: https://github.com/ReactiveCircus/android-emulator-runner/issues/222
-  #   steps :
-  #     - uses : actions/checkout@v3
-  #     - name : set up JDK 11
-  #       uses : actions/setup-java@v3
-  #       with :
-  #         distribution : 'zulu'
-  #         java-version : 11
-
-  #     ## Build before running tests, using cache.
-  #     - uses: gradle/gradle-build-action@v2
-  #       name : Build instrumented tests
-  #       with :
-  #         # Unfortunately I don't think we can key this cache based on our project property so
-  #         # we clean and rebuild.
-  #         arguments : |
-  #           clean assembleDebugAndroidTest --stacktrace -Pworkflow.runtime=timeout
-  #         cache-read-only: false
-
-  #     ## Actual task
-  #     - name : Instrumentation Tests
-  #       uses : reactivecircus/android-emulator-runner@v2
-  #       with :
-  #         # @ychescale9 suspects Galaxy Nexus is the fastest one
-  #         profile : Galaxy Nexus
-  #         api-level : ${{ matrix.api-level }}
-  #         arch : x86_64
-  #         # Skip the benchmarks as this is running on emulators
-  #         script : ./gradlew connectedCheck -x :benchmarks:dungeon-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-poetry:connectedCheck --stacktrace -Pworkflow.runtime=timeout
-
-  #     - name : Upload results
-  #       if : ${{ always() }}
-  #       uses : actions/upload-artifact@v3
-  #       with :
-  #         name : instrumentation-test-results-${{ matrix.api-level }}
-  #         path : ./**/build/reports/androidTests/connected/**
 
   upload-to-mobiledev :
     name : mobile.dev | Build & Upload

--- a/benchmarks/performance-poetry/complex-benchmark/src/main/java/com/squareup/benchmarks/performance/complex/poetry/benchmark/ComplexPoetryBenchmarks.kt
+++ b/benchmarks/performance-poetry/complex-benchmark/src/main/java/com/squareup/benchmarks/performance/complex/poetry/benchmark/ComplexPoetryBenchmarks.kt
@@ -132,8 +132,8 @@ class ComplexPoetryBenchmarks {
     ) {
       startActivityAndWait { intent ->
         intent.apply {
-          putExtra(PerformancePoetryActivity.EXTRA_PERF_CONFIG_INITIALIZING, true)
-          putExtra(PerformancePoetryActivity.EXTRA_PERF_CONFIG_RENDERING, true)
+          putExtra(PerformancePoetryActivity.EXTRA_SCENARIO_CONFIG_INITIALIZING, true)
+          putExtra(PerformancePoetryActivity.EXTRA_TRACE_RENDER_PASSES, true)
           if (useHighFrequencyEvents) {
             putExtra(
               PerformancePoetryActivity.EXTRA_PERF_CONFIG_REPEAT,
@@ -203,8 +203,8 @@ class ComplexPoetryBenchmarks {
             PerformancePoetryActivity.HIGH_FREQUENCY_REPEAT_COUNT
           )
         }
-        putExtra(PerformancePoetryActivity.EXTRA_PERF_CONFIG_INITIALIZING, true)
-        putExtra(PerformancePoetryActivity.EXTRA_PERF_CONFIG_ACTION_TRACING, true)
+        putExtra(PerformancePoetryActivity.EXTRA_SCENARIO_CONFIG_INITIALIZING, true)
+        putExtra(PerformancePoetryActivity.EXTRA_TRACE_ACTION_TRACING, true)
         putExtra(PerformancePoetryActivity.EXTRA_TRACE_SELECT_TIMEOUTS, true)
       }
     }
@@ -251,8 +251,8 @@ class ComplexPoetryBenchmarks {
   @Test fun benchmarkLatencyWithFrameCallbacks() {
     fun addLatencyTracing(intent: Intent) {
       intent.apply {
-        putExtra(PerformancePoetryActivity.EXTRA_PERF_CONFIG_INITIALIZING, true)
-        putExtra(PerformancePoetryActivity.EXTRA_PERF_CONFIG_FRAME_LATENCY, true)
+        putExtra(PerformancePoetryActivity.EXTRA_SCENARIO_CONFIG_INITIALIZING, true)
+        putExtra(PerformancePoetryActivity.EXTRA_TRACE_FRAME_LATENCY, true)
       }
     }
 

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoetryActivity.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoetryActivity.kt
@@ -21,7 +21,6 @@ import com.squareup.benchmarks.performance.complex.poetry.instrumentation.Simula
 import com.squareup.sample.container.SampleContainers
 import com.squareup.sample.poetry.model.Poem
 import com.squareup.workflow1.RuntimeConfig
-import com.squareup.workflow1.RuntimeConfig.FrameTimeout
 import com.squareup.workflow1.RuntimeConfig.RenderPerAction
 import com.squareup.workflow1.WorkflowExperimentalRuntime
 import com.squareup.workflow1.WorkflowInterceptor
@@ -64,12 +63,12 @@ class PerformancePoetryActivity : AppCompatActivity() {
     val simulatedPerfConfig = SimulatedPerfConfig(
       isComplex = true,
       complexityDelay = intent.getLongExtra(EXTRA_PERF_CONFIG_DELAY, 200L),
-      useInitializingState = intent.getBooleanExtra(EXTRA_PERF_CONFIG_INITIALIZING, false),
+      useInitializingState = intent.getBooleanExtra(EXTRA_SCENARIO_CONFIG_INITIALIZING, false),
       repeatOnNext = intent.getIntExtra(EXTRA_PERF_CONFIG_REPEAT, 0),
       simultaneousActions = intent.getIntExtra(EXTRA_PERF_CONFIG_SIMULTANEOUS, 0),
-      traceFrameLatency = intent.getBooleanExtra(EXTRA_PERF_CONFIG_FRAME_LATENCY, false),
-      traceEventLatency = intent.getBooleanExtra(EXTRA_PERF_CONFIG_ACTION_TRACING, false),
-      traceRenderingPasses = intent.getBooleanExtra(EXTRA_PERF_CONFIG_RENDERING, false)
+      traceFrameLatency = intent.getBooleanExtra(EXTRA_TRACE_FRAME_LATENCY, false),
+      traceEventLatency = intent.getBooleanExtra(EXTRA_TRACE_ACTION_TRACING, false),
+      traceRenderingPasses = intent.getBooleanExtra(EXTRA_TRACE_RENDER_PASSES, false)
     )
 
     require(!(simulatedPerfConfig.traceFrameLatency && simulatedPerfConfig.traceRenderingPasses)) {
@@ -84,8 +83,7 @@ class PerformancePoetryActivity : AppCompatActivity() {
       installedInterceptor = ActionHandlingTracingInterceptor()
     }
 
-    val isFrameTimeout = intent.getBooleanExtra(EXTRA_RUNTIME_FRAME_TIMEOUT, false)
-    val runtimeConfig = if (isFrameTimeout) FrameTimeout() else RenderPerAction
+    val runtimeConfig = RenderPerAction
 
     val component =
       PerformancePoetryComponent(installedInterceptor, simulatedPerfConfig, runtimeConfig)
@@ -234,17 +232,16 @@ class PerformancePoetryActivity : AppCompatActivity() {
     const val EXTRA_TRACE_SELECT_TIMEOUTS =
       "complex.poetry.performance.config.trace.select.timeouts"
     const val EXTRA_TRACE_ALL_MAIN_THREAD_MESSAGES = "complex.poetry.performance.config.trace.main"
-    const val EXTRA_PERF_CONFIG_INITIALIZING = "complex.poetry.performance.config.use.initializing"
-    const val EXTRA_PERF_CONFIG_ACTION_TRACING =
+    const val EXTRA_SCENARIO_CONFIG_INITIALIZING =
+      "complex.poetry.performance.config.use.initializing"
+    const val EXTRA_TRACE_ACTION_TRACING =
       "complex.poetry.performance.config.track.action.tracing"
-    const val EXTRA_PERF_CONFIG_FRAME_LATENCY =
+    const val EXTRA_TRACE_FRAME_LATENCY =
       "complex.poetry.performance.config.track.frame.latency"
-    const val EXTRA_PERF_CONFIG_RENDERING = "complex.poetry.performance.config.track.rendering"
+    const val EXTRA_TRACE_RENDER_PASSES = "complex.poetry.performance.config.track.rendering"
     const val EXTRA_PERF_CONFIG_REPEAT = "complex.poetry.performance.config.repeat.amount"
     const val EXTRA_PERF_CONFIG_DELAY = "complex.poetry.performance.config.delay.length"
     const val EXTRA_PERF_CONFIG_SIMULTANEOUS = "complex.poetry.performance.config.simultaneous"
-    const val EXTRA_RUNTIME_FRAME_TIMEOUT =
-      "complex.poetry.performance.config.runtime.frametimeout"
 
     const val SELECT_ON_TIMEOUT_LOG_NAME =
       "kotlinx.coroutines.selects.SelectBuilderImpl\$onTimeout\$\$inlined\$Runnable"

--- a/samples/containers/hello-back-button/src/androidTest/java/com/squareup/sample/hellobackbutton/HelloBackButtonEspressoTest.kt
+++ b/samples/containers/hello-back-button/src/androidTest/java/com/squareup/sample/hellobackbutton/HelloBackButtonEspressoTest.kt
@@ -12,6 +12,7 @@ import com.squareup.workflow1.ui.internal.test.DetectLeaksAfterTestSuccess
 import com.squareup.workflow1.ui.internal.test.IdlingDispatcherRule
 import com.squareup.workflow1.ui.internal.test.actuallyPressBack
 import com.squareup.workflow1.ui.internal.test.inAnyView
+import com.squareup.workflow1.ui.internal.test.retryBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -26,7 +27,7 @@ class HelloBackButtonEspressoTest {
     .around(scenarioRule)
     .around(IdlingDispatcherRule)
 
-  @Test fun wrappedTakesPrecedence() {
+  @Test fun wrappedTakesPrecedence() = retryBlocking {
     inAnyView(withId(R.id.hello_message)).apply {
       check(matches(withText("Able")))
       perform(click())
@@ -40,7 +41,7 @@ class HelloBackButtonEspressoTest {
     }
   }
 
-  @Test fun outerHandlerAppliesIfWrappedHandlerIsNull() {
+  @Test fun outerHandlerAppliesIfWrappedHandlerIsNull() = retryBlocking {
     inAnyView(withId(R.id.hello_message)).apply {
       actuallyPressBack()
       inAnyView(withText("Are you sure you want to do this thing?"))

--- a/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
+++ b/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
@@ -23,6 +23,7 @@ import com.squareup.workflow1.ui.internal.test.DetectLeaksAfterTestSuccess
 import com.squareup.workflow1.ui.internal.test.IdlingDispatcherRule
 import com.squareup.workflow1.ui.internal.test.actuallyPressBack
 import com.squareup.workflow1.ui.internal.test.inAnyView
+import com.squareup.workflow1.ui.internal.test.retryBlocking
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.endsWith
 import org.junit.After
@@ -64,7 +65,7 @@ class TicTacToeEspressoTest {
     }
   }
 
-  @Test fun configChangeReflectsWorkflowState() {
+  @Test fun configChangeReflectsWorkflowState() = retryBlocking {
     inAnyView(withId(R.id.login_email)).type("bad email")
     inAnyView(withId(R.id.login_button)).perform(click())
 
@@ -73,7 +74,7 @@ class TicTacToeEspressoTest {
     inAnyView(withId(R.id.login_error_message)).check(matches(withText("Invalid address")))
   }
 
-  @Test fun editTextSurvivesConfigChange() {
+  @Test fun editTextSurvivesConfigChange() = retryBlocking {
     inAnyView(withId(R.id.login_email)).type("foo@bar")
     inAnyView(withId(R.id.login_password)).type("password")
     rotate()
@@ -82,7 +83,7 @@ class TicTacToeEspressoTest {
     inAnyView(withId(R.id.login_password)).check(matches(withText("")))
   }
 
-  @Test fun backStackPopRestoresViewState() {
+  @Test fun backStackPopRestoresViewState() = retryBlocking {
     // The loading screen is pushed onto the back stack.
     inAnyView(withId(R.id.login_email)).type("foo@bar")
     inAnyView(withId(R.id.login_password)).type("bad password")
@@ -95,7 +96,7 @@ class TicTacToeEspressoTest {
       .check(matches(withText("Unknown email or invalid password")))
   }
 
-  @Test fun dialogSurvivesConfigChange() {
+  @Test fun dialogSurvivesConfigChange() = retryBlocking {
     inAnyView(withId(R.id.login_email)).type("foo@bar")
     inAnyView(withId(R.id.login_password)).type("password")
     inAnyView(withId(R.id.login_button)).perform(click())
@@ -112,7 +113,7 @@ class TicTacToeEspressoTest {
       .check(matches(isDisplayed()))
   }
 
-  @Test fun canGoBackFromAlert() {
+  @Test fun canGoBackFromAlert() = retryBlocking {
     inAnyView(withId(R.id.login_email)).type("foo@bar")
     inAnyView(withId(R.id.login_password)).type("password")
     inAnyView(withId(R.id.login_button)).perform(click())
@@ -133,7 +134,7 @@ class TicTacToeEspressoTest {
     clickCell(0)
   }
 
-  @Test fun canGoBackInModalViewAndSeeRestoredViewState() {
+  @Test fun canGoBackInModalViewAndSeeRestoredViewState() = retryBlocking {
     // Log in and hit the 2fa screen.
     inAnyView(withId(R.id.login_email)).type("foo@2fa")
     inAnyView(withId(R.id.login_password)).type("password")
@@ -146,7 +147,7 @@ class TicTacToeEspressoTest {
     inAnyView(withId(R.id.login_email)).check(matches(withText("foo@2fa")))
   }
 
-  @Test fun canGoBackInModalViewAfterConfigChangeAndSeeRestoredViewState() {
+  @Test fun canGoBackInModalViewAfterConfigChangeAndSeeRestoredViewState() = retryBlocking {
     // Log in and hit the 2fa screen.
     inAnyView(withId(R.id.login_email)).type("foo@2fa")
     inAnyView(withId(R.id.login_password)).type("password")
@@ -164,7 +165,7 @@ class TicTacToeEspressoTest {
    * On tablets this revealed a problem with SavedStateRegistry.
    * https://github.com/square/workflow-kotlin/pull/656#issuecomment-1027274391
    */
-  @Test fun fullJourney() {
+  @Test fun fullJourney() = retryBlocking {
     inAnyView(withId(R.id.login_email)).type("foo@bar")
     inAnyView(withId(R.id.login_password)).type("password")
     inAnyView(withId(R.id.login_button)).perform(click())

--- a/workflow-config/README.md
+++ b/workflow-config/README.md
@@ -5,7 +5,7 @@
 Configuration for the Runtime while running on the JVM. This allows one to specify a project
 property from the gradle build to choose a runtime for JVM tests.
 
-e.g. add "-Pworkflow.runtime=timeout".
+e.g. add "-Pworkflow.runtime=baseline".
 
 Note that this will only work for jvm based tests, use config-android for applications and
 application tests.
@@ -19,7 +19,7 @@ via the utility provided:
 
 Configuration for the Workflow Runtime when building an application.
 
-Add "-Pworkflow.runtime=timeout" to the gradle command for building the app.
+Add "-Pworkflow.runtime=baseline" to the gradle command for building the app.
 
 Your application will also need to fetch the configured `RuntimeConfig` and pass it to
 `renderWorkflowIn` or `renderAsState`. You can fetch it with the utility provided:

--- a/workflow-config/config-android/src/main/java/com/squareup/workflow1/config/AndroidRuntimeConfigTools.kt
+++ b/workflow-config/config-android/src/main/java/com/squareup/workflow1/config/AndroidRuntimeConfigTools.kt
@@ -1,7 +1,6 @@
 package com.squareup.workflow1.config
 
 import com.squareup.workflow1.RuntimeConfig
-import com.squareup.workflow1.RuntimeConfig.FrameTimeout
 import com.squareup.workflow1.RuntimeConfig.RenderPerAction
 import com.squareup.workflow1.WorkflowExperimentalRuntime
 
@@ -18,14 +17,12 @@ public class AndroidRuntimeConfigTools {
      * this function, and then pass that to the call to [renderWorkflowIn] as the [RuntimeConfig].
      *
      * Current options are:
-     * "timeout" : [FrameTimeout] Process Multiple Actions w/ a Frame Timeout.
      * "baseline" : [RenderPerAction] Original Workflow Runtime. Note that this doesn't need to
      *      be specified as it is the current default and is assumed by this utility.
      */
     @WorkflowExperimentalRuntime
     public fun getAppWorkflowRuntimeConfig(): RuntimeConfig {
       return when (BuildConfig.WORKFLOW_RUNTIME) {
-        "timeout" -> FrameTimeout()
         else -> RenderPerAction
       }
     }

--- a/workflow-config/config-jvm/src/main/java/com/squareup/workflow1/config/JvmTestRuntimeConfigTools.kt
+++ b/workflow-config/config-jvm/src/main/java/com/squareup/workflow1/config/JvmTestRuntimeConfigTools.kt
@@ -1,7 +1,6 @@
 package com.squareup.workflow1.config
 
 import com.squareup.workflow1.RuntimeConfig
-import com.squareup.workflow1.RuntimeConfig.FrameTimeout
 import com.squareup.workflow1.RuntimeConfig.RenderPerAction
 import com.squareup.workflow1.WorkflowExperimentalRuntime
 
@@ -17,17 +16,16 @@ public class JvmTestRuntimeConfigTools {
      * [RuntimeConfig].
      *
      * Current options are:
-     * "timeout" : [FrameTimeout] Process Multiple Actions w/ a Frame Timeout.
      * "baseline" : [RenderPerAction] Original Workflow Runtime. Note that this doesn't need to
      *      be specified as it is the current default and is assumed by this utility.
      */
     @OptIn(WorkflowExperimentalRuntime::class)
     public fun getTestRuntimeConfig(): RuntimeConfig {
-      val runtimeConfig = System.getProperty("workflow.runtime", "baseline")
-      return when (runtimeConfig) {
-        "timeout" -> FrameTimeout()
-        else -> RenderPerAction
-      }
+      return RenderPerAction
+      // val runtimeConfig = System.getProperty("workflow.runtime", "baseline")
+      // return when (runtimeConfig) {
+      //   else -> RenderPerAction
+      // }
     }
   }
 }

--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -164,10 +164,6 @@ public final class com/squareup/workflow1/StatelessWorkflow$RenderContext : com/
 	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
-public final class com/squareup/workflow1/TimeoutForFrame : com/squareup/workflow1/ActionProcessingResult {
-	public static final field INSTANCE Lcom/squareup/workflow1/TimeoutForFrame;
-}
-
 public final class com/squareup/workflow1/TypedWorker : com/squareup/workflow1/Worker {
 	public fun <init> (Lkotlin/reflect/KType;Lkotlinx/coroutines/flow/Flow;)V
 	public fun doesSameWorkAs (Lcom/squareup/workflow1/Worker;)Z

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowAction.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowAction.kt
@@ -118,7 +118,6 @@ public fun <PropsT, StateT, OutputT> WorkflowAction<PropsT, StateT, OutputT>.app
 public sealed interface ActionProcessingResult
 
 public object PropsUpdated : ActionProcessingResult
-public object TimeoutForFrame : ActionProcessingResult
 
 /** Wrapper around a potentially-nullable [OutputT] value. */
 public class WorkflowOutput<out OutputT>(public val value: OutputT) : ActionProcessingResult {

--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -28,19 +28,6 @@ public final class com/squareup/workflow1/RuntimeConfig$Companion {
 	public final fun getDEFAULT_CONFIG ()Lcom/squareup/workflow1/RuntimeConfig;
 }
 
-public final class com/squareup/workflow1/RuntimeConfig$FrameTimeout : com/squareup/workflow1/RuntimeConfig {
-	public fun <init> ()V
-	public fun <init> (J)V
-	public synthetic fun <init> (JILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()J
-	public final fun copy (J)Lcom/squareup/workflow1/RuntimeConfig$FrameTimeout;
-	public static synthetic fun copy$default (Lcom/squareup/workflow1/RuntimeConfig$FrameTimeout;JILjava/lang/Object;)Lcom/squareup/workflow1/RuntimeConfig$FrameTimeout;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getFrameTimeoutMs ()J
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class com/squareup/workflow1/RuntimeConfig$RenderPerAction : com/squareup/workflow1/RuntimeConfig {
 	public static final field INSTANCE Lcom/squareup/workflow1/RuntimeConfig$RenderPerAction;
 }
@@ -285,6 +272,6 @@ public final class com/squareup/workflow1/internal/WorkflowRunner {
 	public final fun cancelRuntime (Ljava/util/concurrent/CancellationException;)V
 	public static synthetic fun cancelRuntime$default (Lcom/squareup/workflow1/internal/WorkflowRunner;Ljava/util/concurrent/CancellationException;ILjava/lang/Object;)V
 	public final fun nextRendering ()Lcom/squareup/workflow1/RenderingAndSnapshot;
-	public final fun processActions (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun processAction (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/RenderWorkflow.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/RenderWorkflow.kt
@@ -138,7 +138,7 @@ public fun <PropsT, OutputT, RenderingT> renderWorkflowIn(
       // It might look weird to start by consuming the output before getting the rendering below,
       // but remember the first render pass already occurred above, before this coroutine was even
       // launched.
-      val output: WorkflowOutput<OutputT>? = runner.processActions()
+      val output: WorkflowOutput<OutputT>? = runner.processAction()
 
       // After resuming from runner.nextOutput() our coroutine could now be cancelled, check so we
       // don't surprise anyone with an unexpected rendering pass. Show's over, go home.

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/RuntimeConfig.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/RuntimeConfig.kt
@@ -20,13 +20,6 @@ public annotation class WorkflowExperimentalRuntime
  */
 public sealed interface RuntimeConfig {
   /**
-   * This version of the runtime will process as many actions as possible after one is received
-   * until [frameTimeoutMs] has passed, at which point it will render().
-   */
-  @WorkflowExperimentalRuntime
-  public data class FrameTimeout(public val frameTimeoutMs: Long = 30L) : RuntimeConfig
-
-  /**
    * This is the baseline runtime which will process one action at a time, calling render() after
    * each one.
    */

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowRunnerTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowRunnerTest.kt
@@ -3,7 +3,6 @@ package com.squareup.workflow1.internal
 import com.squareup.workflow1.NoopWorkflowInterceptor
 import com.squareup.workflow1.RuntimeConfig
 import com.squareup.workflow1.RuntimeConfig.Companion
-import com.squareup.workflow1.RuntimeConfig.FrameTimeout
 import com.squareup.workflow1.RuntimeConfig.RenderPerAction
 import com.squareup.workflow1.Worker
 import com.squareup.workflow1.Workflow
@@ -32,7 +31,6 @@ internal class WorkflowRunnerTest {
 
   private val runtimeOptions = arrayOf(
     RenderPerAction,
-    FrameTimeout()
   ).asSequence()
 
   private fun setup() {
@@ -97,7 +95,7 @@ internal class WorkflowRunnerTest {
       )
       runner.nextRendering()
 
-      val outputDeferred = scope.async { runner.processActions() }
+      val outputDeferred = scope.async { runner.processAction() }
 
       scope.runCurrent()
       assertTrue(outputDeferred.isActive)
@@ -126,7 +124,7 @@ internal class WorkflowRunnerTest {
       // Get the runner into the state where it's waiting for a props update.
       val initialRendering = runner.nextRendering().rendering
       assertEquals("initial", initialRendering)
-      val output = scope.async { runner.processActions() }
+      val output = scope.async { runner.processAction() }
       assertTrue(output.isActive)
 
       // Resume the dispatcher to start the coroutines and process the new props value.
@@ -222,7 +220,7 @@ internal class WorkflowRunnerTest {
       val runner =
         WorkflowRunner(workflow, MutableStateFlow(Unit), runtimeConfig)
       runner.nextRendering()
-      val output = scope.async { runner.processActions() }
+      val output = scope.async { runner.processAction() }
       scope.runCurrent()
       assertTrue(output.isActive)
 
@@ -276,7 +274,7 @@ internal class WorkflowRunnerTest {
       val runner =
         WorkflowRunner(workflow, MutableStateFlow(Unit), runtimeConfig)
       runner.nextRendering()
-      val output = scope.async { runner.processActions() }
+      val output = scope.async { runner.processAction() }
       scope.runCurrent()
       assertTrue(output.isActive)
 
@@ -307,7 +305,7 @@ internal class WorkflowRunnerTest {
       val runner =
         WorkflowRunner(workflow, MutableStateFlow(Unit), runtimeConfig)
       runner.nextRendering()
-      val output = scope.async { runner.processActions() }
+      val output = scope.async { runner.processAction() }
       scope.runCurrent()
       assertTrue(output.isActive)
       assertNull(cancellationException)
@@ -322,7 +320,7 @@ internal class WorkflowRunnerTest {
   }
 
   private fun <T> WorkflowRunner<*, T, *>.runTillNextOutput(): WorkflowOutput<T>? = scope.run {
-    val firstOutputDeferred = async { processActions() }
+    val firstOutputDeferred = async { processAction() }
     runCurrent()
     firstOutputDeferred.getCompleted()
   }

--- a/workflow-ui/internal-testing-android/api/internal-testing-android.api
+++ b/workflow-ui/internal-testing-android/api/internal-testing-android.api
@@ -61,6 +61,8 @@ public final class com/squareup/workflow1/ui/internal/test/EspressoKt {
 	public static final fun inAnyView (Lorg/hamcrest/Matcher;)Landroidx/test/espresso/ViewInteraction;
 	public static final fun retry (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun retry$default (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun retryBlocking (Ljava/lang/String;JLkotlin/jvm/functions/Function0;)V
+	public static synthetic fun retryBlocking$default (Ljava/lang/String;JLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 }
 
 public final class com/squareup/workflow1/ui/internal/test/IdleAfterTestRule : org/junit/rules/TestRule {

--- a/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/Espresso.kt
+++ b/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/Espresso.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import junit.framework.AssertionFailedError
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -89,5 +90,15 @@ public suspend inline fun retry(
     }
   } ?: exception?.let {
     throw it
+  }
+}
+
+public inline fun retryBlocking(
+  clue: String = "",
+  timeout_ms: Long = DEFAULT_RETRY_TIMEOUT,
+  crossinline predicate: () -> Any
+) {
+  runBlocking {
+    retry(clue, timeout_ms, predicate)
   }
 }

--- a/workflow-ui/internal-testing-compose/src/main/java/com/squareup/workflow1/ui/internal/test/compose/ComposeEspresso.kt
+++ b/workflow-ui/internal-testing-compose/src/main/java/com/squareup/workflow1/ui/internal/test/compose/ComposeEspresso.kt
@@ -3,8 +3,7 @@ package com.squareup.workflow1.ui.internal.test.compose
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 
 /**
- * This extension is useful when using the frame timeout feature of the runtime as after an action
- * we are not guaranteed synchronous execution of the UI outcomes.
+ * This extension is useful when we are not guaranteed synchronous execution of the UI outcomes.
  *
  * We wait for the Composition to finish and the Recomposer to go idle. Then advance by 200 ms as
  * a safe upper bound to allow our timeout to fire. Then wait for idle on the composition again.


### PR DESCRIPTION
We do not want to risk race conditions from processing actions without updating the Workflow tree structure via render(). Also, while we can count the render passes, it looks like we will achieve more powerful optimization from avoiding the UI layer updates (i.e. conflating 'renderings').

We keep the `RuntimeConfig` mechanisms as these may be valuable for other optimizations.

Second commit retries flaky Espresso tests.