### PR TITLE
Add Configurable Recursive Rendering to Performance Poetry

### DIFF
--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemsBrowserWorkflow.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemsBrowserWorkflow.kt
@@ -4,6 +4,7 @@ import com.squareup.benchmarks.performance.complex.poetry.PerformancePoemsBrowse
 import com.squareup.benchmarks.performance.complex.poetry.PerformancePoemsBrowserWorkflow.State.ComplexCall
 import com.squareup.benchmarks.performance.complex.poetry.PerformancePoemsBrowserWorkflow.State.Initializing
 import com.squareup.benchmarks.performance.complex.poetry.PerformancePoemsBrowserWorkflow.State.NoSelection
+import com.squareup.benchmarks.performance.complex.poetry.PerformancePoemsBrowserWorkflow.State.Recurse
 import com.squareup.benchmarks.performance.complex.poetry.PerformancePoemsBrowserWorkflow.State.Selected
 import com.squareup.benchmarks.performance.complex.poetry.instrumentation.ActionHandlingTracingInterceptor
 import com.squareup.benchmarks.performance.complex.poetry.instrumentation.SimulatedPerfConfig
@@ -11,12 +12,12 @@ import com.squareup.benchmarks.performance.complex.poetry.instrumentation.Tracea
 import com.squareup.benchmarks.performance.complex.poetry.instrumentation.asTraceableWorker
 import com.squareup.benchmarks.performance.complex.poetry.views.BlankScreen
 import com.squareup.sample.container.overviewdetail.OverviewDetailScreen
+import com.squareup.sample.poetry.ConfigAndPoems
 import com.squareup.sample.poetry.PoemListScreen.Companion.NO_POEM_SELECTED
 import com.squareup.sample.poetry.PoemListWorkflow
 import com.squareup.sample.poetry.PoemListWorkflow.Props
 import com.squareup.sample.poetry.PoemWorkflow
 import com.squareup.sample.poetry.PoemsBrowserWorkflow
-import com.squareup.sample.poetry.model.Poem
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.WorkflowAction.Companion.noAction
@@ -50,9 +51,11 @@ class PerformancePoemsBrowserWorkflow(
   private val isLoading: MutableStateFlow<Boolean>,
 ) :
   PoemsBrowserWorkflow,
-  StatefulWorkflow<List<Poem>, State, Unit, OverviewDetailScreen>() {
+  StatefulWorkflow<ConfigAndPoems, State, Unit, OverviewDetailScreen>() {
 
   sealed class State {
+    object Recurse : State()
+
     // N.B. This state is a smell. We include it to be able to mimic smells
     // we encounter in real life. Best practice would be to fold it
     // into [NoSelection] at the very least.
@@ -66,36 +69,63 @@ class PerformancePoemsBrowserWorkflow(
   }
 
   override fun initialState(
-    props: List<Poem>,
+    props: ConfigAndPoems,
     snapshot: Snapshot?
   ): State {
-    return if (simulatedPerfConfig.useInitializingState) Initializing else NoSelection
+    return if (props.first.first > 0 &&
+      props.first.second == simulatedPerfConfig.recursionGraph.second
+    ) {
+      Recurse
+    } else if (simulatedPerfConfig.useInitializingState) {
+      Initializing
+    } else {
+      NoSelection
+    }
   }
 
   @OptIn(WorkflowUiExperimentalApi::class)
   override fun render(
-    renderProps: List<Poem>,
+    renderProps: ConfigAndPoems,
     renderState: State,
     context: RenderContext
   ): OverviewDetailScreen {
-    if (simulatedPerfConfig.simultaneousActions > 0) {
-      repeat(simulatedPerfConfig.simultaneousActions) { index ->
-        context.runningWorker(
-          worker = isLoading.asTraceableWorker("SimultaneousSubscribeBrowser-$index"),
-          key = "Browser-$index"
+    when (renderState) {
+      is Recurse -> {
+        val recursiveChild = PerformancePoemsBrowserWorkflow(
+          simulatedPerfConfig,
+          poemWorkflow,
+          isLoading,
+        )
+        repeat(renderProps.first.second) { breadth ->
+          val nextProps = renderProps.copy(
+            first = renderProps.first.first - 1 to breadth
+          )
+          // When we repeat horizontally we ask the runtime to 'render' these Workflow nodes but
+          // we don't use their renderings in what is passed to the UI layer as this is just to
+          // fill out the Workflow tree to give the runtime more work to do. As such, we call
+          // renderChild here but we ignore the rendering returned and do no action on any Output.
+          // See SimulatedPerfConfig kdoc for more explanation.
+          context.renderChild(
+            child = recursiveChild,
+            props = nextProps,
+            key = "${nextProps.first},${nextProps.second}",
+          ) {
+            noAction()
+          }
+        }
+        val nextProps = renderProps.copy(
+          first = renderProps.first.first - 1 to renderProps.first.second
+        )
+        return context.renderChild(
+          child = recursiveChild,
+          props = nextProps,
+          key = "${nextProps.first},${nextProps.second}",
         ) {
-          noAction()
+          action {
+            setOutput(it)
+          }
         }
       }
-    }
-    val poemListProps = Props(
-      poems = renderProps,
-      eventHandlerTag = ActionHandlingTracingInterceptor::keyForTrace
-    )
-    val poemListRendering = context.renderChild(PoemListWorkflow, poemListProps) { selected ->
-      choosePoem(selected)
-    }
-    when (renderState) {
       // Again, then entire `Initializing` state is a smell, which is most obvious from the
       // use of `Worker.from { Unit }`. A Worker doing no work and only shuttling the state
       // along is usually the sign you have an extraneous state that can be collapsed!
@@ -110,58 +140,86 @@ class PerformancePoemsBrowserWorkflow(
         }
         return OverviewDetailScreen(overviewRendering = BackStackScreen(BlankScreen))
       }
-      is NoSelection -> {
-        return OverviewDetailScreen(
-          overviewRendering = BackStackScreen(
-            poemListRendering.copy(selection = NO_POEM_SELECTED)
-          )
-        )
-      }
-      is ComplexCall -> {
-        context.runningWorker(
-          TraceableWorker.from("ComplexCallBrowser(${renderState.payload})") {
-            isLoading.value = true
-            delay(simulatedPerfConfig.complexityDelay)
-            // No Output for Worker is necessary because the selected index
-            // is already in the state.
-          }
-        ) {
-          action {
-            isLoading.value = false
-            (state as? ComplexCall)?.let { currentState ->
-              state = if (currentState.payload != NO_POEM_SELECTED) {
-                Selected(currentState.payload)
-              } else {
-                NoSelection
-              }
+
+      is ComplexCall, is NoSelection, is Selected -> {
+        if (simulatedPerfConfig.simultaneousActions > 0) {
+          repeat(simulatedPerfConfig.simultaneousActions) { index ->
+            context.runningWorker(
+              worker = isLoading.asTraceableWorker("SimultaneousSubscribeBrowser-$index"),
+              key = "Browser-$index"
+            ) {
+              noAction()
             }
           }
         }
-        var poems = OverviewDetailScreen(
-          overviewRendering = BackStackScreen(
-            poemListRendering.copy(selection = renderState.payload)
-          )
+        val poemListProps = Props(
+          poems = renderProps.second,
+          eventHandlerTag = ActionHandlingTracingInterceptor::keyForTrace
         )
-        if (renderState.payload != NO_POEM_SELECTED) {
-          val poem: OverviewDetailScreen = context.renderChild(
-            poemWorkflow,
-            renderProps[renderState.payload]
-          ) { clearSelection }
-          poems += poem
+        val poemListRendering = context.renderChild(PoemListWorkflow, poemListProps) { selected ->
+          choosePoem(selected)
         }
-        return poems
-      }
-      is Selected -> {
-        val poems = OverviewDetailScreen(
-          overviewRendering = BackStackScreen(
-            poemListRendering.copy(selection = renderState.poemIndex)
-          )
-        )
-        val poem: OverviewDetailScreen = context.renderChild(
-          poemWorkflow,
-          renderProps[renderState.poemIndex]
-        ) { clearSelection }
-        return poems + poem
+        when (renderState) {
+          is NoSelection -> {
+            return OverviewDetailScreen(
+              overviewRendering = BackStackScreen(
+                poemListRendering.copy(selection = NO_POEM_SELECTED)
+              )
+            )
+          }
+
+          is ComplexCall -> {
+            context.runningWorker(
+              TraceableWorker.from("ComplexCallBrowser(${renderState.payload})") {
+                isLoading.value = true
+                delay(simulatedPerfConfig.complexityDelay)
+                // No Output for Worker is necessary because the selected index
+                // is already in the state.
+              }
+            ) {
+              action {
+                isLoading.value = false
+                (state as? ComplexCall)?.let { currentState ->
+                  state = if (currentState.payload != NO_POEM_SELECTED) {
+                    Selected(currentState.payload)
+                  } else {
+                    NoSelection
+                  }
+                }
+              }
+            }
+            var poems = OverviewDetailScreen(
+              overviewRendering = BackStackScreen(
+                poemListRendering.copy(selection = renderState.payload)
+              )
+            )
+            if (renderState.payload != NO_POEM_SELECTED) {
+              val poem: OverviewDetailScreen = context.renderChild(
+                poemWorkflow,
+                renderProps.second[renderState.payload]
+              ) { clearSelection }
+              poems += poem
+            }
+            return poems
+          }
+
+          is Selected -> {
+            val poems = OverviewDetailScreen(
+              overviewRendering = BackStackScreen(
+                poemListRendering.copy(selection = renderState.poemIndex)
+              )
+            )
+            val poem: OverviewDetailScreen = context.renderChild(
+              poemWorkflow,
+              renderProps.second[renderState.poemIndex]
+            ) { clearSelection }
+            return poems + poem
+          }
+
+          else -> {
+            throw IllegalStateException("State can't change while rendering.")
+          }
+        }
       }
     }
   }

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoetryActivity.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoetryActivity.kt
@@ -59,11 +59,15 @@ class PerformancePoetryActivity : AppCompatActivity() {
 
     setupMainLooperTracing()
 
+    val recursiveDepth = intent.getIntExtra(EXTRA_PERF_CONFIG_RECURSION_DEPTH, 0)
+    val recursiveBreadth = intent.getIntExtra(EXTRA_PERF_CONFIG_RECURSION_BREADTH, 0)
+
     // Default is just to have the basic 'delay' complexity.
     val simulatedPerfConfig = SimulatedPerfConfig(
       isComplex = true,
       complexityDelay = intent.getLongExtra(EXTRA_PERF_CONFIG_DELAY, 200L),
       useInitializingState = intent.getBooleanExtra(EXTRA_SCENARIO_CONFIG_INITIALIZING, false),
+      recursionGraph = recursiveDepth to recursiveBreadth,
       repeatOnNext = intent.getIntExtra(EXTRA_PERF_CONFIG_REPEAT, 0),
       simultaneousActions = intent.getIntExtra(EXTRA_PERF_CONFIG_SIMULTANEOUS, 0),
       traceFrameLatency = intent.getBooleanExtra(EXTRA_TRACE_FRAME_LATENCY, false),
@@ -242,6 +246,10 @@ class PerformancePoetryActivity : AppCompatActivity() {
     const val EXTRA_PERF_CONFIG_REPEAT = "complex.poetry.performance.config.repeat.amount"
     const val EXTRA_PERF_CONFIG_DELAY = "complex.poetry.performance.config.delay.length"
     const val EXTRA_PERF_CONFIG_SIMULTANEOUS = "complex.poetry.performance.config.simultaneous"
+    const val EXTRA_PERF_CONFIG_RECURSION_DEPTH =
+      "complex.poetry.performance.config.recursion.depth"
+    const val EXTRA_PERF_CONFIG_RECURSION_BREADTH =
+      "complex.poetry.performance.config.recursion.breadth"
 
     const val SELECT_ON_TIMEOUT_LOG_NAME =
       "kotlinx.coroutines.selects.SelectBuilderImpl\$onTimeout\$\$inlined\$Runnable"
@@ -257,7 +265,7 @@ class PerformancePoetryActivity : AppCompatActivity() {
 
 class PoetryModel(
   savedState: SavedStateHandle,
-  workflow: MaybeLoadingGatekeeperWorkflow<List<Poem>>,
+  workflow: MaybeLoadingGatekeeperWorkflow<Pair<Pair<Int, Int>, List<Poem>>>,
   interceptor: WorkflowInterceptor?,
   runtimeConfig: RuntimeConfig
 ) : ViewModel() {
@@ -274,7 +282,7 @@ class PoetryModel(
 
   class Factory(
     owner: SavedStateRegistryOwner,
-    private val workflow: MaybeLoadingGatekeeperWorkflow<List<Poem>>,
+    private val workflow: MaybeLoadingGatekeeperWorkflow<Pair<Pair<Int, Int>, List<Poem>>>,
     private val workflowInterceptor: WorkflowInterceptor?,
     private val runtimeConfig: RuntimeConfig
   ) : AbstractSavedStateViewModelFactory(owner, null) {

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoetryComponent.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoetryComponent.kt
@@ -34,7 +34,7 @@ class PerformancePoetryComponent(
 
   private val loadingGatekeeperForPoems = MaybeLoadingGatekeeperWorkflow(
     childWithLoading = poemsBrowserWorkflow,
-    childProps = Poem.allPoems,
+    childProps = Pair(simulatedPerfConfig.recursionGraph, Poem.allPoems),
     browserIsLoading.combine(poemIsLoading) { one, two -> one || two }
   )
 

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/instrumentation/SimulatedPerfConfig.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/instrumentation/SimulatedPerfConfig.kt
@@ -1,6 +1,7 @@
 package com.squareup.benchmarks.performance.complex.poetry.instrumentation
 
 import android.os.Parcelable
+import com.squareup.sample.poetry.RecursionGraphConfig
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -8,14 +9,34 @@ import kotlinx.parcelize.Parcelize
  * be able to benchmark and monitor. Firstly we have a complexity which is just used to add some
  * delay to selection activities - only use with Poetry right now.
  *
+ * [isComplex] Determines whether or not we start a Worker in between state transitions that
+ *   roughly approximates doing I/O work or a network call.
+ * [complexityDelay] Is the length of the delay for the work in between the state changes if
+ *   [isComplex] is true.
  * [useInitializingState] is a smell we have observed whereby an 'initializing' state is used
- * while waiting for the first values before doing the real Workflow work.
+ *   while waiting for the first values before doing the real Workflow work.
+ * [recursionGraph] Determines the shape of the tree that is rendered by the Workflow runtime. The
+ *   first number n is the recursive 'depth'. This will have the [PerformancePoemBrowserWorkflow]
+ *   render itself recursively n times, before rendering its actual children - the poem list and
+ *   the poem. The second number m is the 'breadth'. This means that for each recursive depth layer
+ *   n, the [PerformancePoemBrowserWorkflow] will also be rendered as siblings m times. Only the
+ *   (m-1)th rendering is returned from render() though which means that the other renders will be
+ *   work for the runtime to render but they won't be passed to the UI layer.
+ * [repeatOnNext] Is the number of times x that an action should be created when 'next' is pressed
+ *   in the poem before the action takes its effect - advances the state to the next stanza.
+ * [simultaneousActions] Determines the number of workers y that should be created for each
+ *   'complex' state transition. This will result in y actions that need to be handled
+ *   simultaneously and tries to represent a scenario of multiple Workflows listening to the same
+ *   action.
+ * [traceRenderingPasses], [traceFrameLatency], [traceEventLatency] are all flags to add
+ *   instrumentation for different performance measurements.
  */
 @Parcelize
 data class SimulatedPerfConfig(
   val isComplex: Boolean,
   val complexityDelay: Long,
   val useInitializingState: Boolean,
+  val recursionGraph: RecursionGraphConfig = 0 to 0,
   val repeatOnNext: Int = 0,
   val simultaneousActions: Int = 0,
   val traceRenderingPasses: Boolean = false,
@@ -27,6 +48,7 @@ data class SimulatedPerfConfig(
       isComplex = false,
       complexityDelay = 0,
       useInitializingState = false,
+      recursionGraph = 0 to 0,
       repeatOnNext = 0,
       simultaneousActions = 0,
       traceRenderingPasses = false,

--- a/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoetryActivity.kt
+++ b/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoetryActivity.kt
@@ -52,7 +52,7 @@ class PoetryModel(savedState: SavedStateHandle) : ViewModel() {
     renderWorkflowIn(
       workflow = RealPoemsBrowserWorkflow(RealPoemWorkflow()),
       scope = viewModelScope,
-      prop = Poem.allPoems,
+      prop = 0 to 0 to Poem.allPoems,
       savedStateHandle = savedState,
       runtimeConfig = AndroidRuntimeConfigTools.getAppWorkflowRuntimeConfig()
     )

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemsBrowserWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemsBrowserWorkflow.kt
@@ -4,10 +4,14 @@ import com.squareup.sample.container.overviewdetail.OverviewDetailScreen
 import com.squareup.sample.poetry.model.Poem
 import com.squareup.workflow1.Workflow
 
+typealias RecursionGraphConfig = Pair<Int, Int>
+typealias ConfigAndPoems = Pair<RecursionGraphConfig, List<Poem>>
+
 /**
  * Provides an overview / detail treatment of a list of [Poem]s.
  *
  * (Defining this as an interface allows us to use other implementations
  * in other contexts -- check out our :benchmarks module!)
  */
-interface PoemsBrowserWorkflow : Workflow<List<Poem>, Unit, OverviewDetailScreen>
+interface PoemsBrowserWorkflow :
+  Workflow<ConfigAndPoems, Unit, OverviewDetailScreen>

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/RealPoemsBrowserWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/RealPoemsBrowserWorkflow.kt
@@ -23,10 +23,10 @@ typealias SelectedPoem = Int
 class RealPoemsBrowserWorkflow(
   private val poemWorkflow: PoemWorkflow
 ) : PoemsBrowserWorkflow,
-  StatefulWorkflow<List<Poem>, SelectedPoem, Unit, OverviewDetailScreen>() {
+  StatefulWorkflow<ConfigAndPoems, SelectedPoem, Unit, OverviewDetailScreen>() {
 
   override fun initialState(
-    props: List<Poem>,
+    props: ConfigAndPoems,
     snapshot: Snapshot?
   ): SelectedPoem {
     return snapshot?.bytes?.parse { source ->
@@ -36,12 +36,12 @@ class RealPoemsBrowserWorkflow(
 
   @OptIn(WorkflowUiExperimentalApi::class)
   override fun render(
-    renderProps: List<Poem>,
+    renderProps: ConfigAndPoems,
     renderState: SelectedPoem,
     context: RenderContext
   ): OverviewDetailScreen {
     val poems: OverviewDetailScreen =
-      context.renderChild(PoemListWorkflow, Props(poems = renderProps)) { selected ->
+      context.renderChild(PoemListWorkflow, Props(poems = renderProps.second)) { selected ->
         choosePoem(
           selected
         )
@@ -53,7 +53,7 @@ class RealPoemsBrowserWorkflow(
       poems
     } else {
       val poem: OverviewDetailScreen =
-        context.renderChild(poemWorkflow, renderProps[renderState]) { clearSelection }
+        context.renderChild(poemWorkflow, renderProps.second[renderState]) { clearSelection }
       poems + poem
     }
   }


### PR DESCRIPTION
Customizable via intent.

Depth is how many times to recursively render PerformancePoemsBrowserWorkflow in the tree.
Breadth is how many times to repeate rendering of PerformancePoemsBrowserWorkflow horizontally in the tree.

Only one path of the tree provides a rendering.