### PR TITLE
It is not safe to touch decorView before Dialog.show()

### DIFF
--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogOverlay.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogOverlay.kt
@@ -6,23 +6,28 @@ import com.squareup.workflow1.ui.R
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
 /**
- * Returns the most recent [Overlay] rendering [shown][OverlayDialogHolder.show] in this [Dialog],
- * or throws a [NullPointerException] if the receiver was not created via
+ * Returns the most recent [Overlay] rendering [shown][OverlayDialogHolder.show]
+ * in this [Dialog]. Throws a [NullPointerException] if the receiver was not created via
  * [OverlayDialogFactory.buildDialog].
+ *
+ * Note that it is not safe to call this until after the [Dialog] has been shown.
  */
 @WorkflowUiExperimentalApi
-public var Dialog.overlay: Overlay
+internal var Dialog.overlay: Overlay
   get() = checkNotNull(overlayOrNull) {
     "Expected to find an Overlay in tag R.id.workflow_overlay on the decor view of $this"
   }
   internal set(value) = decorView.setTag(R.id.workflow_overlay, value)
 
 /**
- * Returns the most recent [Overlay] rendering [shown][OverlayDialogHolder.show] in this [Dialog],
- * or `null` if the receiver was not created via [OverlayDialogFactory.buildDialog].
+ * Returns the most recent [Overlay] rendering [shown][OverlayDialogHolder.show]
+ * in this [Dialog], or `null` if the receiver was not created via
+ * [OverlayDialogFactory.buildDialog].
+ *
+ * Note that this will return `null` before the [Dialog] is shown.
  */
 @WorkflowUiExperimentalApi
-public val Dialog.overlayOrNull: Overlay?
+internal val Dialog.overlayOrNull: Overlay?
   get() = decorViewOrNull?.getTag(R.id.workflow_overlay) as? Overlay
 
 internal val Dialog.decorView: View

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/OverlayDialogHolder.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/OverlayDialogHolder.kt
@@ -79,7 +79,15 @@ public fun <OverlayT : Overlay> OverlayDialogHolder<OverlayT>.show(
   // Why is this an extension rather than part of the interface?
   // When wrapping, we need to prevent recursive calls from clobbering
   // `overlayOrNull` with the nested rendering type.
-  dialog.overlay = overlay
+
+  if (dialog.decorViewOrNull != null) {
+    // https://github.com/square/workflow-kotlin/issues/863
+    // This writes to the decor view, which is not safe to do before the
+    // dialog has been shown, because why would it be? (Note that DialogSession
+    // primes the pump for us, setting the first `overlay` value right
+    // after the first call to Dialog.show.)
+    dialog.overlay = overlay
+  }
   runner(overlay, environment)
 }
 


### PR DESCRIPTION
You'd think I'd remember that by now.
This should be the fix for #863, but I haven't managed to reproduce that so it's hard to say for sure. Hoping @bnvinay92 can confirm.

Fixes #863.

Replaces #872, closed by rebase side effects.