### PR TITLE
update the Vanniktech gradle publish plugin to 0.22.0

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -28,7 +28,7 @@ jobs:
       - name : Publish Snapshots
         run: |
           ./gradlew build --no-daemon
-          ./gradlew publish --no-parallel --no-daemon
+          ./gradlew publish --no-daemon
         env :
           ORG_GRADLE_PROJECT_mavenCentralUsername : ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword : ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby 2.6
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
       - name: Install dependencies
         run: gem install mdl
       - name: Lint docs

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -98,4 +98,3 @@ appropriate, up to and including a permanent ban from all of Square spaces witho
 [ubuntu_coc]: https://ubuntu.com/community/code-of-conduct
 [gdc_coc]: https://www.gdconf.com/code-of-conduct
 [django_coc]: https://www.djangoproject.com/conduct/reporting/
-

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,11 +26,8 @@
 
 1. Upload the kotlin artifacts:
    ```bash
-   ./gradlew clean build && ./gradlew publish --no-parallel
+   ./gradlew clean build && ./gradlew publish
    ```
-
-   Disabling parallelism and daemon sharing is required by the vanniktech maven publish plugin.
-   Without those, the artifacts will be split across multiple (invalid) staging repositories.
 
 1. Close and release the staging repository at https://s01.oss.sonatype.org/#stagingRepositories.
 
@@ -147,7 +144,7 @@ Double-check that `gradle.properties` correctly contains the `-SNAPSHOT` suffix,
 snapshot artifacts to Sonatype just like you would for a production release:
 
 ```bash
-./gradlew clean build && ./gradlew publish --no-parallel
+./gradlew clean build && ./gradlew publish
 ```
 
 You can verify the artifacts are available by visiting

--- a/dependencies/classpath.txt
+++ b/dependencies/classpath.txt
@@ -68,8 +68,9 @@ com.googlecode.java-diff-utils:diffutils:1.3.0
 com.googlecode.json-simple:json-simple:1.1
 com.googlecode.juniversalchardet:juniversalchardet:1.0.3
 com.squareup.moshi:moshi:1.13.0
-com.squareup.okhttp3:okhttp:3.14.9
-com.squareup.okio:okio:2.10.0
+com.squareup.okhttp3:okhttp:4.10.0
+com.squareup.okio:okio-jvm:3.0.0
+com.squareup.okio:okio:3.0.0
 com.squareup.retrofit2:converter-moshi:2.9.0
 com.squareup.retrofit2:retrofit:2.9.0
 com.squareup:javapoet:1.10.0
@@ -78,8 +79,8 @@ com.squareup:kotlinpoet:1.3.0
 com.sun.activation:javax.activation:1.2.0
 com.sun.istack:istack-commons-runtime:3.0.8
 com.sun.xml.fastinfoset:FastInfoset:1.2.16
-com.vanniktech:gradle-maven-publish-plugin:0.21.0
-com.vanniktech:nexus:0.21.0
+com.vanniktech:gradle-maven-publish-plugin:0.22.0
+com.vanniktech:nexus:0.22.0
 commons-codec:commons-codec:1.11
 commons-io:commons-io:2.4
 commons-logging:commons-logging:1.2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,7 +81,7 @@ squareup-workflow = "1.0.0"
 
 timber = "4.7.1"
 truth = "1.1.3"
-vanniktech-publish = "0.21.0"
+vanniktech-publish = "0.22.0"
 
 [plugins]
 

--- a/workflow-ui/compose/README.md
+++ b/workflow-ui/compose/README.md
@@ -15,8 +15,8 @@ At Square, when we start a project, we like to enumerate and distinguish goals a
 
 - Allow Workflow screens to be written in Compose.
 - Allow interop in both directions using the usual idioms:
-  - Non-Compose Workflow screens to nest Compose-based Workflow screens.
-  - Compose-based Workflow screens to nest both Compose-based and non-Compose Workflow screens.
+   - Non-Compose Workflow screens to nest Compose-based Workflow screens.
+   - Compose-based Workflow screens to nest both Compose-based and non-Compose Workflow screens.
 - Provide a way for Compose-based apps to host a Workflow runtime and display Compose apps, e.g. a parallel entry point to how non-Compose apps can use `WorkflowLayout`.
 - Ensure that data flow through `CompositionLocal`s is propagated to child Compose-based screens, regardless of whether there are non-Workflow screens sitting in between them.
 
@@ -442,4 +442,3 @@ You’ll notice that all the APIs described above explicitly pass `ViewEnvironme
 This is what we did at first, but it made the API awkward for testing and other cases. Google advises against using composition locals in most cases for a reason. Because Workflow UI requires a `ViewRegistry` to be provided through the `ViewEnvironment`, there’s no obvious default value — what is the correct behavior when no `ViewEnvironment` local has been specified? Crashing at runtime is not ideal. We could provide an empty `ViewRegistry`, but that’s just another way to crash at runtime a few levels deeper in the call stack. Requiring explicit parameters for `ViewEnvironment` solves all these problems at the expense of a little more typing, and matches how the existing `ViewFactory` APIs work.
 
 On the other hand, providing an API to access individual view environment elements from a composable that hides the actual mechanism and uses composition locals under the hood would let us take much better advantage of Compose’s fine-grained UI updates. We could ensure that, when a view environment changes, only the parts of the UI that actually care about the modified part of the environment are recomposed. However, renderings typically change an order of magnitude more frequently than view environments, so there’s probably not much point solving this problem until we’ve solved the same problem with renderings (discussed above under _Potential risk: Data model_).
-


### PR DESCRIPTION
TLDR - we don't need `--no-parallel` anymore.

https://github.com/vanniktech/gradle-maven-publish-plugin/blob/master/CHANGELOG.md#version-0220-2022-09-09

Version 0.22.0 *(2022-09-09)*
---------------------------------

- **NEW**: When publishing to maven central by setting `SONATYPE_HOST` or calling `publishToMavenCentral(...)` the plugin will now explicitly create a staging repository on Sonatype. This avoids issues where a single build would create multiple repositories
- The above change means that the plugin supports parallel builds and it is not neccessary anymore to use `--no-parallel` and `--no-daemon` together with `publish`
- **NEW**: When publishing with the `publish` or `publishAllPublicationsToMavenCentralRepository` tasks the plugin will automatically close the staging repository at the end of the build if it was successful.
- **NEW**: Option to also automatically release the staging repository after closing was susccessful
```
SONATYPE_HOST=DEFAULT # or S01
SONATYPE_AUTOMATIC_RELEASE=true
```
or
```
mavenPublishing {
  publishToMavenCentral("DEFAULT", true)
  // or publishToMavenCentral("S01", true)
}
```
- in case the option above is enabled, the `closeAndReleaseRepository` task is not needed anymore
- when closing the repository fails the plugin will fail the build immediately instead of timing out
- when closing the repository fails the plugin will try to print the error messages from Nexus
- increased timeouts for calls to the Sonatype Nexus APIs
- fixed incompatibility with the `com.gradle.plugin-publish` plugin
- added wokaround for Kotlin multiplatform builds reporting disabled build optimizations