### PR TITLE
add Renovate groups for Kotlin and androidx-lifecycle updates

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -113,6 +113,8 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 
 androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "androidx-cardview" }
 
+androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "androidx-compose-compiler" }
+
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose" }
 androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "androidx-compose" }
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,24 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
+  "$schema" : "https://docs.renovatebot.com/renovate-schema.json",
+  "extends" : [
     "config:base"
+  ],
+  "packageRules" : [
+    {
+      "matchPackagePatterns" : [
+        "^org\\.jetbrains\\.kotlin:(?:[\\w-]+)$",
+        "^androidx\\.compose\\.compiler:(?:[\\w-]+)$",
+        "^com\\.google\\.devtools\\.ksp:(?:[\\w-]+)$"
+      ],
+      "groupName" : "Kotlin and compiler plugins"
+    },
+    {
+      "matchPackagePatterns" : [
+        "^androidx\\.activity:(?:[\\w-]+)$",
+        "^androidx\\.fragment:(?:[\\w-]+)$",
+        "^androidx\\.lifecycle:(?:[\\w-]+)$"
+      ],
+      "groupName" : "androidx lifecycle and downstream libs"
+    }
   ]
 }


### PR DESCRIPTION
With [package grouping](https://docs.renovatebot.com/noise-reduction/#package-grouping), Renovate will combine multiple update PRs into a single PR.  This is really nice for dependencies which must be updated together, like Kotlin and KSP.

If only some packages in the group have updates, then Renovate will make a PR for those packages by themselves.