### PR TITLE
split the `publish-snapshot` job into smaller steps, with `gradle/gradle-build-action`

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -13,6 +13,9 @@ on :
       # Don't build the entire app when just changing tutorials, which have their own workflow.
       - 'samples/tutorial/**'
 
+env:
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx5g -Dorg.gradle.daemon=false -Dorg.gradle.logging.stacktrace=all"
+
 jobs :
 
   cancel-stale-jobs :
@@ -41,7 +44,7 @@ jobs :
         name : Assemble with gradle — make sure everything builds
         with :
           arguments : |
-            assemble --stacktrace
+            assemble
           cache-read-only: false
 
       # This should ideally be done as a Check job below, but it needs to be done as a separate
@@ -52,7 +55,7 @@ jobs :
         name : Run dokka to validate kdoc
         with :
           arguments : |
-            siteDokka --build-cache --stacktrace
+            siteDokka --build-cache
           cache-read-only: false
 
   # the `artifactsCheck` task has to run on macOS in order to see the iOS KMP artifacts
@@ -132,7 +135,7 @@ jobs :
         name : Check with Gradle
         with :
           arguments : |
-            allTests test apiCheck checkVersionIsSnapshot lint lintKotlin jvmWorkflowNodeBenchmarkJar --stacktrace --continue
+            allTests test apiCheck checkVersionIsSnapshot lint lintKotlin jvmWorkflowNodeBenchmarkJar --continue
           cache-read-only: false
 
       # Report as Github Pull Request Check.
@@ -160,7 +163,7 @@ jobs :
         name : Check with Gradle
         with :
           arguments : |
-            jvmTest --stacktrace --continue -Pworkflow.runtime=conflate
+            jvmTest --continue -Pworkflow.runtime=conflate
           cache-read-only : false
 
       # Report as Github Pull Request Check.
@@ -188,7 +191,7 @@ jobs :
         name : Check with Gradle
         with :
           arguments : |
-            iosX64Test --stacktrace
+            iosX64Test
           cache-read-only: false
 
       # Report as Github Pull Request Check.
@@ -216,7 +219,7 @@ jobs :
         name : Check with Gradle
         with :
           arguments : |
-            jsTest --stacktrace
+            jsTest
           cache-read-only : false
 
       # Report as Github Pull Request Check.
@@ -251,7 +254,7 @@ jobs :
         name : Build instrumented tests
         with :
           arguments : |
-            :benchmarks:performance-poetry:complex-poetry:assembleDebugAndroidTest --stacktrace
+            :benchmarks:performance-poetry:complex-poetry:assembleDebugAndroidTest
           cache-read-only: false
 
       ## Actual task
@@ -263,7 +266,7 @@ jobs :
           api-level : ${{ matrix.api-level }}
           arch : x86_64
           # Skip the benchmarks as this is running on emulators
-          script : ./gradlew :benchmarks:performance-poetry:complex-poetry:connectedCheck --stacktrace --continue
+          script : ./gradlew :benchmarks:performance-poetry:complex-poetry:connectedCheck --continue
 
       - name : Upload results
         if : ${{ always() }}
@@ -297,7 +300,7 @@ jobs :
         name : Build instrumented tests
         with :
           arguments : |
-            assembleDebugAndroidTest --stacktrace
+            assembleDebugAndroidTest
           cache-read-only: false
 
       ## Actual task
@@ -309,7 +312,7 @@ jobs :
           api-level : ${{ matrix.api-level }}
           arch : x86_64
           # Skip the benchmarks as this is running on emulators
-          script : ./gradlew connectedCheck -x :benchmarks:dungeon-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-poetry:connectedCheck --stacktrace
+          script : ./gradlew connectedCheck -x :benchmarks:dungeon-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-poetry:connectedCheck
 
       - name : Upload results
         if : ${{ always() }}
@@ -345,7 +348,7 @@ jobs :
           # Unfortunately I don't think we can key this cache based on our project property so
           # we clean and rebuild.
           arguments : |
-            clean assembleDebugAndroidTest --stacktrace -Pworkflow.runtime=conflate
+            clean assembleDebugAndroidTest -Pworkflow.runtime=conflate
           cache-read-only: false
 
       ## Actual task
@@ -357,7 +360,7 @@ jobs :
           api-level : ${{ matrix.api-level }}
           arch : x86_64
           # Skip the benchmarks as this is running on emulators
-          script : ./gradlew connectedCheck -x :benchmarks:dungeon-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-poetry:connectedCheck --stacktrace -Pworkflow.runtime=conflate
+          script : ./gradlew connectedCheck -x :benchmarks:dungeon-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-poetry:connectedCheck -Pworkflow.runtime=conflate
 
       - name : Upload results
         if : ${{ always() }}
@@ -389,7 +392,7 @@ jobs :
         if : env.MOBILE_DEV_API_KEY != null
         with :
           arguments : |
-            benchmarks:performance-poetry:complex-poetry:assembleRelease --stacktrace
+            benchmarks:performance-poetry:complex-poetry:assembleRelease
           cache-read-only: false
         env :
           MOBILE_DEV_API_KEY : ${{ secrets.MOBILE_DEV_API_KEY }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -7,6 +7,9 @@ on:
       - main
       - ray/ui-update
 
+env:
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx5g -Dorg.gradle.daemon=false -Dorg.gradle.logging.stacktrace=all"
+
 jobs:
   publish-snapshot :
     runs-on : macos-latest

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -23,12 +23,28 @@ jobs:
           java-version: 11
 
       - name : Check for -SNAPSHOT version
-        run: ./gradlew checkVersionIsSnapshot --no-daemon
+        uses : gradle/gradle-build-action@v2
+        with :
+          arguments : checkVersionIsSnapshot
+          cache-read-only: false
+
+      - name : Assemble
+        uses : gradle/gradle-build-action@v2
+        with :
+          arguments : assemble
+          cache-read-only: false
+
+      - name : Check
+        uses : gradle/gradle-build-action@v2
+        with :
+          arguments : check
+          cache-read-only: false
 
       - name : Publish Snapshots
-        run: |
-          ./gradlew build --no-daemon
-          ./gradlew publish --no-daemon
+        uses : gradle/gradle-build-action@v2
+        with :
+          arguments : publish
+          cache-read-only: false
         env :
           ORG_GRADLE_PROJECT_mavenCentralUsername : ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword : ${{ secrets.SONATYPE_NEXUS_PASSWORD }}


### PR DESCRIPTION
We've been getting timeouts at the 35 minute mark.  A single step was doing all the work, running `./gradlew build` and then `./gradlew publish`.  The build task runs all checks, including Android Lint, so it ran for too long.  And none of it was using a build cache.

With the way `gradle/gradle-build-action` works, nothing is actually uploaded until after the step has completed successfully.  So if a step times out, all the incremental progress it made will be lost.  For this reason, it's best to break very long-running steps down into smaller ones.  That way, even if the very first run times out, subsequent runs will save time by using its cache.