### PR TITLE
update KtLint to 0.47.1 and switch KtLint-gradle to Kotlinter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -484,6 +484,8 @@ ij_groovy_while_on_new_line = false
 ij_groovy_wrap_long_lines = false
 
 [{*.gradle.kts,*.kt,*.kts,*.main.kts}]
+# noinspection EditorConfigKeyCorrectness
+ktlint_disabled_rules = trailing-comma-on-declaration-site,trailing-comma-on-call-site
 ij_continuation_indent_size = 2
 ij_kotlin_align_in_columns_case_branch = false
 ij_kotlin_align_multiline_binary_operation = false

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -90,7 +90,7 @@ jobs :
         name : Check with Gradle
         with :
           arguments : |
-            allTests test apiCheck checkVersionIsSnapshot dependencyGuard lint ktlintCheck jvmWorkflowNodeBenchmarkJar --stacktrace --continue
+            allTests test apiCheck checkVersionIsSnapshot dependencyGuard lint lintKotlin jvmWorkflowNodeBenchmarkJar --stacktrace --continue
           cache-read-only: false
 
       # Report as Github Pull Request Check.

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemWorkflow.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemWorkflow.kt
@@ -64,6 +64,7 @@ class PerformancePoemWorkflow(
 
   sealed class State {
     val isLoading: Boolean = false
+
     // N.B. This state is a smell. We include it to be able to mimic smells
     // we encounter in real life. Best practice would be to fold it
     // into [Selected(NO_SELECTED_STANZA)] at the very least.
@@ -85,9 +86,13 @@ class PerformancePoemWorkflow(
     props: Poem,
     snapshot: Snapshot?
   ): State {
-    return if (simulatedPerfConfig.useInitializingState) Initializing else Selected(
-      NO_SELECTED_STANZA
-    )
+    return if (simulatedPerfConfig.useInitializingState) {
+      Initializing
+    } else {
+      Selected(
+        NO_SELECTED_STANZA
+      )
+    }
   }
 
   @OptIn(WorkflowUiExperimentalApi::class)
@@ -174,23 +179,26 @@ class PerformancePoemWorkflow(
         }
 
         val previousStanzas: List<StanzaScreen> =
-          if (stanzaIndex == NO_SELECTED_STANZA) emptyList()
-          else renderProps.stanzas.subList(0, stanzaIndex)
-            .mapIndexed { index, _ ->
-              context.renderChild(
-                StanzaWorkflow,
-                Props(
-                  poem = renderProps,
-                  index = index,
-                  eventHandlerTag = ActionHandlingTracingInterceptor::keyForTrace
-                ),
-                key = "$index"
-              ) {
-                noAction()
+          if (stanzaIndex == NO_SELECTED_STANZA) {
+            emptyList()
+          } else {
+            renderProps.stanzas.subList(0, stanzaIndex)
+              .mapIndexed { index, _ ->
+                context.renderChild(
+                  StanzaWorkflow,
+                  Props(
+                    poem = renderProps,
+                    index = index,
+                    eventHandlerTag = ActionHandlingTracingInterceptor::keyForTrace
+                  ),
+                  key = "$index"
+                ) {
+                  noAction()
+                }
+              }.map { originalStanzaScreen ->
+                originalStanzaScreen
               }
-            }.map { originalStanzaScreen ->
-              originalStanzaScreen
-            }
+          }
 
         val visibleStanza =
           if (stanzaIndex == NO_SELECTED_STANZA) {

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemsBrowserWorkflow.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemsBrowserWorkflow.kt
@@ -102,12 +102,12 @@ class PerformancePoemsBrowserWorkflow(
       // Don't try this at home.
       is Initializing -> {
         context.runningWorker(TraceableWorker.from("BrowserInitializing") { Unit }, "init") {
-        isLoading.value = true
-        action {
-          isLoading.value = false
-          state = NoSelection
+          isLoading.value = true
+          action {
+            isLoading.value = false
+            state = NoSelection
+          }
         }
-      }
         return OverviewDetailScreen(overviewRendering = BackStackScreen(BlankScreen))
       }
       is NoSelection -> {

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoetryActivity.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoetryActivity.kt
@@ -261,7 +261,8 @@ class PoetryModel(
   interceptor: WorkflowInterceptor?,
   runtimeConfig: RuntimeConfig
 ) : ViewModel() {
-  @OptIn(WorkflowUiExperimentalApi::class) val renderings: StateFlow<Screen> by lazy {
+  @OptIn(WorkflowUiExperimentalApi::class)
+  val renderings: StateFlow<Screen> by lazy {
     renderWorkflowIn(
       workflow = workflow,
       scope = viewModelScope,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
+import com.squareup.workflow1.buildsrc.applyKtLint
 import org.jetbrains.dokka.gradle.DokkaTask
-import org.jlleitschuh.gradle.ktlint.KtlintExtension
-import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 buildscript {
   dependencies {
@@ -11,7 +10,6 @@ buildscript {
     classpath(libs.kotlinx.binaryCompatibility.gradle.plugin)
     classpath(libs.kotlin.gradle.plugin)
     classpath(libs.google.ksp)
-    classpath(libs.ktlint.gradle)
     classpath(libs.vanniktech.publish)
   }
 
@@ -32,7 +30,6 @@ plugins {
 
 subprojects {
 
-  apply(plugin = "org.jlleitschuh.gradle.ktlint")
   afterEvaluate {
     configurations.configureEach {
       // There could be transitive dependencies in tests with a lower version. This could cause
@@ -40,17 +37,9 @@ subprojects {
       resolutionStrategy.force(libs.kotlin.reflect)
     }
   }
-
-  // Configuration documentation: https://github.com/JLLeitschuh/ktlint-gradle#configuration
-  configure<KtlintExtension> {
-    // Prints the name of failed rules.
-    verbose.set(true)
-    reporters {
-      // Default "plain" reporter is actually harder to read.
-      reporter(ReporterType.JSON)
-    }
-  }
 }
+
+applyKtLint()
 
 apply(from = rootProject.file(".buildscript/binary-validation.gradle"))
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,4 +1,4 @@
-@Suppress("UnstableApiUsage")
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
   `kotlin-dsl`
   alias(libs.plugins.google.ksp)
@@ -7,6 +7,7 @@ plugins {
 repositories {
   mavenCentral()
   google()
+  maven("https://plugins.gradle.org/m2/")
 }
 
 dependencies {
@@ -19,6 +20,8 @@ dependencies {
   implementation(libs.dokka.gradle.plugin)
   implementation(libs.dropbox.dependencyGuard)
   implementation(libs.kotlin.gradle.plugin)
+  implementation(libs.ktlint.core)
+  implementation(libs.kotlinter)
   implementation(libs.squareup.moshi)
   implementation(libs.squareup.moshi.adapters)
   implementation(libs.vanniktech.publish)

--- a/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/KotlinCommonSettings.kt
+++ b/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/KotlinCommonSettings.kt
@@ -15,6 +15,8 @@ fun Project.kotlinCommonSettings(
   bomConfigurationName: String
 ) {
 
+  applyKtLint()
+
   // force the same Kotlin version everywhere, including transitive dependencies
   dependencies {
     bomConfigurationName(platform(kotlin("bom")))

--- a/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/ktlint.kt
+++ b/buildSrc/src/main/java/com/squareup/workflow1/buildsrc/ktlint.kt
@@ -1,0 +1,77 @@
+package com.squareup.workflow1.buildsrc
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskContainer
+import org.jmailen.gradle.kotlinter.tasks.ConfigurableKtLintTask
+import org.jmailen.gradle.kotlinter.tasks.FormatTask
+import org.jmailen.gradle.kotlinter.tasks.LintTask
+
+/**
+ * Applies Kotlinter settings to any project, with additional tasks for the root project.
+ *
+ * @since 0.10.0
+ */
+fun Project.applyKtLint() {
+  pluginManager.apply("org.jmailen.kotlinter")
+
+  tasks.withType(LintTask::class.java) {
+    ignoreFailures.set(false)
+    mustRunAfter(tasks.withType(FormatTask::class.java))
+  }
+
+  if (project == rootProject) {
+    tasks.register("lintKotlin")
+    tasks.register("formatKotlin")
+    afterEvaluate {
+      addGradleScriptTasks(tasks, taskNameQualifier = "")
+    }
+  }
+
+  // dummy ktlint-gradle plugin task names which just delegate to the Kotlinter ones
+  tasks.register("ktlintCheck") {
+    dependsOn(tasks.withType(LintTask::class.java))
+  }
+  tasks.register("ktlintFormat") {
+    dependsOn(tasks.withType(FormatTask::class.java))
+  }
+}
+
+// Add check/format tasks to each root project (including child root projects) which target every
+// `build.gradle.kts` and `settings.gradle.kts` file within that project group.
+private fun Project.addGradleScriptTasks(
+  taskContainer: TaskContainer,
+  taskNameQualifier: String = ""
+) {
+  val includedProjectScriptFiles = allprojects
+    .flatMap { included ->
+      listOfNotNull(
+        included.buildFile,
+        included.file("settings.gradle.kts").takeIf { it.exists() }
+      )
+    }
+
+  val lintKotlinBuildLogic = taskContainer.register(
+    "lintKotlin${taskNameQualifier}BuildScripts",
+    LintTask::class.java
+  ) {
+    group = "Formatting"
+    description = "Runs lint on the build and settings files"
+    source(includedProjectScriptFiles)
+  }
+
+  tasks.named("lintKotlin") {
+    dependsOn(lintKotlinBuildLogic)
+  }
+
+  val formatKotlinBuildLogic = taskContainer.register(
+    "formatKotlin${taskNameQualifier}BuildScripts",
+    FormatTask::class.java
+  ) {
+    group = "Formatting"
+    description = "Formats the build and settings files"
+    source(includedProjectScriptFiles)
+  }
+  tasks.named("formatKotlin") {
+    dependsOn(formatKotlinBuildLogic)
+  }
+}

--- a/dependencies/classpath.txt
+++ b/dependencies/classpath.txt
@@ -166,7 +166,6 @@ org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.5.0
 org.jetbrains:annotations:13.0
 org.jetbrains:markdown-jvm:0.2.4
 org.jetbrains:markdown:0.2.4
-org.jlleitschuh.gradle:ktlint-gradle:10.3.0
 org.json:json:20180813
 org.jsoup:jsoup:1.13.1
 org.jvnet.staxex:stax-ex:1.8.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,8 @@ kotlinx-serialization-json = "1.3.2"
 kotlinx-benchmark = "0.4.2"
 kotlinx-atomicfu = "0.17.2"
 
-ktlint = "10.3.0"
+kotlinter = "3.12.0"
+ktlint = "0.47.1"
 material = "1.3.0"
 mavenPublish = "0.13.0"
 
@@ -94,9 +95,9 @@ dropbox-dependencyGuard = { id = "com.dropbox.dependency-guard", version.ref = "
 google-ksp = { id = "com.google.devtools.ksp", version.ref = "google-ksp" }
 
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
 kotlinx-apiBinaryCompatibility = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binary-compatibility" }
 kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark" }
-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech-publish" }
 
 [libraries]
@@ -194,6 +195,8 @@ kotlin-test-common = { module = "org.jetbrains.kotlin:kotlin-test-common", versi
 kotlin-test-core = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-test-jdk = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 
+kotlinter = { module = "org.jmailen.gradle:kotlinter-gradle", version.ref = "kotlinter" }
+
 kotlinx-binaryCompatibility-gradle-plugin = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "kotlinx-binary-compatibility" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
@@ -205,7 +208,7 @@ kotlinx-benchmark-gradle-plugin = { module = "org.jetbrains.kotlinx:kotlinx-benc
 kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "kotlinx-atomicfu" }
 
-ktlint-gradle = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlint" }
+ktlint-core = { module = "com.pinterest.ktlint:ktlint-core", version.ref = "ktlint" }
 
 lanterna = "com.googlecode.lanterna:lanterna:3.1.1"
 

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/hellocompose/HelloComposeTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/hellocompose/HelloComposeTest.kt
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith
 class HelloComposeTest {
 
   private val composeRule = createAndroidComposeRule<HelloComposeActivity>()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/hellocomposebinding/HelloBindingTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/hellocomposebinding/HelloBindingTest.kt
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 class HelloBindingTest {
 
   private val composeRule = createAndroidComposeRule<HelloBindingActivity>()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/hellocomposeworkflow/HelloComposeWorkflowTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/hellocomposeworkflow/HelloComposeWorkflowTest.kt
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 class HelloComposeWorkflowTest {
 
   private val composeRule = createAndroidComposeRule<HelloComposeWorkflowActivity>()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/inlinerendering/InlineRenderingTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/inlinerendering/InlineRenderingTest.kt
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith
 class InlineRenderingTest {
 
   private val composeRule = createAndroidComposeRule<InlineRenderingActivity>()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/launcher/SampleLauncherTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/launcher/SampleLauncherTest.kt
@@ -25,13 +25,15 @@ import org.junit.runner.RunWith
 class SampleLauncherTest {
 
   private val composeRule = createAndroidComposeRule<SampleLauncherActivity>()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)
     .around(IdlingDispatcherRule)
 
   @OptIn(ExperimentalTestApi::class)
-  @Test fun allSamplesLaunch() {
+  @Test
+  fun allSamplesLaunch() {
     val appName =
       InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.app_name)
     composeRule.onNodeWithText(appName).assertIsDisplayed()

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsTest.kt
@@ -25,6 +25,7 @@ private const val ADD_BUTTON_TEXT = "Add Child"
 class NestedRenderingsTest {
 
   private val composeRule = createAndroidComposeRule<NestedRenderingsActivity>()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/preview/PreviewTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/preview/PreviewTest.kt
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 class PreviewTest {
 
   private val composeRule = createAndroidComposeRule<PreviewActivity>()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)

--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/textinput/TextInputTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/textinput/TextInputTest.kt
@@ -26,13 +26,15 @@ import org.junit.runner.RunWith
 class TextInputTest {
 
   private val composeRule = createAndroidComposeRule<TextInputActivity>()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)
     .around(IdlingDispatcherRule)
 
   @OptIn(ExperimentalTestApi::class)
-  @Test fun allowsTextEditing() {
+  @Test
+  fun allowsTextEditing() {
     runBlocking {
       composeRule.onNode(hasSetTextAction()).performTextInput("he")
       composeRule.onNode(hasSetTextAction()).assertTextEquals("he")

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/App.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/App.kt
@@ -30,7 +30,8 @@ private val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(HelloBinding)
       onOutput = {}
     )
     WorkflowRendering(
-      rendering, viewEnvironment,
+      rendering,
+      viewEnvironment,
       Modifier.border(
         shape = RoundedCornerShape(10.dp),
         width = 10.dp,
@@ -41,6 +42,7 @@ private val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(HelloBinding)
 }
 
 @Preview(showBackground = true)
-@Composable private fun AppPreview() {
+@Composable
+private fun AppPreview() {
   App()
 }

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloBinding.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloBinding.kt
@@ -25,6 +25,7 @@ val HelloBinding = composeScreenViewFactory<Rendering> { rendering, _ ->
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @Preview(heightDp = 150, showBackground = true)
-@Composable fun DrawHelloRenderingPreview() {
+@Composable
+fun DrawHelloRenderingPreview() {
   HelloBinding.Preview(Rendering("Hello!", onClick = {}))
 }

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/HelloComposeWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/HelloComposeWorkflow.kt
@@ -50,7 +50,8 @@ object HelloComposeWorkflow : ComposeWorkflow<String, Toggle>() {
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @Preview(showBackground = true)
-@Composable fun HelloComposeWorkflowPreview() {
+@Composable
+fun HelloComposeWorkflowPreview() {
   val rendering by HelloComposeWorkflow.renderAsState(
     props = "hello",
     onOutput = {},

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
@@ -54,7 +54,8 @@ object InlineRenderingWorkflow : StatefulWorkflow<Unit, Int, Nothing, AndroidScr
 }
 
 @Preview
-@Composable fun InlineRenderingWorkflowPreview() {
+@Composable
+fun InlineRenderingWorkflowPreview() {
   val rendering by InlineRenderingWorkflow.renderAsState(
     props = Unit,
     onOutput = {},
@@ -64,7 +65,8 @@ object InlineRenderingWorkflow : StatefulWorkflow<Unit, Int, Nothing, AndroidScr
 }
 
 @OptIn(ExperimentalAnimationApi::class)
-@Composable private fun AnimatedCounter(
+@Composable
+private fun AnimatedCounter(
   counterValue: Int,
   content: @Composable (Int) -> Unit
 ) {

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/launcher/SampleLauncherApp.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/launcher/SampleLauncherApp.kt
@@ -60,12 +60,14 @@ import com.squareup.sample.compose.R
   }
 }
 
-@Preview @Composable private fun SampleLauncherAppPreview() {
+@Preview @Composable
+private fun SampleLauncherAppPreview() {
   SampleLauncherApp()
 }
 
 @OptIn(ExperimentalMaterialApi::class)
-@Composable private fun SampleItem(sample: Sample) {
+@Composable
+private fun SampleItem(sample: Sample) {
   val rootView = LocalView.current
 
   /**

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/launcher/Samples.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/launcher/Samples.kt
@@ -24,32 +24,39 @@ import kotlin.reflect.KClass
 @OptIn(WorkflowUiExperimentalApi::class)
 val samples = listOf(
   Sample(
-    "Compose Workflow", HelloComposeWorkflowActivity::class,
+    "Compose Workflow",
+    HelloComposeWorkflowActivity::class,
     "Demonstrates a special implementation of Workflow that lets the workflow define " +
       "its own composable content inline."
   ) { HelloComposeWorkflowPreview() },
   Sample(
-    "Hello Compose", HelloComposeActivity::class,
+    "Hello Compose",
+    HelloComposeActivity::class,
     "A pure Compose app that launches its root Workflow from inside Compose."
   ) { App() },
   Sample(
-    "Hello Compose Binding", HelloBindingActivity::class,
+    "Hello Compose Binding",
+    HelloBindingActivity::class,
     "Creates a ViewFactory using composeViewFactory."
   ) { DrawHelloRenderingPreview() },
   Sample(
-    "Nested Renderings", NestedRenderingsActivity::class,
+    "Nested Renderings",
+    NestedRenderingsActivity::class,
     "Demonstrates recursive view factories using both Compose and legacy view factories."
   ) { RecursiveViewFactoryPreview() },
   Sample(
-    "Text Input", TextInputActivity::class,
+    "Text Input",
+    TextInputActivity::class,
     "Demonstrates a workflow that drives a TextField."
   ) { TextInputAppPreview() },
   Sample(
-    "ViewFactory Preview", PreviewActivity::class,
+    "ViewFactory Preview",
+    PreviewActivity::class,
     "Demonstrates displaying @Previews of ViewFactories."
   ) { PreviewApp() },
   Sample(
-    "Inline ComposeRendering", InlineRenderingActivity::class,
+    "Inline ComposeRendering",
+    InlineRenderingActivity::class,
     "Demonstrates a workflow that returns an anonymous ComposeRendering."
   ) { InlineRenderingWorkflowPreview() },
 )

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/LegacyRunner.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/LegacyRunner.kt
@@ -29,13 +29,15 @@ class LegacyRunner(private val binding: LegacyViewBinding) : ScreenViewRunner<Le
   }
 
   companion object : ScreenViewFactory<LegacyRendering> by fromViewBinding(
-    LegacyViewBinding::inflate, ::LegacyRunner
+    LegacyViewBinding::inflate,
+    ::LegacyRunner
   )
 }
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @Preview(widthDp = 200, heightDp = 150, showBackground = true)
-@Composable private fun LegacyRunnerPreview() {
+@Composable
+private fun LegacyRunnerPreview() {
   LegacyRunner.Preview(
     rendering = LegacyRendering(StringRendering("child")),
     placeholderModifier = Modifier.fillMaxSize()

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/RecursiveViewFactory.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/RecursiveViewFactory.kt
@@ -56,7 +56,8 @@ val RecursiveViewFactory = composeScreenViewFactory<Rendering> { rendering, view
     ) {
       CompositionLocalProvider(LocalBackgroundColor provides childColor) {
         Children(
-          rendering.children, viewEnvironment,
+          rendering.children,
+          viewEnvironment,
           // Pass a weight so that the column fills all the space not occupied by the buttons.
           modifier = Modifier.weight(1f, fill = true)
         )
@@ -71,7 +72,8 @@ val RecursiveViewFactory = composeScreenViewFactory<Rendering> { rendering, view
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @Preview
-@Composable fun RecursiveViewFactoryPreview() {
+@Composable
+fun RecursiveViewFactoryPreview() {
   CompositionLocalProvider(LocalBackgroundColor provides Color.Green) {
     RecursiveViewFactory.Preview(
       Rendering(
@@ -79,10 +81,12 @@ val RecursiveViewFactory = composeScreenViewFactory<Rendering> { rendering, view
           StringRendering("foo"),
           Rendering(
             children = listOf(StringRendering("bar")),
-            onAddChildClicked = {}, onResetClicked = {}
+            onAddChildClicked = {},
+            onResetClicked = {}
           )
         ),
-        onAddChildClicked = {}, onResetClicked = {}
+        onAddChildClicked = {},
+        onResetClicked = {}
       ),
       placeholderModifier = Modifier.fillMaxSize()
     )
@@ -90,7 +94,8 @@ val RecursiveViewFactory = composeScreenViewFactory<Rendering> { rendering, view
 }
 
 @OptIn(WorkflowUiExperimentalApi::class)
-@Composable private fun Children(
+@Composable
+private fun Children(
   children: List<Screen>,
   viewEnvironment: ViewEnvironment,
   modifier: Modifier

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/preview/PreviewActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/preview/PreviewActivity.kt
@@ -45,7 +45,8 @@ val previewContactRendering = ContactRendering(
 )
 
 @Preview
-@Composable fun PreviewApp() {
+@Composable
+fun PreviewApp() {
   MaterialTheme {
     Surface {
       contactViewFactory.Preview(previewContactRendering)

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/App.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/App.kt
@@ -29,6 +29,7 @@ private val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(TextInputView
 }
 
 @Preview(showBackground = true)
-@Composable internal fun TextInputAppPreview() {
+@Composable
+internal fun TextInputAppPreview() {
   TextInputApp()
 }

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/TextInputViewFactory.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/TextInputViewFactory.kt
@@ -50,7 +50,8 @@ val TextInputViewFactory = composeScreenViewFactory<Rendering> { rendering, _ ->
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @Preview(showBackground = true)
-@Composable private fun TextInputViewFactoryPreview() {
+@Composable
+private fun TextInputViewFactoryPreview() {
   TextInputViewFactory.Preview(
     Rendering(
       textController = TextController("Hello world"),

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/SampleContainers.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/SampleContainers.kt
@@ -7,5 +7,7 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
 @OptIn(WorkflowUiExperimentalApi::class)
 val SampleContainers = ViewRegistry(
-  OverviewDetailContainer, PanelOverlayDialogFactory, ScrimContainer
+  OverviewDetailContainer,
+  PanelOverlayDialogFactory,
+  ScrimContainer
 )

--- a/samples/containers/android/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailContainer.kt
+++ b/samples/containers/android/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailContainer.kt
@@ -45,8 +45,11 @@ class OverviewDetailContainer(view: View) : ScreenViewRunner<OverviewDetailScree
     rendering: OverviewDetailScreen,
     environment: ViewEnvironment
   ) {
-    if (singleStub == null) renderSplitView(rendering, environment)
-    else renderSingleView(rendering, environment, singleStub)
+    if (singleStub == null) {
+      renderSplitView(rendering, environment)
+    } else {
+      renderSingleView(rendering, environment, singleStub)
+    }
   }
 
   private fun renderSplitView(

--- a/samples/containers/app-poetry/src/androidTest/java/com/squareup/sample/poetryapp/PoetryAppTest.kt
+++ b/samples/containers/app-poetry/src/androidTest/java/com/squareup/sample/poetryapp/PoetryAppTest.kt
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith
 class PoetryAppTest {
 
   private val scenarioRule = ActivityScenarioRule(PoetryActivity::class.java)
+
   @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(scenarioRule)
     .around(IdlingDispatcherRule)

--- a/samples/containers/app-raven/src/androidTest/java/com/squareup/sample/ravenapp/RavenAppTest.kt
+++ b/samples/containers/app-raven/src/androidTest/java/com/squareup/sample/ravenapp/RavenAppTest.kt
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 class RavenAppTest {
 
   private val scenarioRule = ActivityScenarioRule(RavenActivity::class.java)
+
   @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(scenarioRule)
     .around(IdlingDispatcherRule)

--- a/samples/containers/common/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailScreen.kt
+++ b/samples/containers/common/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailScreen.kt
@@ -49,8 +49,11 @@ class OverviewDetailScreen private constructor(
       ?.let { it + other.detailRendering }
       ?: other.detailRendering
 
-    return if (newDetail == null) OverviewDetailScreen(newOverview, other.selectDefault)
-    else OverviewDetailScreen(newOverview, newDetail)
+    return if (newDetail == null) {
+      OverviewDetailScreen(newOverview, other.selectDefault)
+    } else {
+      OverviewDetailScreen(newOverview, newDetail)
+    }
   }
 
   override fun equals(other: Any?): Boolean {

--- a/samples/containers/hello-back-button/src/androidTest/java/com/squareup/sample/hellobackbutton/HelloBackButtonEspressoTest.kt
+++ b/samples/containers/hello-back-button/src/androidTest/java/com/squareup/sample/hellobackbutton/HelloBackButtonEspressoTest.kt
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith
 class HelloBackButtonEspressoTest {
 
   private val scenarioRule = ActivityScenarioRule(HelloBackButtonActivity::class.java)
+
   @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(scenarioRule)
     .around(IdlingDispatcherRule)

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonLayoutRunner.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonLayoutRunner.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:filename")
+
 package com.squareup.sample.hellobackbutton
 
 import android.view.View
@@ -16,7 +18,8 @@ data class HelloBackButtonScreen(
   val onBackPressed: (() -> Unit)?
 ) : AndroidScreen<HelloBackButtonScreen> {
   override val viewFactory = ScreenViewFactory.fromLayout<HelloBackButtonScreen>(
-    R.layout.hello_back_button_layout, ::HelloBackButtonLayoutRunner
+    R.layout.hello_back_button_layout,
+    ::HelloBackButtonLayoutRunner
   )
 }
 

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
@@ -44,11 +44,15 @@ object HelloBackButtonWorkflow : StatefulWorkflow<
           Charlie -> Able
         }
       },
-      onBackPressed = if (renderState == Able) null else context.eventHandler {
-        state = when (state) {
-          Able -> throw IllegalStateException()
-          Baker -> Able
-          Charlie -> Baker
+      onBackPressed = if (renderState == Able) {
+        null
+      } else {
+        context.eventHandler {
+          state = when (state) {
+            Able -> throw IllegalStateException()
+            Baker -> Able
+            Charlie -> Baker
+          }
         }
       }
     )

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemListRendering.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemListRendering.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:filename")
+
 package com.squareup.sample.poetry
 
 import android.view.LayoutInflater
@@ -24,7 +26,8 @@ data class PoemListScreen(
   val selection: Int = -1
 ) : AndroidScreen<PoemListScreen> {
   override val viewFactory = ScreenViewFactory.fromLayout(
-    R.layout.list, ::PoemListLayoutRunner
+    R.layout.list,
+    ::PoemListLayoutRunner
   )
 
   companion object {

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/RealPoemWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/RealPoemWorkflow.kt
@@ -43,22 +43,26 @@ class RealPoemWorkflow : PoemWorkflow,
     renderState: SelectedStanza,
     context: RenderContext
   ): OverviewDetailScreen {
-
     val previousStanzas: List<StanzaScreen> =
-      if (renderState == NO_SELECTED_STANZA) emptyList()
-      else renderProps.stanzas.subList(0, renderState)
-        .mapIndexed { index, _ ->
-          context.renderChild(StanzaWorkflow, Props(renderProps, index), "$index") {
-            noAction()
+      if (renderState == NO_SELECTED_STANZA) {
+        emptyList()
+      } else {
+        renderProps.stanzas.subList(0, renderState)
+          .mapIndexed { index, _ ->
+            context.renderChild(StanzaWorkflow, Props(renderProps, index), "$index") {
+              noAction()
+            }
           }
-        }
+      }
 
     val visibleStanza =
       if (renderState == NO_SELECTED_STANZA) {
         null
       } else {
         context.renderChild(
-          StanzaWorkflow, Props(renderProps, renderState), "$renderState"
+          StanzaWorkflow,
+          Props(renderProps, renderState),
+          "$renderState"
         ) {
           when (it) {
             CloseStanzas -> ClearSelection

--- a/samples/dungeon/app/src/androidTest/java/com/squareup/sample/dungeon/DungeonAppTest.kt
+++ b/samples/dungeon/app/src/androidTest/java/com/squareup/sample/dungeon/DungeonAppTest.kt
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 class DungeonAppTest {
 
   private val scenarioRule = ActivityScenarioRule(DungeonActivity::class.java)
+
   @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(scenarioRule)
     .around(IdlingDispatcherRule)

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardsListLayoutRunner.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardsListLayoutRunner.kt
@@ -102,6 +102,7 @@ class BoardsListLayoutRunner(rootView: View) : ScreenViewRunner<DisplayBoardsLis
   }
 
   companion object : ScreenViewFactory<DisplayBoardsListScreen> by fromLayout(
-    R.layout.boards_list_layout, ::BoardsListLayoutRunner
+    R.layout.boards_list_layout,
+    ::BoardsListLayoutRunner
   )
 }

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/Component.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/Component.kt
@@ -61,6 +61,8 @@ class Component(context: AppCompatActivity) {
   val timeMachineWorkflow = TimeMachineAppWorkflow(appWorkflow, clock, context)
 
   val timeMachineModelFactory = TimeMachineModel.Factory(
-    context, timeMachineWorkflow, traceFilesDir = context.filesDir
+    context,
+    timeMachineWorkflow,
+    traceFilesDir = context.filesDir
   )
 }

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
@@ -46,7 +46,6 @@ class DungeonAppWorkflow(
     renderState: State,
     context: RenderContext
   ): AlertContainerScreen<Any> = when (renderState) {
-
     LoadingBoardList -> {
       context.runningWorker(boardLoader.loadAvailableBoards()) { displayBoards(it) }
       AlertContainerScreen(renderState)

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameLayoutRunner.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameLayoutRunner.kt
@@ -67,6 +67,7 @@ class GameLayoutRunner(view: View) : ScreenViewRunner<GameRendering> {
   }
 
   companion object : ScreenViewFactory<GameRendering> by fromLayout(
-    R.layout.game_layout, ::GameLayoutRunner
+    R.layout.game_layout,
+    ::GameLayoutRunner
   )
 }

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameSessionWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameSessionWorkflow.kt
@@ -56,7 +56,6 @@ class GameSessionWorkflow(
     renderState: State,
     context: RenderContext
   ): AlertContainerScreen<Any> = when (renderState) {
-
     Loading -> {
       context.runningWorker(boardLoader.loadBoard(renderProps.boardPath)) { StartRunning(it) }
       AlertContainerScreen(Loading)

--- a/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/AiWorkflow.kt
+++ b/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/AiWorkflow.kt
@@ -47,7 +47,9 @@ class AiWorkflow(
     state: State
   ): State = if (!old.ticks.doesSameWorkAs(new.ticks)) {
     state.copy(directionTicker = new.ticks.createDirectionTicker(random))
-  } else state
+  } else {
+    state
+  }
 
   override fun render(
     renderProps: ActorProps,

--- a/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/GameWorkflow.kt
+++ b/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/GameWorkflow.kt
@@ -119,7 +119,10 @@ class GameWorkflow(
     if (running) {
       context.runningWorker(ticker) { tick ->
         return@runningWorker updateGame(
-          renderProps.ticksPerSecond, tick, playerRendering, aiRenderings
+          renderProps.ticksPerSecond,
+          tick,
+          playerRendering,
+          aiRenderings
         )
       }
     }
@@ -158,7 +161,8 @@ class GameWorkflow(
     var newPlayerLocation: Location = state.game.playerLocation
     if (playerRendering.actorRendering.movement.isTimeToMove()) {
       val moveResult = state.game.playerLocation.move(
-        playerRendering.actorRendering.movement, props.board
+        playerRendering.actorRendering.movement,
+        props.board
       )
       newPlayerLocation = moveResult.newLocation
       if (moveResult.collisionDetected) output = Vibrate

--- a/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/board/Parser.kt
+++ b/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/board/Parser.kt
@@ -59,8 +59,9 @@ fun BufferedSource.parseBoard(metadata: BoardMetadata = parseBoardMetadata()): B
 
   // Pad short rows.
   rows = rows.map { row ->
-    if (row.size == width) row
-    else {
+    if (row.size == width) {
+      row
+    } else {
       row + List(width - row.size) { EMPTY_FLOOR }
     }
   }

--- a/samples/dungeon/common/src/test/java/com/squareup/sample/dungeon/board/ParserTest.kt
+++ b/samples/dungeon/common/src/test/java/com/squareup/sample/dungeon/board/ParserTest.kt
@@ -118,7 +118,7 @@ class ParserTest {
           |🌳🌳 
           |🌳🌳 
           |🌳🌳 
-    """.trimMargin().parseBoard()
+      """.trimMargin().parseBoard()
     )
   }
 
@@ -139,7 +139,7 @@ class ParserTest {
           | 🌳🌳 
           | 🌳🌳 
           | 🌳🌳 
-    """.trimMargin().parseBoard()
+      """.trimMargin().parseBoard()
     )
   }
 
@@ -157,7 +157,7 @@ class ParserTest {
           |🌳🌳🌳
           |🌳🌳🌳
           |   
-    """.trimMargin().parseBoard()
+      """.trimMargin().parseBoard()
     )
   }
 
@@ -176,7 +176,7 @@ class ParserTest {
           |🌳🌳🌳🌳
           |🌳🌳🌳🌳
           |    
-    """.trimMargin().parseBoard()
+      """.trimMargin().parseBoard()
     )
   }
 

--- a/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineLayoutRunner.kt
+++ b/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineLayoutRunner.kt
@@ -89,6 +89,7 @@ class ShakeableTimeMachineLayoutRunner(
   private fun Duration.toUiString(): String = toString()
 
   companion object : ScreenViewFactory<ShakeableTimeMachineScreen> by fromLayout(
-    R.layout.shakeable_time_machine_layout, ::ShakeableTimeMachineLayoutRunner
+    R.layout.shakeable_time_machine_layout,
+    ::ShakeableTimeMachineLayoutRunner
   )
 }

--- a/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
+++ b/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
@@ -41,7 +41,9 @@ class EditTextWorkflow : StatefulWorkflow<EditTextProps, EditTextState, String, 
     return if (old.text != new.text) {
       // Clamp the cursor position to the text length.
       state.copy(cursorPosition = state.cursorPosition.coerceIn(new.text))
-    } else state
+    } else {
+      state
+    }
   }
 
   override fun render(

--- a/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/TodoWorkflow.kt
+++ b/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/TodoWorkflow.kt
@@ -65,7 +65,6 @@ class TodoWorkflow : TerminalWorkflow,
     renderState: TodoList,
     context: RenderContext
   ): TerminalRendering {
-
     context.runningWorker(renderProps.keyStrokes) { onKeystroke(it) }
 
     return TerminalRendering(

--- a/samples/hello-workflow-fragment/src/androidTest/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragmentAppTest.kt
+++ b/samples/hello-workflow-fragment/src/androidTest/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragmentAppTest.kt
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith
 class HelloWorkflowFragmentAppTest {
 
   private val scenarioRule = ActivityScenarioRule(HelloWorkflowFragmentActivity::class.java)
+
   @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(scenarioRule)
     .around(IdlingDispatcherRule)

--- a/samples/hello-workflow/src/androidTest/java/com/squareup/sample/helloworkflow/HelloWorkflowAppTest.kt
+++ b/samples/hello-workflow/src/androidTest/java/com/squareup/sample/helloworkflow/HelloWorkflowAppTest.kt
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith
 class HelloWorkflowAppTest {
 
   private val scenarioRule = ActivityScenarioRule(HelloWorkflowActivity::class.java)
+
   @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(scenarioRule)
     .around(IdlingDispatcherRule)

--- a/samples/stub-visibility/src/androidTest/java/com/squareup/sample/stubvisibility/StubVisibilityAppTest.kt
+++ b/samples/stub-visibility/src/androidTest/java/com/squareup/sample/stubvisibility/StubVisibilityAppTest.kt
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith
 internal class StubVisibilityAppTest {
 
   private val scenarioRule = ActivityScenarioRule(StubVisibilityActivity::class.java)
+
   @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(scenarioRule)
     .around(IdlingDispatcherRule)

--- a/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
+++ b/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
@@ -43,6 +43,7 @@ import org.junit.runner.RunWith
 class TicTacToeEspressoTest {
 
   private val scenarioRule = ActivityScenarioRule(TicTacToeActivity::class.java)
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(scenarioRule)
     .around(IdlingDispatcherRule)

--- a/samples/tictactoe/app/src/main/java/com/squareup/sample/gameworkflow/GameOverLayoutRunner.kt
+++ b/samples/tictactoe/app/src/main/java/com/squareup/sample/gameworkflow/GameOverLayoutRunner.kt
@@ -63,7 +63,9 @@ internal class GameOverLayoutRunner(
     }
 
     renderGame(
-      binding.gamePlayBoard, binding.gamePlayToolbar, rendering.endGameState.completedGame,
+      binding.gamePlayBoard,
+      binding.gamePlayToolbar,
+      rendering.endGameState.completedGame,
       rendering.endGameState.playerInfo
     )
   }
@@ -103,6 +105,7 @@ internal class GameOverLayoutRunner(
 
   /** Note how easily we're sharing this layout with [GamePlayViewFactory]. */
   companion object : ScreenViewFactory<GameOverScreen> by fromViewBinding(
-    GamePlayLayoutBinding::inflate, ::GameOverLayoutRunner
+    GamePlayLayoutBinding::inflate,
+    ::GameOverLayoutRunner
   )
 }

--- a/samples/tictactoe/app/src/main/java/com/squareup/sample/gameworkflow/GamePlayViewFactory.kt
+++ b/samples/tictactoe/app/src/main/java/com/squareup/sample/gameworkflow/GamePlayViewFactory.kt
@@ -31,8 +31,11 @@ private fun setCellClickListeners(
     val box = turn.board[row][col]
 
     val cellClickListener =
-      if (box != null) null
-      else View.OnClickListener { takeSquareHandler(row, col) }
+      if (box != null) {
+        null
+      } else {
+        View.OnClickListener { takeSquareHandler(row, col) }
+      }
 
     cell.setOnClickListener(cellClickListener)
   }

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/RealAuthService.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/RealAuthService.kt
@@ -26,7 +26,8 @@ class RealAuthService : AuthService {
       )
       SECOND_FACTOR != request.secondFactor -> response(
         AuthResponse(
-          format("Invalid second factor (try %s)", SECOND_FACTOR), WEAK_TOKEN,
+          format("Invalid second factor (try %s)", SECOND_FACTOR),
+          WEAK_TOKEN,
           true
         )
       )

--- a/samples/todo-android/app/src/androidTest/java/com/squareup/sample/mainactivity/TodoAppTest.kt
+++ b/samples/todo-android/app/src/androidTest/java/com/squareup/sample/mainactivity/TodoAppTest.kt
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith
 class TodoAppTest {
 
   private val scenarioRule = ActivityScenarioRule(ToDoActivity::class.java)
+
   @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(scenarioRule)
     .around(IdlingDispatcherRule)

--- a/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
+++ b/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
@@ -98,8 +98,11 @@ private fun TodoEditingSession.toTodoList(): TodoList {
     title = title.textValue,
     entries = rows
       .mapIndexedNotNull { index, row ->
-        if (index == rows.size - 1 && row.isEmpty()) null
-        else TodoEntry(row.textController.textValue, row.checked)
+        if (index == rows.size - 1 && row.isEmpty()) {
+          null
+        } else {
+          TodoEntry(row.textController.textValue, row.checked)
+        }
       }
   )
 }

--- a/trace-encoder/src/main/java/com/squareup/tracing/ChromeTraceEvent.kt
+++ b/trace-encoder/src/main/java/com/squareup/tracing/ChromeTraceEvent.kt
@@ -73,6 +73,7 @@ internal data class ChromeTraceEvent(
 @Suppress("unused")
 private object PhaseAdapter {
   @ToJson fun toJson(phase: Phase) = phase.code
+
   @FromJson fun fromJson(code: Char) = Phase.values().single { it.code == code }
 }
 

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/BaseRenderContext.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/BaseRenderContext.kt
@@ -224,6 +224,7 @@ BaseRenderContext<PropsT, StateT, OutputT>.renderChild(
   key: String = "",
   handler: (ChildOutputT) -> WorkflowAction<PropsT, StateT, OutputT>
 ): ChildRenderingT = renderChild(child, Unit, key, handler)
+
 /**
  * Convenience alias of [BaseRenderContext.renderChild] for workflows that don't emit output.
  */
@@ -233,6 +234,7 @@ BaseRenderContext<PropsT, StateT, OutputT>.renderChild(
   props: ChildPropsT,
   key: String = ""
 ): ChildRenderingT = renderChild(child, props, key) { noAction() }
+
 /**
  * Convenience alias of [BaseRenderContext.renderChild] for children that don't take props or emit
  * output.
@@ -242,6 +244,7 @@ BaseRenderContext<PropsT, StateT, OutputT>.renderChild(
   child: Workflow<Unit, Nothing, ChildRenderingT>,
   key: String = ""
 ): ChildRenderingT = renderChild(child, Unit, key) { noAction() }
+
 /**
  * Ensures a [Worker] that never emits anything is running. Since [worker] can't emit anything,
  * it can't trigger any [WorkflowAction]s.

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowIdentifierType.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowIdentifierType.kt
@@ -24,7 +24,8 @@ public sealed class WorkflowIdentifierType {
     val kClass: KClass<*>? = null,
   ) : WorkflowIdentifierType() {
     public constructor(kClass: KClass<*>) : this(
-      kClass.qualifiedName ?: kClass.toString(), kClass
+      kClass.qualifiedName ?: kClass.toString(),
+      kClass
     )
   }
 

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/RuntimeConfig.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/RuntimeConfig.kt
@@ -7,7 +7,9 @@ import kotlin.annotation.AnnotationRetention.BINARY
  * This is used to mark any experimental runtimes.
  */
 @Target(
-  AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION,
+  AnnotationTarget.CLASS,
+  AnnotationTarget.PROPERTY,
+  AnnotationTarget.FUNCTION,
   AnnotationTarget.TYPEALIAS
 )
 @MustBeDocumented

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/TreeSnapshotTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/TreeSnapshotTest.kt
@@ -49,13 +49,16 @@ internal class TreeSnapshotTest {
     assertTrue(id3 in treeSnapshot.childTreeSnapshots)
 
     assertEquals(
-      "one", treeSnapshot.childTreeSnapshots.getValue(id1).workflowSnapshot!!.bytes.utf8()
+      "one",
+      treeSnapshot.childTreeSnapshots.getValue(id1).workflowSnapshot!!.bytes.utf8()
     )
     assertEquals(
-      "two", treeSnapshot.childTreeSnapshots.getValue(id2).workflowSnapshot!!.bytes.utf8()
+      "two",
+      treeSnapshot.childTreeSnapshots.getValue(id2).workflowSnapshot!!.bytes.utf8()
     )
     assertEquals(
-      "three", treeSnapshot.childTreeSnapshots.getValue(id3).workflowSnapshot!!.bytes.utf8()
+      "three",
+      treeSnapshot.childTreeSnapshots.getValue(id3).workflowSnapshot!!.bytes.utf8()
     )
   }
 
@@ -94,10 +97,12 @@ internal class TreeSnapshotTest {
     assertTrue(id4 !in treeSnapshot.childTreeSnapshots)
 
     assertEquals(
-      "one", treeSnapshot.childTreeSnapshots.getValue(id1).workflowSnapshot!!.bytes.utf8()
+      "one",
+      treeSnapshot.childTreeSnapshots.getValue(id1).workflowSnapshot!!.bytes.utf8()
     )
     assertEquals(
-      "three", treeSnapshot.childTreeSnapshots.getValue(id3).workflowSnapshot!!.bytes.utf8()
+      "three",
+      treeSnapshot.childTreeSnapshots.getValue(id3).workflowSnapshot!!.bytes.utf8()
     )
   }
 

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
@@ -82,7 +82,8 @@ internal class WorkflowInterceptorTest {
 
     assertEquals(Snapshot.of("state"), snapshot)
     assertEquals(
-      listOf("BEGIN|onSnapshotState", "END|onSnapshotState"), recorder.consumeEventNames()
+      listOf("BEGIN|onSnapshotState", "END|onSnapshotState"),
+      recorder.consumeEventNames()
     )
   }
 
@@ -166,7 +167,8 @@ internal class WorkflowInterceptorTest {
         session: WorkflowSession
       ): R {
         return proceed(
-          renderProps, renderState,
+          renderProps,
+          renderState,
           object : RenderContextInterceptor<P, S, O> {
             override fun onRunningSideEffect(
               key: String,

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
@@ -54,7 +54,8 @@ internal class ChainedWorkflowInterceptorTest {
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
-  @Test fun `chains calls to onInstanceStarted in left-to-right order`() {
+  @Test
+  fun `chains calls to onInstanceStarted in left-to-right order`() {
     val events = mutableListOf<String>()
     val interceptor1 = object : WorkflowInterceptor {
       override fun onSessionStarted(
@@ -196,7 +197,11 @@ internal class ChainedWorkflowInterceptorTest {
 
     val finalRendering =
       chained.onRender<String, String, Nothing, Any>(
-        "props", "state", FakeRenderContext, { p, s, _ -> "($p|$s)" }, TestSession,
+        "props",
+        "state",
+        FakeRenderContext,
+        { p, s, _ -> "($p|$s)" },
+        TestSession,
       )
 
     assertEquals(

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/RealRenderContextTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/RealRenderContextTest.kt
@@ -98,7 +98,8 @@ internal class RealRenderContextTest {
     Channel<WorkflowAction<String, String, String>>(capacity = UNLIMITED)
 
   @OptIn(ExperimentalCoroutinesApi::class)
-  @Test fun `send completes update`() {
+  @Test
+  fun `send completes update`() {
     val context = createdPoisonedContext()
     val stringAction = action<String, String, String>({ "stringAction" }) { }
 

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
@@ -145,7 +145,10 @@ internal class SubtreeManagerTest {
     val workflow = TestWorkflow()
 
     val (composeProps, composeState) = manager.render(
-      workflow, "props", key = "", handler = { fail() }
+      workflow,
+      "props",
+      key = "",
+      handler = { fail() }
     )
     assertEquals("props", composeProps)
     assertEquals("initialState:props", composeState)

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -170,7 +170,11 @@ internal class WorkflowNodeTest {
       }
     }
     val node = WorkflowNode(
-      workflow.id(), workflow, "", null, context,
+      workflow.id(),
+      workflow,
+      "",
+      null,
+      context,
       emitOutputToParent = { WorkflowOutput("tick:$it") }
     )
     node.render(workflow, "")("event")
@@ -204,7 +208,11 @@ internal class WorkflowNodeTest {
       }
     }
     val node = WorkflowNode(
-      workflow.id(), workflow, "", null, context,
+      workflow.id(),
+      workflow,
+      "",
+      null,
+      context,
       emitOutputToParent = { WorkflowOutput("tick:$it") }
     )
     val sink = node.render(workflow, "")
@@ -262,8 +270,11 @@ internal class WorkflowNodeTest {
       assertFalse(started)
     }
     val node = WorkflowNode(
-      workflow.id(), workflow.asStatefulWorkflow(), initialProps = Unit,
-      snapshot = null, baseContext = context
+      workflow.id(),
+      workflow.asStatefulWorkflow(),
+      initialProps = Unit,
+      snapshot = null,
+      baseContext = context
     )
 
     runTest {
@@ -280,8 +291,11 @@ internal class WorkflowNodeTest {
       }
     }
     val node = WorkflowNode(
-      workflow.id(), workflow.asStatefulWorkflow(), initialProps = Unit,
-      snapshot = null, baseContext = context
+      workflow.id(),
+      workflow.asStatefulWorkflow(),
+      initialProps = Unit,
+      snapshot = null,
+      baseContext = context
     )
 
     node.render(workflow.asStatefulWorkflow(), Unit)
@@ -299,8 +313,11 @@ internal class WorkflowNodeTest {
       }
     }
     val node = WorkflowNode(
-      workflow.id(), workflow.asStatefulWorkflow(), initialProps = Unit,
-      snapshot = null, baseContext = context
+      workflow.id(),
+      workflow.asStatefulWorkflow(),
+      initialProps = Unit,
+      snapshot = null,
+      baseContext = context
     )
     node.render(workflow.asStatefulWorkflow(), Unit)
 
@@ -328,8 +345,11 @@ internal class WorkflowNodeTest {
       }
     }
     val node = WorkflowNode(
-      workflow.id(), workflow.asStatefulWorkflow(), initialProps = true,
-      snapshot = null, baseContext = context
+      workflow.id(),
+      workflow.asStatefulWorkflow(),
+      initialProps = true,
+      snapshot = null,
+      baseContext = context
     )
 
     runTest {
@@ -354,8 +374,11 @@ internal class WorkflowNodeTest {
       }
     }
     val node = WorkflowNode(
-      workflow.id(), workflow.asStatefulWorkflow(), initialProps = Unit,
-      snapshot = null, baseContext = context
+      workflow.id(),
+      workflow.asStatefulWorkflow(),
+      initialProps = Unit,
+      snapshot = null,
+      baseContext = context
     )
 
     runTest {
@@ -380,8 +403,11 @@ internal class WorkflowNodeTest {
       }
     }
     val node = WorkflowNode(
-      workflow.id(), workflow.asStatefulWorkflow(), initialProps = 0,
-      snapshot = null, baseContext = context
+      workflow.id(),
+      workflow.asStatefulWorkflow(),
+      initialProps = 0,
+      snapshot = null,
+      baseContext = context
     )
 
     runTest {
@@ -405,8 +431,11 @@ internal class WorkflowNodeTest {
       }
     }
     val node = WorkflowNode(
-      workflow.id(), workflow.asStatefulWorkflow(), initialProps = 0,
-      snapshot = null, baseContext = context
+      workflow.id(),
+      workflow.asStatefulWorkflow(),
+      initialProps = 0,
+      snapshot = null,
+      baseContext = context
     )
 
     runTest {
@@ -426,8 +455,11 @@ internal class WorkflowNodeTest {
       runningSideEffect("same") { fail() }
     }
     val node = WorkflowNode(
-      workflow.id(), workflow.asStatefulWorkflow(), initialProps = Unit,
-      snapshot = null, baseContext = context
+      workflow.id(),
+      workflow.asStatefulWorkflow(),
+      initialProps = Unit,
+      snapshot = null,
+      baseContext = context
     )
 
     val error = assertFailsWith<IllegalArgumentException> {
@@ -454,7 +486,10 @@ internal class WorkflowNodeTest {
     }
       .asStatefulWorkflow()
     val node = WorkflowNode(
-      workflow.id(), workflow, initialProps = 0, snapshot = null,
+      workflow.id(),
+      workflow,
+      initialProps = 0,
+      snapshot = null,
       baseContext = context
     )
 
@@ -487,8 +522,11 @@ internal class WorkflowNodeTest {
       runningSideEffect("two") { started2 = true }
     }
     val node = WorkflowNode(
-      workflow.id(), workflow.asStatefulWorkflow(), initialProps = Unit,
-      snapshot = null, baseContext = context
+      workflow.id(),
+      workflow.asStatefulWorkflow(),
+      initialProps = Unit,
+      snapshot = null,
+      baseContext = context
     )
 
     assertFalse(started1)

--- a/workflow-runtime/src/jvmWorkflowNode/kotlin/com/squareup/workflow1/WorkflowNodeBenchmark.kt
+++ b/workflow-runtime/src/jvmWorkflowNode/kotlin/com/squareup/workflow1/WorkflowNodeBenchmark.kt
@@ -56,7 +56,8 @@ internal open class WorkflowNodeBenchmark {
   private val context = Unconfined
 
   @Param
-  @JvmField var treeShape = TreeShape.SQUARE
+  @JvmField
+  var treeShape = TreeShape.SQUARE
 
   private lateinit var workflow: FractalWorkflow
   private lateinit var node: WorkflowNode<Props, Unit, Nothing, Unit>
@@ -136,8 +137,11 @@ private class FractalWorkflow(
   }
 
   private val childWorkflow =
-    if (depth > 0 && childCount > 0) FractalWorkflow(childCount, depth - 1)
-    else null
+    if (depth > 0 && childCount > 0) {
+      FractalWorkflow(childCount, depth - 1)
+    } else {
+      null
+    }
 
   private val areChildrenLeaves = depth == 1
 

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/RealRenderTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/RealRenderTester.kt
@@ -308,7 +308,9 @@ internal class RealRenderTester<PropsT, StateT, OutputT, RenderingT>(
   }
 
   private fun deepCloneForRender(): BaseRenderContext<PropsT, StateT, OutputT> = RealRenderTester(
-    workflow, props, state,
+    workflow,
+    props,
+    state,
     // Copy the list of expectations since it's mutable.
     expectations = ArrayList(expectations),
     // Don't care about consumed expectations.

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderTester.kt
@@ -486,7 +486,10 @@ RenderTester<PropsT, StateT, OutputT, RenderingT>.expectWorkflow(
   description: String = ""
 ): RenderTester<PropsT, StateT, OutputT, RenderingT> =
   expectWorkflow(
-    workflowType.workflowIdentifier, rendering, key = key, output = output,
+    workflowType.workflowIdentifier,
+    rendering,
+    key = key,
+    output = output,
     description = description,
     assertProps = {
       @Suppress("UNCHECKED_CAST")

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkerSink.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkerSink.kt
@@ -27,6 +27,7 @@ public class WorkerSink<T>(
 ) : Worker<T> {
 
   private val channel = Channel<T>(capacity = UNLIMITED)
+
   /** This could be an atomic boolean, but this way we don't need to deal with atomicfu. */
   private var active = Mutex()
 

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkerStressTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkerStressTest.kt
@@ -20,7 +20,8 @@ private const val WORKER_COUNT = 500
 internal class WorkerStressTest {
 
   @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
-  @Test fun `multiple subscriptions to single channel when closed`() {
+  @Test
+  fun `multiple subscriptions to single channel when closed`() {
     val channel = Channel<Unit>()
     val workers = List(WORKER_COUNT / 2) {
       channel.consumeAsFlow()
@@ -66,7 +67,8 @@ internal class WorkerStressTest {
   }
 
   @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
-  @Test fun `multiple subscriptions to single StateFlow when emits`() {
+  @Test
+  fun `multiple subscriptions to single StateFlow when emits`() {
     val flow = MutableStateFlow(Unit)
 
     val workers = List(WORKER_COUNT) { flow.asWorker() }

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkerTest.kt
@@ -47,7 +47,8 @@ internal class WorkerTest {
   }
 
   @Suppress("DEPRECATION")
-  @Test fun `createSideEffect returns equivalent workers`() {
+  @Test
+  fun `createSideEffect returns equivalent workers`() {
     val worker1 = Worker.createSideEffect {}
     val worker2 = Worker.createSideEffect {}
 
@@ -56,7 +57,8 @@ internal class WorkerTest {
   }
 
   @Suppress("DEPRECATION")
-  @Test fun `createSideEffect runs`() {
+  @Test
+  fun `createSideEffect runs`() {
     var ran = false
     val worker = Worker.createSideEffect {
       ran = true
@@ -68,7 +70,8 @@ internal class WorkerTest {
   }
 
   @Suppress("DEPRECATION")
-  @Test fun `createSideEffect finishes`() {
+  @Test
+  fun `createSideEffect finishes`() {
     val worker = Worker.createSideEffect {}
 
     worker.test {
@@ -77,7 +80,8 @@ internal class WorkerTest {
   }
 
   @Suppress("DEPRECATION")
-  @Test fun `createSideEffect propagates exceptions`() {
+  @Test
+  fun `createSideEffect propagates exceptions`() {
     val worker = Worker.createSideEffect { throw ExpectedException() }
 
     worker.test {

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
@@ -93,7 +93,8 @@ internal class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Unit, Unit> {}
     val tester = workflow.testRender(Unit)
       .expectWorkflow(
-        OutputWhateverChild::class, rendering = Unit,
+        OutputWhateverChild::class,
+        rendering = Unit,
         output = WorkflowOutput(Unit)
       )
 
@@ -880,7 +881,8 @@ internal class RealRenderTesterTest {
       tester.render {}
     }
     assertEquals(
-      "Tried to render unexpected child $actualId", error.message
+      "Tried to render unexpected child $actualId",
+      error.message
     )
   }
 

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/RenderIdempotencyCheckerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/RenderIdempotencyCheckerTest.kt
@@ -28,7 +28,10 @@ class RenderIdempotencyCheckerTest {
     val scope = TestScope()
 
     renderWorkflowIn(
-      rootWorkflow, scope, MutableStateFlow(Unit), interceptors = listOf(RenderIdempotencyChecker)
+      rootWorkflow,
+      scope,
+      MutableStateFlow(Unit),
+      interceptors = listOf(RenderIdempotencyChecker)
     ) {}
     assertEquals(2, rootRenders)
     assertEquals(2, leafRenders)
@@ -46,7 +49,9 @@ class RenderIdempotencyCheckerTest {
     }
     val outputs = mutableListOf<String>()
     val renderings = renderWorkflowIn(
-      workflow, CoroutineScope(Unconfined), MutableStateFlow(Unit),
+      workflow,
+      CoroutineScope(Unconfined),
+      MutableStateFlow(Unit),
       interceptors = listOf(RenderIdempotencyChecker)
     ) {
       outputs += it
@@ -70,7 +75,9 @@ class RenderIdempotencyCheckerTest {
     }
     val outputs = mutableListOf<String>()
     val renderings = renderWorkflowIn(
-      workflow, CoroutineScope(Unconfined), MutableStateFlow(Unit),
+      workflow,
+      CoroutineScope(Unconfined),
+      MutableStateFlow(Unit),
       interceptors = listOf(RenderIdempotencyChecker)
     ) {
       outputs += it

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/WorkerSinkTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/WorkerSinkTest.kt
@@ -25,7 +25,8 @@ import kotlin.test.assertTrue
 class WorkerSinkTest {
 
   @OptIn(ExperimentalStdlibApi::class)
-  @Test fun types() {
+  @Test
+  fun types() {
     abstract class IntermediateWorker<out T> : Worker<T>
     class MyWorker : IntermediateWorker<String>() {
       override fun run(): Flow<String> = emptyFlow()
@@ -84,7 +85,8 @@ class WorkerSinkTest {
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
-  @Test fun `multiple values are buffered`() {
+  @Test
+  fun `multiple values are buffered`() {
     val worker = WorkerSink<String>("foo")
     worker.send("hello")
     worker.send("world")
@@ -95,7 +97,8 @@ class WorkerSinkTest {
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
-  @Test fun `throws when consumed concurrently`() {
+  @Test
+  fun `throws when consumed concurrently`() {
     val worker = WorkerSink<String>("foo")
 
     runBlocking {

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/WorkerTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/WorkerTesterTest.kt
@@ -17,7 +17,8 @@ class WorkerTesterTest {
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
-  @Test fun `assertNoOutput fails after worker emits`() {
+  @Test
+  fun `assertNoOutput fails after worker emits`() {
     val worker = Worker.from { Unit }
     val error = assertFailsWith<AssertionError> {
       worker.test {

--- a/workflow-tracing/src/main/java/com/squareup/workflow1/diagnostic/tracing/GcDetector.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/diagnostic/tracing/GcDetector.kt
@@ -13,7 +13,8 @@ internal open class GcDetector(private val onGcDetected: () -> Unit) {
   @Volatile private var running = true
 
   private inner class GcCanary {
-    @Throws(Throwable::class) protected fun finalize() {
+    @Throws(Throwable::class)
+    protected fun finalize() {
       if (!running) return
 
       onGcDetected()

--- a/workflow-tracing/src/test/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptorTest.kt
+++ b/workflow-tracing/src/test/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptorTest.kt
@@ -69,7 +69,9 @@ internal class TracingWorkflowInterceptorTest {
 
     runBlocking(scope.coroutineContext) {
       val renderings = renderWorkflowIn(
-        TestWorkflow(), scope, props.stateIn(this),
+        TestWorkflow(),
+        scope,
+        props.stateIn(this),
         interceptors = listOf(listener),
         onOutput = {}
       ).map { it.rendering }
@@ -123,10 +125,12 @@ internal class TracingWorkflowInterceptorTest {
       if (renderProps == 0) return "initial"
       if (renderProps in 1..6) context.renderChild(this, 0) { bubbleUp(it) }
       if (renderProps in 4..5) context.renderChild(this, props = 1, key = "second") { bubbleUp(it) }
-      if (renderProps in 2..3) context.runningWorker(
-        channel.receiveAsFlow()
-          .asWorker()
-      ) { bubbleUp(it) }
+      if (renderProps in 2..3) {
+        context.runningWorker(
+          channel.receiveAsFlow()
+            .asWorker()
+        ) { bubbleUp(it) }
+      }
 
       return if (renderProps > 10) "final" else "rendering"
     }

--- a/workflow-ui/compose-tooling/src/androidTest/java/com/squareup/workflow1/ui/compose/tooling/LegacyPreviewViewFactoryTest.kt
+++ b/workflow-ui/compose-tooling/src/androidTest/java/com/squareup/workflow1/ui/compose/tooling/LegacyPreviewViewFactoryTest.kt
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith
 internal class LegacyPreviewViewFactoryTest {
 
   private val composeRule = createComposeRule()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)
@@ -101,7 +102,8 @@ internal class LegacyPreviewViewFactoryTest {
       }
     }
 
-  @Preview @Composable private fun ParentWithOneChildPreview() {
+  @Preview @Composable
+  private fun ParentWithOneChildPreview() {
     ParentWithOneChild.Preview(Pair("one", "two"))
   }
 
@@ -114,7 +116,8 @@ internal class LegacyPreviewViewFactoryTest {
       }
     }
 
-  @Preview @Composable private fun ParentWithTwoChildrenPreview() {
+  @Preview @Composable
+  private fun ParentWithTwoChildrenPreview() {
     ParentWithTwoChildren.Preview(Triple("one", "two", "three"))
   }
 
@@ -132,7 +135,8 @@ internal class LegacyPreviewViewFactoryTest {
     }
   }
 
-  @Preview @Composable private fun ParentRecursivePreview() {
+  @Preview @Composable
+  private fun ParentRecursivePreview() {
     ParentRecursive.Preview(
       RecursiveRendering(
         text = "one",
@@ -144,14 +148,16 @@ internal class LegacyPreviewViewFactoryTest {
     )
   }
 
-  @Preview @Composable private fun ParentWithModifier() {
+  @Preview @Composable
+  private fun ParentWithModifier() {
     ParentWithOneChild.Preview(
       Pair("one", "two"),
       modifier = Modifier.size(0.dp)
     )
   }
 
-  @Preview @Composable private fun ParentWithPlaceholderModifier() {
+  @Preview @Composable
+  private fun ParentWithPlaceholderModifier() {
     ParentWithOneChild.Preview(
       Pair("one", "two"),
       placeholderModifier = Modifier.size(0.dp)
@@ -166,7 +172,8 @@ internal class LegacyPreviewViewFactoryTest {
     BasicText(environment[TestEnvironmentKey])
   }
 
-  @Preview @Composable private fun ParentConsumesCustomKeyPreview() {
+  @Preview @Composable
+  private fun ParentConsumesCustomKeyPreview() {
     ParentConsumesCustomKey.Preview(Unit) {
       it + (TestEnvironmentKey to "foo")
     }

--- a/workflow-ui/compose-tooling/src/androidTest/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewFactoryTest.kt
+++ b/workflow-ui/compose-tooling/src/androidTest/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewFactoryTest.kt
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith
 internal class PreviewViewFactoryTest {
 
   private val composeRule = createComposeRule()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)
@@ -102,7 +103,8 @@ internal class PreviewViewFactoryTest {
       }
     }
 
-  @Preview @Composable private fun ParentWithOneChildPreview() {
+  @Preview @Composable
+  private fun ParentWithOneChildPreview() {
     ParentWithOneChild.Preview(TwoStrings("one", "two"))
   }
 
@@ -115,7 +117,8 @@ internal class PreviewViewFactoryTest {
       }
     }
 
-  @Preview @Composable private fun ParentWithTwoChildrenPreview() {
+  @Preview @Composable
+  private fun ParentWithTwoChildrenPreview() {
     ParentWithTwoChildren.Preview(ThreeStrings("one", "two", "three"))
   }
 
@@ -162,7 +165,8 @@ internal class PreviewViewFactoryTest {
       }
     }
 
-  @Preview @Composable private fun ParentRecursivePreview() {
+  @Preview @Composable
+  private fun ParentRecursivePreview() {
     ParentRecursive.Preview(
       RecursiveRendering(
         text = "one",
@@ -174,14 +178,16 @@ internal class PreviewViewFactoryTest {
     )
   }
 
-  @Preview @Composable private fun ParentWithModifier() {
+  @Preview @Composable
+  private fun ParentWithModifier() {
     ParentWithOneChild.Preview(
       TwoStrings("one", "two"),
       modifier = Modifier.size(0.dp)
     )
   }
 
-  @Preview @Composable private fun ParentWithPlaceholderModifier() {
+  @Preview @Composable
+  private fun ParentWithPlaceholderModifier() {
     ParentWithOneChild.Preview(
       TwoStrings("one", "two"),
       placeholderModifier = Modifier.size(0.dp)
@@ -196,7 +202,8 @@ internal class PreviewViewFactoryTest {
     BasicText(environment[TestEnvironmentKey])
   }
 
-  @Preview @Composable private fun ParentConsumesCustomKeyPreview() {
+  @Preview @Composable
+  private fun ParentConsumesCustomKeyPreview() {
     ParentConsumesCustomKey.Preview(TwoStrings("ignored", "ignored")) {
       it + (TestEnvironmentKey to "foo")
     }

--- a/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/LegacyViewFactories.kt
+++ b/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/LegacyViewFactories.kt
@@ -1,4 +1,5 @@
 @file:Suppress("DEPRECATION")
+
 package com.squareup.workflow1.ui.compose.tooling
 
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
@@ -34,7 +35,8 @@ import com.squareup.workflow1.ui.compose.composeViewFactory
  */
 @Deprecated("Use ScreenViewFactory.Preview")
 @WorkflowUiExperimentalApi
-@Composable public fun <RenderingT : Any> ViewFactory<RenderingT>.Preview(
+@Composable
+public fun <RenderingT : Any> ViewFactory<RenderingT>.Preview(
   rendering: RenderingT,
   modifier: Modifier = Modifier,
   placeholderModifier: Modifier = Modifier,
@@ -47,7 +49,8 @@ import com.squareup.workflow1.ui.compose.composeViewFactory
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @Preview(showBackground = true)
-@Composable private fun ViewFactoryPreviewPreview() {
+@Composable
+private fun ViewFactoryPreviewPreview() {
   val factory = composeViewFactory<Unit> { _, environment ->
     Column(
       verticalArrangement = spacedBy(8.dp),

--- a/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/PlaceholderViewFactory.kt
+++ b/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/PlaceholderViewFactory.kt
@@ -104,28 +104,32 @@ internal fun placeholderScreenViewFactory(modifier: Modifier): ScreenViewFactory
   }
 
 @Preview(widthDp = 200, heightDp = 200)
-@Composable private fun PreviewStubViewBindingOnWhite() {
+@Composable
+private fun PreviewStubViewBindingOnWhite() {
   Box(Modifier.background(Color.White)) {
     PreviewStubBindingPreviewTemplate()
   }
 }
 
 @Preview(widthDp = 200, heightDp = 200)
-@Composable private fun PreviewStubViewBindingOnBlack() {
+@Composable
+private fun PreviewStubViewBindingOnBlack() {
   Box(Modifier.background(Color.Black)) {
     PreviewStubBindingPreviewTemplate()
   }
 }
 
 @Preview(widthDp = 50, showBackground = true)
-@Composable private fun PreviewStubViewBindingTall() {
+@Composable
+private fun PreviewStubViewBindingTall() {
   Box {
     PreviewStubBindingPreviewTemplate("very long text to test cross-hatch rendering edge cases")
   }
 }
 
 @Preview(widthDp = 200, showBackground = true)
-@Composable private fun PreviewStubViewBindingWide() {
+@Composable
+private fun PreviewStubViewBindingWide() {
   Box {
     PreviewStubBindingPreviewTemplate("very long text to test cross-hatch rendering edge cases")
   }

--- a/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewEnvironment.kt
+++ b/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewEnvironment.kt
@@ -18,7 +18,8 @@ import com.squareup.workflow1.ui.plus
 import kotlin.reflect.KClass
 
 @Deprecated("Use overload with a ScreenViewFactory parameter.")
-@Composable internal fun rememberPreviewViewEnvironment(
+@Composable
+internal fun rememberPreviewViewEnvironment(
   placeholderModifier: Modifier,
   viewEnvironmentUpdater: ((ViewEnvironment) -> ViewEnvironment)? = null,
   mainFactory: ViewFactory<*>? = null
@@ -93,6 +94,9 @@ private class PreviewScreenViewFactoryFinder<RenderingT : Screen>(
     rendering: ScreenT
   ): ScreenViewFactory<ScreenT> =
     @Suppress("UNCHECKED_CAST")
-    if (rendering::class == mainFactory?.type) mainFactory as ScreenViewFactory<ScreenT>
-    else placeholderFactory
+    if (rendering::class == mainFactory?.type) {
+      mainFactory as ScreenViewFactory<ScreenT>
+    } else {
+      placeholderFactory
+    }
 }

--- a/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/ViewFactories.kt
+++ b/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/ViewFactories.kt
@@ -33,7 +33,8 @@ import com.squareup.workflow1.ui.compose.composeScreenViewFactory
  * factory.
  */
 @WorkflowUiExperimentalApi
-@Composable public fun <RenderingT : Screen> ScreenViewFactory<RenderingT>.Preview(
+@Composable
+public fun <RenderingT : Screen> ScreenViewFactory<RenderingT>.Preview(
   rendering: RenderingT,
   modifier: Modifier = Modifier,
   placeholderModifier: Modifier = Modifier,
@@ -46,7 +47,8 @@ import com.squareup.workflow1.ui.compose.composeScreenViewFactory
 
 @OptIn(WorkflowUiExperimentalApi::class)
 @Preview(showBackground = true)
-@Composable private fun ViewFactoryPreviewPreview() {
+@Composable
+private fun ViewFactoryPreviewPreview() {
   val factory = composeScreenViewFactory<Screen> { _, environment ->
     Column(
       verticalArrangement = spacedBy(8.dp),

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewFactoryTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewFactoryTest.kt
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith
 internal class ComposeViewFactoryTest {
 
   private val composeRule = createComposeRule()
+
   @get:Rule val rules: RuleChain =
     RuleChain.outerRule(DetectLeaksAfterTestSuccess())
       .around(IdleAfterTestRule)

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -52,6 +52,7 @@ import kotlin.reflect.KClass
 internal class ComposeViewTreeIntegrationTest {
 
   private val composeRule = createAndroidComposeRule<WorkflowUiTestActivity>()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)
@@ -371,7 +372,8 @@ internal class ComposeViewTreeIntegrationTest {
     scenario.onActivity {
       it.setRendering(
         BodyAndOverlaysScreen(
-          EmptyRendering, TestModal(BackStackScreen(EmptyRendering, firstScreen))
+          EmptyRendering,
+          TestModal(BackStackScreen(EmptyRendering, firstScreen))
         )
       )
     }
@@ -426,7 +428,10 @@ internal class ComposeViewTreeIntegrationTest {
     scenario.onActivity {
       it.setRendering(
         BodyAndOverlaysScreen(
-          EmptyRendering, TestModal(firstScreen), TestModal(secondScreen), TestModal(thirdScreen)
+          EmptyRendering,
+          TestModal(firstScreen),
+          TestModal(secondScreen),
+          TestModal(thirdScreen)
         )
       )
     }

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/CompositionRootTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/CompositionRootTest.kt
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith
 internal class CompositionRootTest {
 
   private val composeRule = createComposeRule()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/LegacyComposeViewFactoryTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/LegacyComposeViewFactoryTest.kt
@@ -37,6 +37,7 @@ import org.junit.runner.RunWith
 internal class LegacyComposeViewFactoryTest {
 
   private val composeRule = createComposeRule()
+
   @get:Rule val rules: RuleChain =
     RuleChain.outerRule(DetectLeaksAfterTestSuccess())
       .around(IdleAfterTestRule)

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/LegacyComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/LegacyComposeViewTreeIntegrationTest.kt
@@ -53,6 +53,7 @@ import kotlin.reflect.KClass
 internal class LegacyComposeViewTreeIntegrationTest {
 
   private val composeRule = createAndroidComposeRule<LegacyWorkflowUiTestActivity>()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/LegacyWorkflowRenderingTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/LegacyWorkflowRenderingTest.kt
@@ -84,6 +84,7 @@ import kotlin.reflect.KClass
 internal class LegacyWorkflowRenderingTest {
 
   private val composeRule = createComposeRule()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)
@@ -348,7 +349,8 @@ internal class LegacyWorkflowRenderingTest {
 
     composeRule.setContent {
       WorkflowRendering(
-        Rendering(), ViewEnvironment.EMPTY,
+        Rendering(),
+        ViewEnvironment.EMPTY,
         Modifier.size(width = 42.dp, height = 43.dp)
       )
     }
@@ -367,7 +369,8 @@ internal class LegacyWorkflowRenderingTest {
 
     composeRule.setContent {
       WorkflowRendering(
-        Rendering(), ViewEnvironment.EMPTY,
+        Rendering(),
+        ViewEnvironment.EMPTY,
         Modifier.sizeIn(minWidth = 42.dp, minHeight = 43.dp)
       )
     }
@@ -397,7 +400,8 @@ internal class LegacyWorkflowRenderingTest {
     composeRule.setContent {
       with(LocalDensity.current) {
         WorkflowRendering(
-          LegacyRendering(viewId), ViewEnvironment.EMPTY,
+          LegacyRendering(viewId),
+          ViewEnvironment.EMPTY,
           Modifier.size(42.toDp(), 43.toDp())
         )
       }

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/RenderAsStateTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/RenderAsStateTest.kt
@@ -50,6 +50,7 @@ import kotlin.test.assertFailsWith
 internal class RenderAsStateTest {
 
   private val composeRule = createComposeRule()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/WorkflowRenderingTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/WorkflowRenderingTest.kt
@@ -82,6 +82,7 @@ import kotlin.reflect.KClass
 internal class WorkflowRenderingTest {
 
   private val composeRule = createComposeRule()
+
   @get:Rule val rules: RuleChain = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(IdleAfterTestRule)
     .around(composeRule)
@@ -344,7 +345,8 @@ internal class WorkflowRenderingTest {
 
     composeRule.setContent {
       WorkflowRendering(
-        Rendering(), ViewEnvironment.EMPTY,
+        Rendering(),
+        ViewEnvironment.EMPTY,
         Modifier.size(width = 42.dp, height = 43.dp)
       )
     }
@@ -363,7 +365,8 @@ internal class WorkflowRenderingTest {
 
     composeRule.setContent {
       WorkflowRendering(
-        Rendering(), ViewEnvironment.EMPTY,
+        Rendering(),
+        ViewEnvironment.EMPTY,
         Modifier.sizeIn(minWidth = 42.dp, minHeight = 43.dp)
       )
     }
@@ -389,7 +392,8 @@ internal class WorkflowRenderingTest {
     composeRule.setContent {
       with(LocalDensity.current) {
         WorkflowRendering(
-          LegacyRendering(viewId), ViewEnvironment.EMPTY,
+          LegacyRendering(viewId),
+          ViewEnvironment.EMPTY,
           Modifier.size(42.toDp(), 43.toDp())
         )
       }

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeScreenViewFactory.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeScreenViewFactory.kt
@@ -52,6 +52,7 @@ internal fun <RenderingT : Screen> composeScreenViewFactory(
   ) -> Unit
 ): ScreenViewFactory<RenderingT> = object : ComposeScreenViewFactory<RenderingT>() {
   override val type: KClass<in RenderingT> = type
+
   @Composable override fun Content(
     rendering: RenderingT,
     viewEnvironment: ViewEnvironment

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeViewFactory.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeViewFactory.kt
@@ -60,6 +60,7 @@ internal fun <RenderingT : Any> composeViewFactory(
   ) -> Unit
 ): ViewFactory<RenderingT> = object : ComposeViewFactory<RenderingT>() {
   override val type: KClass<in RenderingT> = type
+
   @Composable override fun Content(
     rendering: RenderingT,
     viewEnvironment: ViewEnvironment

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/CompositionRoot.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/CompositionRoot.kt
@@ -89,7 +89,8 @@ public fun ScreenViewFactoryFinder.withCompositionRoot(
  * wrap the content at the highest occurrence of this function in the composition subtree.
  */
 @VisibleForTesting(otherwise = PRIVATE)
-@Composable internal fun WrappedWithRootIfNecessary(
+@Composable
+internal fun WrappedWithRootIfNecessary(
   root: CompositionRoot,
   content: @Composable () -> Unit
 ) {

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/LegacyWorkflowRendering.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/LegacyWorkflowRendering.kt
@@ -34,7 +34,8 @@ import kotlin.reflect.KClass
 
 @Deprecated("Use the overload with a `rendering: Screen` parameter")
 @WorkflowUiExperimentalApi
-@Composable public fun WorkflowRendering(
+@Composable
+public fun WorkflowRendering(
   rendering: Any,
   viewEnvironment: ViewEnvironment,
   modifier: Modifier = Modifier

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/RenderAsState.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/RenderAsState.kt
@@ -122,7 +122,8 @@ public fun <PropsT, OutputT : Any, RenderingT> Workflow<PropsT, OutputT, Renderi
  * the [LocalSaveableStateRegistry]. If null, will use the default key based on source location.
  */
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-@Composable internal fun <PropsT, OutputT : Any, RenderingT> renderAsState(
+@Composable
+internal fun <PropsT, OutputT : Any, RenderingT> renderAsState(
   workflow: Workflow<PropsT, OutputT, RenderingT>,
   scope: CoroutineScope,
   props: PropsT,

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/WorkflowRendering.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/WorkflowRendering.kt
@@ -67,7 +67,8 @@ import kotlin.reflect.KClass
  * @throws IllegalArgumentException if no factory can be found for [rendering]'s type.
  */
 @WorkflowUiExperimentalApi
-@Composable public fun WorkflowRendering(
+@Composable
+public fun WorkflowRendering(
   rendering: Screen,
   viewEnvironment: ViewEnvironment,
   modifier: Modifier = Modifier

--- a/workflow-ui/container-android/src/androidTest/java/com/squareup/workflow1/ui/modal/test/ModalViewContainerLifecycleTest.kt
+++ b/workflow-ui/container-android/src/androidTest/java/com/squareup/workflow1/ui/modal/test/ModalViewContainerLifecycleTest.kt
@@ -24,6 +24,7 @@ internal class ModalViewContainerLifecycleTest {
 
   private val scenarioRule =
     ActivityScenarioRule(ModalViewContainerLifecycleActivity::class.java)
+
   @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(scenarioRule)
     .around(IdlingDispatcherRule)

--- a/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/backstack/BackStackScreen.kt
+++ b/workflow-ui/container-common/src/main/java/com/squareup/workflow1/ui/backstack/BackStackScreen.kt
@@ -51,8 +51,11 @@ public class BackStackScreen<StackedT : Any>(
   public operator fun get(index: Int): StackedT = frames[index]
 
   public operator fun plus(other: BackStackScreen<StackedT>?): BackStackScreen<StackedT> {
-    return if (other == null) this
-    else BackStackScreen(frames[0], frames.subList(1, frames.size) + other.frames)
+    return if (other == null) {
+      this
+    } else {
+      BackStackScreen(frames[0], frames.subList(1, frames.size) + other.frames)
+    }
   }
 
   public fun <R : Any> map(transform: (StackedT) -> R): BackStackScreen<R> {

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/WorkflowViewStubLifecycleTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/WorkflowViewStubLifecycleTest.kt
@@ -45,6 +45,7 @@ internal class WorkflowViewStubLifecycleTest {
 
   private val scenarioRule =
     ActivityScenarioRule(WorkflowViewStubLifecycleActivity::class.java)
+
   @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(scenarioRule)
     .around(IdlingDispatcherRule)

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/BackStackContainerPersistenceLifecycleTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/BackStackContainerPersistenceLifecycleTest.kt
@@ -31,6 +31,7 @@ internal class BackStackContainerPersistenceLifecycleTest {
 
   private val scenarioRule =
     ActivityScenarioRule(BackStackContainerLifecycleActivity::class.java)
+
   @get:Rule val rules = RuleChain.outerRule(DetectLeaksAfterTestSuccess())
     .around(scenarioRule)
     .around(IdlingDispatcherRule)
@@ -412,7 +413,8 @@ internal class BackStackContainerPersistenceLifecycleTest {
 
   // https://github.com/square/workflow-kotlin/issues/559
   @SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
-  @Test fun lifecycle_replace_after_pause() {
+  @Test
+  fun lifecycle_replace_after_pause() {
     assertThat(scenario.state).isEqualTo(RESUMED)
     scenario.onActivity {
       it.update(LeafRendering("initial"))

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/BackStackContainerTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/BackStackContainerTest.kt
@@ -156,7 +156,9 @@ internal class BackStackContainerTest {
 
   private class VisibleBackStackContainer(context: Context) : BackStackContainer(context) {
     var transitionCount = 0
-    @Suppress("UNCHECKED_CAST") val visibleRendering: Screen
+
+    @Suppress("UNCHECKED_CAST")
+    val visibleRendering: Screen
       get() = (getChildAt(0)?.tag as NamedScreen<*>).wrapped
 
     override fun performTransition(

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/DialogIntegrationTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/DialogIntegrationTest.kt
@@ -68,7 +68,8 @@ internal class DialogIntegrationTest {
 
   @Test fun showOne() {
     val screen = BodyAndOverlaysScreen(
-      ContentRendering("body"), DialogRendering("dialog", ContentRendering("content"))
+      ContentRendering("body"),
+      DialogRendering("dialog", ContentRendering("content"))
     )
 
     scenario.onActivity { activity ->
@@ -84,7 +85,8 @@ internal class DialogIntegrationTest {
   /** https://github.com/square/workflow-kotlin/issues/825 */
   @Test fun showASecondDialog() {
     val oneDialog = BodyAndOverlaysScreen(
-      ContentRendering("body"), DialogRendering("dialog", ContentRendering("content"))
+      ContentRendering("body"),
+      DialogRendering("dialog", ContentRendering("content"))
     )
     lateinit var root: WorkflowLayout
 

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/ViewStateCacheTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/container/ViewStateCacheTest.kt
@@ -122,7 +122,9 @@ internal class ViewStateCacheTest {
         it.show(firstRendering, viewEnvironment)
       }
     cache.update(
-      listOf(firstRendering), oldHolderMaybe = secondView, newHolder = firstHolderRestored
+      listOf(firstRendering),
+      oldHolderMaybe = secondView,
+      newHolder = firstHolderRestored
     )
 
     // Check that the state was restored.

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidRenderWorkflow.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidRenderWorkflow.kt
@@ -170,7 +170,13 @@ public fun <PropsT, OutputT, RenderingT> renderWorkflowIn(
   runtimeConfig: RuntimeConfig = RuntimeConfig.DEFAULT_CONFIG,
   onOutput: suspend (OutputT) -> Unit = {}
 ): StateFlow<RenderingT> = renderWorkflowIn(
-  workflow, scope, MutableStateFlow(prop), savedStateHandle, interceptors, runtimeConfig, onOutput
+  workflow,
+  scope,
+  MutableStateFlow(prop),
+  savedStateHandle,
+  interceptors,
+  runtimeConfig,
+  onOutput
 )
 
 /**
@@ -267,7 +273,13 @@ public fun <PropsT, OutputT, RenderingT> renderWorkflowIn(
 ): StateFlow<RenderingT> {
   val restoredSnap = savedStateHandle?.get<PickledTreesnapshot>(KEY)?.snapshot
   val renderingsAndSnapshots = renderWorkflowIn(
-    workflow, scope, props, restoredSnap, interceptors, runtimeConfig, onOutput
+    workflow,
+    scope,
+    props,
+    restoredSnap,
+    interceptors,
+    runtimeConfig,
+    onOutput
   )
 
   return renderingsAndSnapshots

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/AndroidViewRegistry.kt
@@ -89,7 +89,10 @@ public fun <RenderingT : Any> ViewRegistry.buildView(
   viewStarter: ViewStarter? = null,
 ): View {
   return getFactoryForRendering(initialRendering).buildView(
-    initialRendering, initialViewEnvironment, contextForNewView, container
+    initialRendering,
+    initialViewEnvironment,
+    contextForNewView,
+    container
   ).also { view ->
     checkNotNull(view.workflowViewStateOrNull) {
       "View.bindShowRendering should have been called for $view, typically by the " +

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunner.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LayoutRunner.kt
@@ -1,4 +1,5 @@
 @file:Suppress("DEPRECATION")
+
 package com.squareup.workflow1.ui
 
 import android.view.View

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LegacyFactoryForScreenType.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/LegacyFactoryForScreenType.kt
@@ -18,7 +18,10 @@ internal class LegacyFactoryForScreenType : ViewFactory<Screen> {
   ): View {
     val modernFactory = initialRendering.toViewFactory(initialViewEnvironment)
     val holder = modernFactory.buildView(
-      initialRendering, initialViewEnvironment, contextForNewView, container
+      initialRendering,
+      initialViewEnvironment,
+      contextForNewView,
+      container
     )
     holder.view.bindShowRendering(initialRendering, initialViewEnvironment) { r, e ->
       holder.runner.showRendering(r, e)

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewFactory.kt
@@ -14,31 +14,29 @@ import com.squareup.workflow1.ui.ScreenViewFactory.Companion.fromViewBinding
 public typealias ViewBindingInflater<BindingT> = (LayoutInflater, ViewGroup?, Boolean) -> BindingT
 
 /**
- * A [ViewRegistry.Entry] that can build Android [View] instances, along with functions
- * that can update them to display [Screen] renderings of a particular [type], bundled
- * together in instances of [ScreenViewHolder].
+ * A [ViewRegistry.Entry] that can build Android [View] instances, along with functions that can
+ * update them to display [Screen] renderings of a particular [type], bundled together in instances
+ * of [ScreenViewHolder].
  *
- * Use [fromLayout], [fromViewBinding], etc., to create a [ScreenViewFactory].
- * These helper methods take a layout resource, view binding, or view building
- * function as arguments, along with a factory to create a [showRendering]
- * [ScreenViewRunner.showRendering] function.
+ * Use [fromLayout], [fromViewBinding], etc., to create a [ScreenViewFactory]. These helper methods
+ * take a layout resource, view binding, or view building function as arguments, along with a
+ * factory to create a [showRendering] [ScreenViewRunner.showRendering] function.
  *
  * It is rare to call [buildView] directly. Instead the most common path is to pass [Screen]
- * instances to [WorkflowViewStub.show], which will apply the [ScreenViewFactory] machinery
- * for you.
+ * instances to [WorkflowViewStub.show], which will apply the [ScreenViewFactory] machinery for you.
  *
- * If you are building a custom container and [WorkflowViewStub] is too restrictive,
- * use [ScreenViewFactory.startShowing].
+ * If you are building a custom container and [WorkflowViewStub] is too restrictive, use
+ * [ScreenViewFactory.startShowing].
  */
 @WorkflowUiExperimentalApi
 public interface ScreenViewFactory<in ScreenT : Screen> : ViewRegistry.Entry<ScreenT> {
   /**
    * It is rare to call this method directly. Instead the most common path is to pass [Screen]
-   * instances to [WorkflowViewStub.show], which will apply the [ScreenViewFactory] machinery
-   * for you.
+   * instances to [WorkflowViewStub.show], which will apply the [ScreenViewFactory] machinery for
+   * you.
    *
-   * Called by [startShowing] to create a [ScreenViewHolder] wrapping a [View] able to
-   * display a stream of [ScreenT] renderings, starting with [initialRendering].
+   * Called by [startShowing] to create a [ScreenViewHolder] wrapping a [View] able to display a
+   * stream of [ScreenT] renderings, starting with [initialRendering].
    */
   public fun buildView(
     initialRendering: ScreenT,
@@ -52,15 +50,13 @@ public interface ScreenViewFactory<in ScreenT : Screen> : ViewRegistry.Entry<Scr
      * Creates a [ScreenViewFactory] that [inflates][bindingInflater] a [ViewBinding] ([BindingT])
      * to show renderings of type [ScreenT] : [Screen], using [a lambda][showRendering].
      *
-     *    val HelloViewFactory: ScreenViewFactory<HelloScreen> =
-     *      forViewBinding(HelloGoodbyeViewBinding::inflate) { rendering, _ ->
-     *        helloMessage.text = rendering.message
-     *        helloMessage.setOnClickListener { rendering.onClick(Unit) }
-     *      }
+     * val HelloViewFactory: ScreenViewFactory<HelloScreen> =
+     * forViewBinding(HelloGoodbyeViewBinding::inflate) { rendering, _ -> helloMessage.text
+     * = rendering.message helloMessage.setOnClickListener { rendering.onClick(Unit) } }
      *
-     * If you need to initialize your view before [showRendering] is called,
-     * implement [ScreenViewRunner] and create a binding using the `forViewBinding` variant
-     * that accepts a `(ViewBinding) -> ScreenViewRunner` function, below.
+     * If you need to initialize your view before [showRendering] is called, implement
+     * [ScreenViewRunner] and create a binding using the `forViewBinding` variant that accepts a
+     * `(ViewBinding) -> ScreenViewRunner` function, below.
      */
     public inline fun <BindingT : ViewBinding, reified ScreenT : Screen> fromViewBinding(
       noinline bindingInflater: ViewBindingInflater<BindingT>,
@@ -72,27 +68,22 @@ public interface ScreenViewFactory<in ScreenT : Screen> : ViewRegistry.Entry<Scr
     }
 
     /**
-     * Creates a [ScreenViewFactory] that [inflates][bindingInflater] a
-     * [ViewBinding] (of type [BindingT]) to show renderings of type [ScreenT],
-     * using a [ScreenViewRunner] created by [constructor]. Handy if you need
-     * to perform some set up before [ScreenViewRunner.showRendering] is called.
+     * Creates a [ScreenViewFactory] that [inflates][bindingInflater] a [ViewBinding] (of
+     * type [BindingT]) to show renderings of type [ScreenT], using a [ScreenViewRunner]
+     * created by [constructor]. Handy if you need to perform some set up before
+     * [ScreenViewRunner.showRendering] is called.
      *
-     *   class HelloScreenRunner(
-     *     private val binding: HelloGoodbyeViewBinding
-     *   ) : ScreenViewRunner<HelloScreen> {
+     * class HelloScreenRunner( private val binding: HelloGoodbyeViewBinding ) :
+     * ScreenViewRunner<HelloScreen> {
      *
-     *     override fun showRendering(rendering: HelloScreen) {
-     *       binding.messageView.text = rendering.message
-     *       binding.messageView.setOnClickListener { rendering.onClick(Unit) }
-     *     }
+     * override fun showRendering(rendering: HelloScreen) { binding.messageView.text =
+     * rendering.message binding.messageView.setOnClickListener { rendering.onClick(Unit) } }
      *
-     *     companion object : ScreenViewFactory<HelloScreen> by forViewBinding(
-     *       HelloGoodbyeViewBinding::inflate, ::HelloScreenRunner
-     *     )
-     *   }
+     * companion object : ScreenViewFactory<HelloScreen> by forViewBinding(
+     * HelloGoodbyeViewBinding::inflate, ::HelloScreenRunner ) }
      *
-     * If the view doesn't need to be initialized before [showRendering] is called,
-     * use the variant above which just takes a lambda.
+     * If the view doesn't need to be initialized before [showRendering] is called, use the variant
+     * above which just takes a lambda.
      */
     public inline fun <BindingT : ViewBinding, reified ScreenT : Screen> fromViewBinding(
       noinline bindingInflater: ViewBindingInflater<BindingT>,
@@ -101,9 +92,9 @@ public interface ScreenViewFactory<in ScreenT : Screen> : ViewRegistry.Entry<Scr
       ViewBindingScreenViewFactory(ScreenT::class, bindingInflater, constructor)
 
     /**
-     * Creates a [ScreenViewFactory] that inflates [layoutId] to show renderings of
-     * type [ScreenT], using a [ScreenViewRunner] created by [constructor] to update it.
-     * Avoids any use of [AndroidX ViewBinding][ViewBinding].
+     * Creates a [ScreenViewFactory] that inflates [layoutId] to show renderings of type [ScreenT],
+     * using a [ScreenViewRunner] created by [constructor] to update it. Avoids any use of
+     * [AndroidX ViewBinding][ViewBinding].
      */
     public inline fun <reified ScreenT : Screen> fromLayout(
       @LayoutRes layoutId: Int,
@@ -113,8 +104,8 @@ public interface ScreenViewFactory<in ScreenT : Screen> : ViewRegistry.Entry<Scr
 
     /**
      * Creates a [ScreenViewFactory] that inflates [layoutId] to "show" renderings of type
-     * [ScreenT], but never updates the created view. Handy for showing static displays,
-     * e.g. when prototyping.
+     * [ScreenT], but never updates the created view. Handy for showing static displays, e.g. when
+     * prototyping.
      */
     @Suppress("unused")
     public inline fun <reified ScreenT : Screen> fromStaticLayout(
@@ -122,8 +113,8 @@ public interface ScreenViewFactory<in ScreenT : Screen> : ViewRegistry.Entry<Scr
     ): ScreenViewFactory<ScreenT> = fromLayout(layoutId) { ScreenViewRunner { _, _ -> } }
 
     /**
-     * Creates a [ScreenViewFactory] that builds [View] instances entirely from code,
-     * using a [ScreenViewRunner] created by [buildView] to update it.
+     * Creates a [ScreenViewFactory] that builds [View] instances entirely from code, using a
+     * [ScreenViewRunner] created by [buildView] to update it.
      */
     @WorkflowUiExperimentalApi
     public inline fun <reified ScreenT : Screen> fromCode(
@@ -148,55 +139,45 @@ public interface ScreenViewFactory<in ScreenT : Screen> : ViewRegistry.Entry<Scr
     }
 
     /**
-     * Creates a [ScreenViewFactory] for [WrapperT] that finds and delegates to
-     * the one for [WrappedT].  Allows [WrapperT] to wrap instances of [WrappedT]
-     * to add information or behavior, without requiring wasteful wrapping in the view system.
+     * Creates a [ScreenViewFactory] for [WrapperT] that finds and delegates to the one for
+     * [WrappedT]. Allows [WrapperT] to wrap instances of [WrappedT] to add information or behavior,
+     * without requiring wasteful wrapping in the view system.
      *
-     * One general note: when creating a wrapper rendering, you're very likely to want it
-     * to implement [Compatible], to ensure that checks made to update or replace a view
-     * are based on the wrapped item. Each wrapper example below illustrates this.
+     * One general note: when creating a wrapper rendering, you're very likely to want it to
+     * implement [Compatible], to ensure that checks made to update or replace a view are based on
+     * the wrapped item. Each wrapper example below illustrates this.
      *
-     * This a simpler variant of the like named function that takes three arguments, for
-     * use when there is no need to manipulate the [ScreenViewHolder].
+     * This a simpler variant of the like named function that takes three arguments, for use when
+     * there is no need to manipulate the [ScreenViewHolder].
      *
      * ## Examples
      *
-     * To make one rendering type an "alias" for another -- that is, to use the
-     * same [ScreenViewFactory] to display it:
+     * To make one rendering type an "alias" for another -- that is, to use the same
+     * [ScreenViewFactory] to display it:
      *
-     *    class RealScreen(val data: String): AndroidScreen<RealScreen> {
-     *      override val viewFactory = fromLayout<RealScreen>(...)
-     *    }
+     * class RealScreen(val data: String): AndroidScreen<RealScreen> { override val viewFactory =
+     * fromLayout<RealScreen>(...) }
      *
-     *    class AliasScreen(val similarData: String) : AndroidScreen<AliasScreen> {
-     *      override val viewFactory = forWrapper<AliasScreen, RealScreen> { aliasScreen ->
-     *        RealScreen(aliasScreen.similarData)
-     *      }
-     *    }
+     * class AliasScreen(val similarData: String) : AndroidScreen<AliasScreen> {
+     * override val viewFactory = forWrapper<AliasScreen, RealScreen> { aliasScreen ->
+     * RealScreen(aliasScreen.similarData) } }
      *
      * To make one [Screen] type a wrapper for others:
      *
-     *    class Wrapper<W>(val wrapped: W: Screen) : AndroidScreen<Wrapper<W>>, Compatible {
-     *      override val compatibilityKey = Compatible.keyFor(wrapped)
-     *      override val viewFactory = ScreenViewFactory.forWrapper<Wrapper<W>, W> { it.wrapped }
-     *    }
+     * class Wrapper<W>(val wrapped: W: Screen) : AndroidScreen<Wrapper<W>>, Compatible {
+     * override val compatibilityKey = Compatible.keyFor(wrapped) override val viewFactory =
+     * ScreenViewFactory.forWrapper<Wrapper<W>, W> { it.wrapped } }
      *
      * To make a wrapper that adds information to the [ViewEnvironment]:
      *
-     *    class ReverseNeutronFlowPolarity : ViewEnvironmentKey<Boolean>(Boolean::class) {
-     *      override val default = false
-     *    }
+     * class ReverseNeutronFlowPolarity : ViewEnvironmentKey<Boolean>(Boolean::class) { override val
+     * default = false }
      *
-     *    class ReversePolarityScreen<W : Screen>(
-     *      val wrapped: W
-     *    ) : AndroidScreen<ReversePolarityScreen<W>>, Compatible {
-     *      override val compatibilityKey: String = Compatible.keyFor(wrapped)
-     *      override val viewFactory = forWrapper<OverrideNeutronFlow<W>, Screen> {
-     *        it.wrapped.withEnvironment(
-     *          Environment.EMPTY + (ReverseNeutronFlowPolarity to true)
-     *        )
-     *      }
-     *    }
+     * class ReversePolarityScreen<W : Screen>( val wrapped: W ) :
+     * AndroidScreen<ReversePolarityScreen<W>>, Compatible { override val compatibilityKey: String
+     * = Compatible.keyFor(wrapped) override val viewFactory = forWrapper<OverrideNeutronFlow<W>,
+     * Screen> { it.wrapped.withEnvironment( Environment.EMPTY + (ReverseNeutronFlowPolarity to
+     * true) ) } }
      *
      * @param unwrap a function to extract [WrappedT] instances from [WrapperT]s.
      */
@@ -214,35 +195,26 @@ public interface ScreenViewFactory<in ScreenT : Screen> : ViewRegistry.Entry<Scr
     }
 
     /**
-     * Creates a [ScreenViewFactory] for [WrapperT] that finds and delegates to
-     * the one for [WrappedT].  Allows [WrapperT] to wrap instances of [WrappedT]
-     * to add information or behavior, without requiring wasteful wrapping in the view system.
+     * Creates a [ScreenViewFactory] for [WrapperT] that finds and delegates to the one for
+     * [WrappedT]. Allows [WrapperT] to wrap instances of [WrappedT] to add information or behavior,
+     * without requiring wasteful wrapping in the view system.
      *
-     * This fully featured variant of the function is able to initialize the freshly
-     * created [ScreenViewHolder], and transform the wrapped [ScreenViewHolder.runner].
+     * This fully featured variant of the function is able to initialize the freshly created
+     * [ScreenViewHolder], and transform the wrapped [ScreenViewHolder.runner].
      *
      * To make a wrapper that customizes [View] initialization:
      *
-     *    class WithTutorialTips<W : Screen>(
-     *      val wrapped: W
-     *    ) : AndroidScreen<WithTutorialTips<W>>, Compatible {
-     *      override val compatibilityKey = Compatible.keyFor(wrapped)
-     *      override val viewFactory = forWrapper<WithTutorialTips<W>, W>(
-     *        unwrap = { it.wrapped },
-     *        beforeShowing = { TutorialTipRunner.initialize(it.view) },
-     *        showWrapperScreen = { _, wrapper, environment, showWrapper ->
-     *          showWrapper(unwrap(wrapper), environment)
-     *        }
-     *      )
-     *    }
+     * class WithTutorialTips<W : Screen>( val wrapped: W ) : AndroidScreen<WithTutorialTips<W>>,
+     * Compatible { override val compatibilityKey = Compatible.keyFor(wrapped) override
+     * val viewFactory = forWrapper<WithTutorialTips<W>, W>( unwrap = { it.wrapped },
+     * beforeShowing = { TutorialTipRunner.initialize(it.view) }, showWrapperScreen = { _,
+     * wrapper, environment, showWrapper -> showWrapper(unwrap(wrapper), environment) } ) }
      *
      * @param unwrap a function to extract [WrappedT] instances from [WrapperT]s.
-     *
      * @param beforeShowing a function to be invoked immediately after a new [View] is built.
-     *
-     * @param showWrapperScreen a function to be invoked when an instance of [WrapperT] needs
-     * to be shown in a [View] built to display instances of [WrappedT]. Allows
-     * pre- and post-processing of the [View].
+     * @param showWrapperScreen a function to be invoked when an instance of [WrapperT] needs to be
+     *     shown in a [View] built to display instances of [WrappedT]. Allows pre- and
+     *     post-processing of the [View].
      */
     @WorkflowUiExperimentalApi
     public inline fun <
@@ -262,7 +234,10 @@ public interface ScreenViewFactory<in ScreenT : Screen> : ViewRegistry.Entry<Scr
         val wrappedFactory = unwrap(initialRendering).toViewFactory(initialEnvironment)
         val wrapperFactory = wrappedFactory.toUnwrappingViewFactory(unwrap, showWrapperScreen)
         wrapperFactory.buildView(
-          initialRendering, initialEnvironment, context, container
+          initialRendering,
+          initialEnvironment,
+          context,
+          container
         ).also { beforeShowing(it) }
       }
   }
@@ -270,12 +245,11 @@ public interface ScreenViewFactory<in ScreenT : Screen> : ViewRegistry.Entry<Scr
 
 /**
  * It is rare to call this method directly. Instead the most common path is to pass [Screen]
- * instances to [WorkflowViewStub.show], which will apply the [ScreenViewFactory] machinery
- * for you.
+ * instances to [WorkflowViewStub.show], which will apply the [ScreenViewFactory] machinery for you.
  *
- * Use the [ScreenViewFactoryFinder] in [environment] to return the [ScreenViewFactory]
- * bound to the type of the receiving [Screen]. Call [ScreenViewFactory.startShowing] to
- * create and initialize a new [View].
+ * Use the [ScreenViewFactoryFinder] in [environment] to return the [ScreenViewFactory] bound to the
+ * type of the receiving [Screen]. Call [ScreenViewFactory.startShowing] to create and initialize a
+ * new [View].
  */
 @WorkflowUiExperimentalApi
 public fun <ScreenT : Screen> ScreenT.toViewFactory(
@@ -286,11 +260,10 @@ public fun <ScreenT : Screen> ScreenT.toViewFactory(
 
 /**
  * It is rare to call this method directly. Instead the most common path is to pass [Screen]
- * instances to [WorkflowViewStub.show], which will apply the [ScreenViewFactory] machinery
- * for you.
+ * instances to [WorkflowViewStub.show], which will apply the [ScreenViewFactory] machinery for you.
  *
- * Creates a [ScreenViewHolder] wrapping a [View] able to display a stream
- * of [ScreenT] renderings, starting with [initialRendering].
+ * Creates a [ScreenViewHolder] wrapping a [View] able to display a stream of [ScreenT] renderings,
+ * starting with [initialRendering].
  *
  * To add more initialization behavior (typically a call to
  * [WorkflowLifecycleOwner.installOn][com.squareup.workflow1.ui.androidx.WorkflowLifecycleOwner.installOn]),
@@ -330,7 +303,8 @@ public fun <ScreenT : Screen> ScreenViewFactory<ScreenT>.startShowing(
       // This same call to bindShowRendering will also update View.getRendering() and
       // View.environment() to return what was passed in here, as expected.
       holder.view.bindShowRendering(
-        initialRendering, initialEnvironment
+        initialRendering,
+        initialEnvironment
       ) { rendering, environment ->
         holder.show(rendering, environment)
         shown = true
@@ -360,9 +334,9 @@ public fun <ScreenT : Screen> ScreenViewFactory<ScreenT>.startShowing(
 }
 
 /**
- * A wrapper for the function invoked when [ScreenViewFactory.startShowing] is called,
- * allowing for custom initialization of a newly built [View] before or after the first
- * call to [ScreenViewHolder.show].
+ * A wrapper for the function invoked when [ScreenViewFactory.startShowing] is called, allowing
+ * for custom initialization of a newly built [View] before or after the first call to
+ * [ScreenViewHolder.show].
  */
 @WorkflowUiExperimentalApi
 public fun interface ViewStarter {
@@ -374,8 +348,7 @@ public fun interface ViewStarter {
 }
 
 /**
- * Transforms a [ScreenViewFactory] of [WrappedT] into one that can handle
- * instances of [WrapperT].
+ * Transforms a [ScreenViewFactory] of [WrappedT] into one that can handle instances of [WrapperT].
  *
  * @see [ScreenViewFactory.forWrapper].
  */
@@ -392,8 +365,7 @@ public inline fun <
 }
 
 /**
- * Transforms a [ScreenViewFactory] of [WrappedT] into one that can handle
- * instances of [WrapperT].
+ * Transforms a [ScreenViewFactory] of [WrappedT] into one that can handle instances of [WrapperT].
  *
  * @see [ScreenViewFactory.forWrapper].
  */
@@ -412,11 +384,13 @@ public inline fun <
 ): ScreenViewFactory<WrapperT> {
   val wrappedFactory = this
 
-  return object : ScreenViewFactory<WrapperT>
-  by fromCode(
+  return object : ScreenViewFactory<WrapperT> by fromCode(
     buildView = { initialRendering, initialEnvironment, context, container ->
       val wrappedHolder = wrappedFactory.buildView(
-        unwrap(initialRendering), initialEnvironment, context, container
+        unwrap(initialRendering),
+        initialEnvironment,
+        context,
+        container
       )
 
       object : ScreenViewHolder<WrapperT> {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
@@ -98,7 +98,10 @@ public class WorkflowViewStub @JvmOverloads constructor(
 
   init {
     val attrs = context.obtainStyledAttributes(
-      attributeSet, R.styleable.WorkflowViewStub, defStyle, defStyleRes
+      attributeSet,
+      R.styleable.WorkflowViewStub,
+      defStyle,
+      defStyleRes
     )
     inflatedId = attrs.getResourceId(R.styleable.WorkflowViewStub_inflatedId, NO_ID)
     updatesVisibility = attrs.getBoolean(R.styleable.WorkflowViewStub_updatesVisibility, true)

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/AlertOverlayDialogFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/AlertOverlayDialogFactory.kt
@@ -83,8 +83,12 @@ public fun AlertDialog.toDialogHolder(
       setTitle(rendering.title)
 
       // The buttons won't actually exist until the dialog is showing.
-      if (isShowing) updateButtonsOnShow(rendering) else setOnShowListener {
+      if (isShowing) {
         updateButtonsOnShow(rendering)
+      } else {
+        setOnShowListener {
+          updateButtonsOnShow(rendering)
+        }
       }
     }
   }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogSession.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogSession.kt
@@ -68,7 +68,10 @@ internal class DialogSession(
    * Wrap the given dialog holder to maintain [allowEvents] on each update.
    */
   val holder: OverlayDialogHolder<Overlay> = OverlayDialogHolder(
-    holder.environment, holder.dialog, holder.onUpdateBounds, holder.onBackPressed
+    holder.environment,
+    holder.dialog,
+    holder.onUpdateBounds,
+    holder.onBackPressed
   ) { overlay, environment ->
     allowEvents = !environment[CoveredByModal]
     holder.show(overlay, environment)
@@ -98,9 +101,11 @@ internal class DialogSession(
 
           // If there is an onBackPressed handler invoke it instead of allowing
           // the normal machinery to call Dialog.onBackPressed.
-          if (event.isBackPress) holder.onBackPressed?.let { onBackPressed ->
-            onBackPressed.invoke()
-            return true
+          if (event.isBackPress) {
+            holder.onBackPressed?.let { onBackPressed ->
+              onBackPressed.invoke()
+              return true
+            }
           }
 
           // Allow the usual handling, including the usual call to Dialog.onBackPressed.

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/LegacyAndroidViewRegistryTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/LegacyAndroidViewRegistryTest.kt
@@ -18,7 +18,8 @@ import kotlin.test.assertTrue
 internal class LegacyAndroidViewRegistryTest {
 
   @OptIn(WorkflowUiExperimentalApi::class)
-  @Test fun missingBindingMessage_isUseful() {
+  @Test
+  fun missingBindingMessage_isUseful() {
     val emptyReg = object : ViewRegistry {
       override val keys: Set<KClass<*>> = emptySet()
       override fun <RenderingT : Any> getEntryFor(

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ScreenViewFactoryTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/ScreenViewFactoryTest.kt
@@ -15,7 +15,8 @@ import kotlin.test.assertFailsWith
 internal class ScreenViewFactoryTest {
 
   @OptIn(WorkflowUiExperimentalApi::class)
-  @Test fun missingBindingMessage_isUseful() {
+  @Test
+  fun missingBindingMessage_isUseful() {
     val emptyReg = object : ViewRegistry {
       override val keys: Set<KClass<*>> = emptySet()
       override fun <RenderingT : Any> getEntryFor(

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/WorkflowUiExperimentalApi.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/WorkflowUiExperimentalApi.kt
@@ -12,7 +12,9 @@ import kotlin.annotation.AnnotationRetention.BINARY
  * workflow versions. Proceed with caution, and be ready to have the rug pulled out from under you.
  */
 @Target(
-  AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION,
+  AnnotationTarget.CLASS,
+  AnnotationTarget.PROPERTY,
+  AnnotationTarget.FUNCTION,
   AnnotationTarget.TYPEALIAS
 )
 @MustBeDocumented

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/container/BackStackScreen.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/container/BackStackScreen.kt
@@ -43,8 +43,11 @@ public class BackStackScreen<StackedT : Screen>(
   public operator fun get(index: Int): StackedT = frames[index]
 
   public operator fun plus(other: BackStackScreen<StackedT>?): BackStackScreen<StackedT> {
-    return if (other == null) this
-    else BackStackScreen(frames[0], frames.subList(1, frames.size) + other.frames)
+    return if (other == null) {
+      this
+    } else {
+      BackStackScreen(frames[0], frames.subList(1, frames.size) + other.frames)
+    }
   }
 
   public fun <R : Screen> map(transform: (StackedT) -> R): BackStackScreen<R> {

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreen.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/container/EnvironmentScreen.kt
@@ -52,8 +52,11 @@ public fun Screen.withEnvironment(
 ): EnvironmentScreen<*> {
   return when (this) {
     is EnvironmentScreen<*> -> {
-      if (environment.map.isEmpty()) this
-      else EnvironmentScreen(wrapped, this.environment + environment)
+      if (environment.map.isEmpty()) {
+        this
+      } else {
+        EnvironmentScreen(wrapped, this.environment + environment)
+      }
     }
     else -> EnvironmentScreen(this, environment)
   }

--- a/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/IdlingDispatcher.kt
+++ b/workflow-ui/internal-testing-android/src/main/java/com/squareup/workflow1/ui/internal/test/IdlingDispatcher.kt
@@ -48,7 +48,6 @@ public class IdlingDispatcher(
     context: CoroutineContext,
     block: Runnable
   ) {
-
     val runnable = Runnable {
       counter.increment()
       try {

--- a/workflow-ui/internal-testing-android/src/test/java/com/squareup/workflow1/ui/internal/test/IdlingDispatcherTest.kt
+++ b/workflow-ui/internal-testing-android/src/test/java/com/squareup/workflow1/ui/internal/test/IdlingDispatcherTest.kt
@@ -21,7 +21,6 @@ import kotlin.coroutines.CoroutineContext
 internal class IdlingDispatcherTest {
 
   @Test fun `should not go to idle when dispatching to another dispatcher`() = runBlocking {
-
     val a = NamedDispatcher("a")
     val b = NamedDispatcher("b")
 
@@ -46,7 +45,6 @@ internal class IdlingDispatcherTest {
   }
 
   @Test fun `should return to idle if a coroutine is cancelled before completion`() = runBlocking {
-
     val a = NamedDispatcher("a")
     val b = NamedDispatcher("b")
 
@@ -54,7 +52,6 @@ internal class IdlingDispatcherTest {
 
     val job = launch(idler) {
       withContext(b) {
-
         // second -- cancel this current coroutine before it's completed.  Call yield() right away
         // because we need a suspension point in order to make the coroutine check for cancellation.
         cancel()


### PR DESCRIPTION
The `ktlint-gradle` plugin is no longer being maintained and does not support any version of KtLint past `0.45.2`.  [Kotlinter](https://github.com/jeremymailen/kotlinter-gradle) is current.  Kotlinter also happens to be faster and has nicer console output.

These changes make us current with our internal ktlint settings and version.  

The first commit shows my logic changes.  The second commit's all automatic except for two cases of `@file:Suppress("ktlint:filename")` where the rule is giving a false positive.