### PR TITLE
Add Property for Target Selection

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,9 @@
    ```
    NOTE: If you have any unexpected errors in the build or tests and they are related to non-jvm
    targets you may need to update your XCode or other iOS tools. See note in the workflow-core and
-   workflow-runtime modules.
+   workflow-runtime modules. Alternatively you can specify only the target you care about (while
+   developing - do not do this for actual releases) with the property `workflow.targets` which is
+   set to any of `kmp`, `jvm`, `ios`, or `js`.
 
 1. Update your tags.
    ```bash

--- a/workflow-core/README.md
+++ b/workflow-core/README.md
@@ -9,6 +9,14 @@ are `jvm`, `ios`, and `iosSimulatorSimulatorArm64`. If you are having issues wit
 ensure you have the correct version of XCode installed and can launch a simulator as it's specified
 in the gradle build file (Currently iPhone 14).
 
+You can also choose to specify your targets for build and test with the property `workflow.targets`
+as either `kmp`, `jvm`, `ios`, `js`. The default is `kmp` (all the targets). Set this in your
+global `~/.gradle/gradle.properties` or specify the property in your gradle command, e.g.:
+
+```bash
+./gradlew build -Pworkflow.targets=jvm
+```
+
 ## Notes on Dispatchers
 
 _Dispatchers control what threads/pools coroutines are run on. [See here for more information.][1]_

--- a/workflow-core/build.gradle.kts
+++ b/workflow-core/build.gradle.kts
@@ -6,9 +6,16 @@ plugins {
 }
 
 kotlin {
-  iosWithSimulatorArm64()
-  jvm { withJava() }
-  js { browser() }
+  val targets = project.findProperty("workflow.targets") ?: "kmp"
+  if (targets == "kmp" || targets == "ios") {
+    iosWithSimulatorArm64()
+  }
+  if (targets == "kmp" || targets == "jvm") {
+    jvm { withJava() }
+  }
+  if (targets == "kmp" || targets == "js") {
+    js { browser() }
+  }
 }
 
 dependencies {

--- a/workflow-runtime/README.md
+++ b/workflow-runtime/README.md
@@ -8,3 +8,11 @@ This module is a Kotlin Multiplatform module. The targets currently included for
 are `jvm`, `ios`, and `iosSimulatorSimulatorArm64`. If you are having issues with the tests,
 ensure you have the correct version of XCode installed and can launch a simulator as it's specified
 in the gradle build file (Currently iPhone 14).
+
+You can also choose to specify your targets for build and test with the property `workflow.targets`
+as either `kmp`, `jvm`, `ios`, `js`. The default is `kmp` (all the targets). Set this in your
+global `~/.gradle/gradle.properties` or specify the property in your gradle command, e.g.:
+
+```bash
+./gradlew build -Pworkflow.targets=jvm
+```

--- a/workflow-runtime/build.gradle.kts
+++ b/workflow-runtime/build.gradle.kts
@@ -9,30 +9,37 @@ plugins {
 }
 
 kotlin {
-  iosWithSimulatorArm64()
-  jvm {
-    compilations {
-      val main by getting
+  val targets = project.findProperty("workflow.targets") ?: "kmp"
+  if (targets == "kmp" || targets == "ios") {
+    iosWithSimulatorArm64()
+  }
+  if (targets == "kmp" || targets == "jvm") {
+    jvm {
+      compilations {
+        val main by getting
 
-      create("workflowNode") {
-        val workflowNodeCompilation: KotlinJvmCompilation = this
-        kotlinOptions {
-          // Associating compilations allows us to access declarations with `internal` visibility.
-          // It's the new version of the "-Xfriend-paths=___" compiler argument.
-          // https://youtrack.jetbrains.com/issue/KTIJ-7662/IDE-support-internal-visibility-introduced-by-associated-compilations
-          workflowNodeCompilation.associateWith(main)
-        }
-        defaultSourceSet {
-          dependencies {
-            implementation(libs.kotlinx.benchmark.runtime)
+        create("workflowNode") {
+          val workflowNodeCompilation: KotlinJvmCompilation = this
+          kotlinOptions {
+            // Associating compilations allows us to access declarations with `internal` visibility.
+            // It's the new version of the "-Xfriend-paths=___" compiler argument.
+            // https://youtrack.jetbrains.com/issue/KTIJ-7662/IDE-support-internal-visibility-introduced-by-associated-compilations
+            workflowNodeCompilation.associateWith(main)
+          }
+          defaultSourceSet {
+            dependencies {
+              implementation(libs.kotlinx.benchmark.runtime)
 
-            implementation(main.compileDependencyFiles + main.output.classesDirs)
+              implementation(main.compileDependencyFiles + main.output.classesDirs)
+            }
           }
         }
       }
     }
   }
-  js { browser() }
+  if (targets == "kmp" || targets == "js") {
+    js { browser() }
+  }
 }
 
 dependencies {


### PR DESCRIPTION
Gives us the ability to specify targets for gradle commands with the `workflow.targets` property as any of `kmp`, `jvm`, `ios`, or `js`