### PR TITLE
trigger GitHub Actions CI with `merge_group` events

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -8,6 +8,10 @@ on :
     paths-ignore :
       # Don't build the entire app when just changing tutorials, which have their own workflow.
       - 'samples/tutorial/**'
+  merge_group :
+    paths-ignore :
+      # Don't build the entire app when just changing tutorials, which have their own workflow.
+      - 'samples/tutorial/**'
 
 jobs :
 

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 jobs:
   codeowners:


### PR DESCRIPTION
GitHub's merge queue feature has its own event type for GHA workflow triggers.  Our CI checks must respond to that event in order to run against merge queue branches.

docs are [here](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions).