### PR TITLE
Introduces `DialogCollator`

### DIFF
--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/views/MayBeLoadingScreen.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/views/MayBeLoadingScreen.kt
@@ -4,11 +4,11 @@ import com.squareup.sample.container.overviewdetail.OverviewDetailScreen
 import com.squareup.sample.container.panel.ScrimScreen
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.container.BodyAndOverlaysScreen
-import com.squareup.workflow1.ui.container.FullScreenOverlay
+import com.squareup.workflow1.ui.container.FullScreenModal
 
 @OptIn(WorkflowUiExperimentalApi::class)
 typealias MayBeLoadingScreen =
-  BodyAndOverlaysScreen<ScrimScreen<OverviewDetailScreen>, FullScreenOverlay<LoaderSpinner>>
+  BodyAndOverlaysScreen<ScrimScreen<OverviewDetailScreen>, FullScreenModal<LoaderSpinner>>
 
 @OptIn(WorkflowUiExperimentalApi::class)
 fun MayBeLoadingScreen(
@@ -17,6 +17,6 @@ fun MayBeLoadingScreen(
 ): MayBeLoadingScreen {
   return BodyAndOverlaysScreen(
     ScrimScreen(baseScreen, dimmed = loaders.isNotEmpty()),
-    loaders.map { FullScreenOverlay(it) }
+    loaders.map { FullScreenModal(it) }
   )
 }

--- a/samples/nested-overlays/src/androidTest/java/com/squareup/sample/nestedoverlays/NestedOverlaysAppTest.kt
+++ b/samples/nested-overlays/src/androidTest/java/com/squareup/sample/nestedoverlays/NestedOverlaysAppTest.kt
@@ -3,9 +3,12 @@ package com.squareup.sample.nestedoverlays
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withParentIndex
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -36,17 +39,17 @@ class NestedOverlaysAppTest {
     onBottomCoverEverything().assertDisplayed()
 
     onTopCoverBody().perform(click())
-    onView(withText("Close")).perform(click())
+    onView(withText("❌")).perform(click())
     onTopCoverEverything().perform(click())
-    onView(withText("Close")).perform(click())
+    onView(withText("❌")).perform(click())
 
-    onView(withText("Hide Top Bar")).perform(click())
+    onView(withText("Hide Top")).perform(click())
     onTopCoverBody().assertNotDisplayed()
     onTopCoverEverything().assertNotDisplayed()
     onBottomCoverBody().assertDisplayed()
     onBottomCoverEverything().assertDisplayed()
 
-    onView(withText("Hide Bottom Bar")).perform(click())
+    onView(withText("Hide Bottom")).perform(click())
     onTopCoverBody().assertNotDisplayed()
     onTopCoverEverything().assertNotDisplayed()
     onBottomCoverBody().assertNotDisplayed()
@@ -56,25 +59,109 @@ class NestedOverlaysAppTest {
   // https://github.com/square/workflow-kotlin/issues/966
   @Test fun canInsertDialog() {
     onTopCoverEverything().perform(click())
-    onView(withText("Hide Top Bar")).check(doesNotExist())
-    onView(withText("Cover Body")).perform(click())
 
-    // This line fails due to https://github.com/square/workflow-kotlin/issues/966
-    // onView(withText("Hide Top Bar")).check(doesNotExist())
+    // Cannot see the inner dialog.
+    onView(withText("Hide Top")).inRoot(isDialog()).check(doesNotExist())
 
-    // Should continue to close the top sheet and assert that the inner sheet is visible.
+    // Click the outer dialog's button to show the inner dialog.
+    onView(withText("Cover Body")).inRoot(isDialog()).perform(click())
+    // Inner was created below outer, so we still can't see it.
+    onView(withText("Hide Top")).inRoot(isDialog()).check(doesNotExist())
+
+    // Close the outer dialog.
+    onView(withText("❌")).inRoot(isDialog()).perform(click())
+    // Now we can see the inner.
+    onView(withText("Hide Top")).inRoot(isDialog()).check(matches(isDisplayed()))
+    // Close it to confirm it really works.
+    onView(withText("❌")).inRoot(isDialog()).perform(click())
+    onTopCoverEverything().check(matches(isDisplayed()))
   }
 
-  // So far can't express this in Espresso. Considering move to Maestro
-  // @Test fun canClickPastInnerWindow() {
-  //   onView(allOf(withText("Cover Everything"), withParent(withParentIndex(0))))
+  @Test fun canInsertAndRemoveCoveredDialog() {
+    // Show the outer dialog
+    onTopCoverEverything().perform(click())
+    // Show the inner dialog behind it
+    onView(withText("Cover Body")).inRoot(isDialog()).perform(click())
+    // Close the (covered) inner dialog and don't crash. :/
+    onView(withText("Reveal Body")).inRoot(isDialog()).perform(click())
+    // Close the outer dialog
+    onView(withText("❌")).inRoot(isDialog()).perform(click())
+    // We can see the activity window again
+    onTopCoverEverything().check(matches(isDisplayed()))
+  }
+
+  @Test fun whenReorderingViewStateIsPreserved() {
+    // Show the outer dialog
+    onTopCoverEverything().perform(click())
+
+    // Type something on it
+    onView(withId(R.id.button_bar_text)).inRoot(isDialog())
+      .perform(typeText("banana"))
+
+    // Click the outer dialog's button to show the inner dialog.
+    onView(withText("Cover Body")).inRoot(isDialog()).perform(click())
+
+    // The original outer dialog was destroyed and replaced.
+    // Check that the text we entered made it to the replacement dialog via view state.
+    onView(withId(R.id.button_bar_text)).inRoot(isDialog())
+      .check(matches(withText("banana")))
+  }
+
+  // https://github.com/square/workflow-kotlin/issues/314
+  @Test fun whenBodyAndOverlaysStopsBeingRenderedDialogsAreDismissed() {
+    onBottomCoverBody().perform(click())
+    onView(withText("💣")).inRoot(isDialog()).perform(click())
+
+    onBottomCoverBody().check(doesNotExist())
+    onView(withText("Reset")).perform(click())
+
+    onBottomCoverBody().perform(click())
+    onView(withText("💣")).inRoot(isDialog()).check(matches(isDisplayed()))
+  }
+
+  // So far can't express this in Espresso, because it refuses to work
+  // w/a root that lacks window focus. Considering move to Maestro.
+  // In the meantime I'd like to keep this commented out block around
+  // as a reminder.
+
+  // @Test fun canCoverDialogAndRemoveItWhileCovered() {
+  //   // Show the inner dialog
+  //   onTopCoverBody().perform(click())
+  //
+  //   lateinit var activity: Activity
+  //   scenarioRule.scenario.onActivity { activity = it }
+  //
+  //   // Show the outer dialog
+  //   onTopCoverEverything()
+  //     .inRoot(
+  //       allOf(
+  //         withDecorView(Matchers.`is`(activity.window.decorView)),
+  //         Matchers.not(hasWindowFocus())
+  //       )
+  //     )
   //     .perform(click())
   //
-  //   scenario.onActivity { activity ->
-  //     onView(allOf(withText("Cover Everything"), withParent(withParentIndex(0))))
-  //       .inRoot(withDecorView(not(`is`(activity.window.decorView))))
-  //       .perform(click())
-  //   }
+  //   // Close the (covered) inner dialog
+  //   onView(withText("Reveal Body")).inRoot(isDialog()).perform(click())
+  //   // Close the outer dialog
+  //   onView(withText("❌")).inRoot(isDialog()).perform(click())
+  //   // We can see the activity window again
+  //   onTopCoverEverything().check(matches(isDisplayed()))
+  // }
+  //
+  // /**
+  //  * Like the private (why?) `hasWindowFocus` method in Espresso, but
+  //  * built into a `Matcher<Root>` rather than a `Matcher<View>` (since
+  //  * that was our only use case).
+  //  */
+  // fun hasWindowFocus(): Matcher<Root> {
+  //   return withDecorView(object : TypeSafeMatcher<View>() {
+  //     override fun describeTo(description: Description) {
+  //       description.appendText("has window focus (Square fork)")
+  //     }
+  //
+  //     override fun matchesSafely(item: View): Boolean = item.hasWindowFocus()
+  //   })
   // }
 
   private fun ViewInteraction.assertNotDisplayed() {

--- a/samples/nested-overlays/src/main/java/com/squareup/sample/nestedoverlays/ButtonBar.kt
+++ b/samples/nested-overlays/src/main/java/com/squareup/sample/nestedoverlays/ButtonBar.kt
@@ -2,6 +2,9 @@ package com.squareup.sample.nestedoverlays
 
 import android.graphics.drawable.ColorDrawable
 import android.view.Gravity
+import android.view.View.GONE
+import android.view.View.VISIBLE
+import android.widget.EditText
 import android.widget.LinearLayout
 import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
@@ -21,23 +24,33 @@ data class Button(
 class ButtonBar(
   vararg buttons: Button?,
   @ColorRes val color: Int = -1,
+  val showEditText: Boolean = false,
 ) : AndroidScreen<ButtonBar> {
   private val buttons: List<Button> = buttons.filterNotNull().toList()
 
   override val viewFactory =
     ScreenViewFactory.fromCode<ButtonBar> { _, initialEnvironment, context, _ ->
       LinearLayout(context).let { view ->
-        @Suppress("DEPRECATION")
-        if (color > -1) view.background = ColorDrawable(view.resources.getColor(color))
+        // Child 0 is always an EditText, which may or may not be visible.
+        val editText = EditText(context)
+        editText.id = R.id.button_bar_text
+        view.addView(editText)
 
         view.gravity = Gravity.CENTER
 
-        ScreenViewHolder(initialEnvironment, view) { bar, _ ->
-          val existing = view.childCount
+        ScreenViewHolder(initialEnvironment, view) { newBar, _ ->
+          @Suppress("DEPRECATION")
+          view.background =
+            if (newBar.color > -1) ColorDrawable(view.resources.getColor(newBar.color)) else null
 
-          bar.buttons.forEachIndexed { index, button ->
-            val buttonView = if (index < existing) {
-              view[index] as ButtonView
+          editText.visibility = if (newBar.showEditText) VISIBLE else GONE
+
+          // After the EditText, an arbitrary number of ButtonView.
+          val existingButtonCount = view.childCount - 1
+
+          newBar.buttons.forEachIndexed { index, button ->
+            val buttonView = if (index < existingButtonCount) {
+              view[index + 1] as ButtonView
             } else {
               ButtonView(context).also { view.addView(it) }
             }
@@ -46,7 +59,7 @@ class ButtonBar(
               setOnClickListener { button.onClick() }
             }
           }
-          for (i in bar.buttons.size until view.childCount) view.removeViewAt(i)
+          for (i in newBar.buttons.size + 1 until view.childCount) view.removeViewAt(i)
         }
       }
     }

--- a/samples/nested-overlays/src/main/res/values/ids.xml
+++ b/samples/nested-overlays/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <item name="button_bar_text" type="id"/>
+</resources>

--- a/samples/nested-overlays/src/main/res/values/strings.xml
+++ b/samples/nested-overlays/src/main/res/values/strings.xml
@@ -1,13 +1,15 @@
 <resources>
+  <string name="body">body</string>
+  <string name="bottom">bottom</string>
+  <string name="close">❌</string>
+  <string name="cover_all">Cover Everything</string>
+  <string name="cover_body">Cover Body</string>
+  <string name="hide_bottom">Hide Bottom</string>
+  <string name="hide_top">Hide Top</string>
+  <string name="nuke">💣</string>
+  <string name="reset">Reset</string>
+  <string name="reveal_body">Reveal Body</string>
+  <string name="show_bottom">Show Bottom Bar</string>
+  <string name="show_top">Show Top Bar</string>
   <string name="app_name">Nested Overlays</string>
-  <string name="BODY">body</string>
-  <string name="COVER_BODY">Cover Body</string>
-  <string name="BOTTOM">bottom</string>
-  <string name="HIDE_BOTTOM">Hide Bottom Bar</string>
-  <string name="SHOW_BOTTOM">Show Bottom Bar</string>
-  <string name="HIDE_TOP">Hide Top Bar</string>
-  <string name="SHOW_TOP">Show Top Bar</string>
-  <string name="REVEAL_BODY">Reveal Body</string>
-  <string name="COVER_ALL">Cover Everything</string>
-  <string name="CLOSE">Close</string>
 </resources>

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
 import com.squareup.workflow1.ui.AndroidScreen
 import com.squareup.workflow1.ui.Compatible
+import com.squareup.workflow1.ui.NamedScreen
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ScreenViewFactory
 import com.squareup.workflow1.ui.ScreenViewHolder
@@ -390,7 +391,7 @@ internal class ComposeViewTreeIntegrationTest {
   }
 
   @Test fun composition_is_restored_in_multiple_modals_after_config_change() {
-    val firstScreen: Screen = TestComposeRendering(compatibilityKey = "key") {
+    val firstScreen: Screen = TestComposeRendering(compatibilityKey = "0") {
       var counter by rememberSaveable { mutableStateOf(0) }
       BasicText(
         "Counter: $counter",
@@ -400,9 +401,7 @@ internal class ComposeViewTreeIntegrationTest {
       )
     }
 
-    // Use the same compatibility key – these screens are in different modals, so they won't
-    // conflict.
-    val secondScreen: Screen = TestComposeRendering(compatibilityKey = "key") {
+    val secondScreen: Screen = TestComposeRendering(compatibilityKey = "1") {
       var counter by rememberSaveable { mutableStateOf(0) }
       BasicText(
         "Counter2: $counter",
@@ -412,9 +411,7 @@ internal class ComposeViewTreeIntegrationTest {
       )
     }
 
-    // Use the same compatibility key – these screens are in different modals, so they won't
-    // conflict.
-    val thirdScreen: Screen = TestComposeRendering(compatibilityKey = "key") {
+    val thirdScreen: Screen = TestComposeRendering(compatibilityKey = "2") {
       var counter by rememberSaveable { mutableStateOf(0) }
       BasicText(
         "Counter3: $counter",
@@ -492,7 +489,10 @@ internal class ComposeViewTreeIntegrationTest {
         BodyAndOverlaysScreen(
           EmptyRendering,
           TestModal(BackStackScreen(EmptyRendering, layer0Screen0)),
-          TestModal(BackStackScreen(EmptyRendering, layer1Screen0)),
+          // A SavedStateRegistry is set up for each modal. Each registry needs a unique name,
+          // and these names default to their `Compatible.keyFor` value. When we show two
+          // of the same type at the same time, we need to give them unique names.
+          TestModal(NamedScreen(BackStackScreen(EmptyRendering, layer1Screen0), "another")),
         )
       )
     }
@@ -515,7 +515,12 @@ internal class ComposeViewTreeIntegrationTest {
         BodyAndOverlaysScreen(
           EmptyRendering,
           TestModal(BackStackScreen(EmptyRendering, layer0Screen0, layer0Screen1)),
-          TestModal(BackStackScreen(EmptyRendering, layer1Screen0, layer1Screen1)),
+          // A SavedStateRegistry is set up for each modal. Each registry needs a unique name,
+          // and these names default to their `Compatible.keyFor` value. When we show two
+          // of the same type at the same time, we need to give them unique names.
+          TestModal(
+            NamedScreen(BackStackScreen(EmptyRendering, layer1Screen0, layer1Screen1), "another")
+          ),
         )
       )
     }
@@ -552,7 +557,10 @@ internal class ComposeViewTreeIntegrationTest {
         BodyAndOverlaysScreen(
           EmptyRendering,
           TestModal(BackStackScreen(EmptyRendering, layer0Screen0)),
-          TestModal(BackStackScreen(EmptyRendering, layer1Screen0)),
+          // A SavedStateRegistry is set up for each modal. Each registry needs a unique name,
+          // and these names default to their `Compatible.keyFor` value. When we show two
+          // of the same type at the same time, we need to give them unique names.
+          TestModal(NamedScreen(BackStackScreen(EmptyRendering, layer1Screen0), "another")),
         )
       )
     }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/KeyedSavedStateRegistryOwner.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/KeyedSavedStateRegistryOwner.kt
@@ -25,10 +25,14 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
  */
 @WorkflowUiExperimentalApi
 internal class KeyedSavedStateRegistryOwner internal constructor(
-  public val key: String,
+  val key: String,
   lifecycleOwner: LifecycleOwner
 ) : SavedStateRegistryOwner, LifecycleOwner by lifecycleOwner {
   internal val controller: SavedStateRegistryController = SavedStateRegistryController.create(this)
   override val savedStateRegistry: SavedStateRegistry
     get() = controller.savedStateRegistry
+
+  override fun toString(): String {
+    return "KeyedSavedStateRegistryOwner(key='$key', controller=$controller)"
+  }
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/WorkflowSavedStateRegistryAggregator.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/WorkflowSavedStateRegistryAggregator.kt
@@ -99,11 +99,17 @@ public class WorkflowSavedStateRegistryAggregator {
       // We don't care about the lifecycle anymore, we've got what we need.
       source.lifecycle.removeObserver(this)
 
-      // These properties are guaranteed to be non-null because this observer is only registered
-      // while attached, and these properties are always non-null while attached.
-      restoreFromBundle(
-        parentRegistryOwner!!.savedStateRegistry.consumeRestoredStateForKey(parentKey!!)
-      )
+      val restoredState: Bundle?
+      try {
+        restoredState =
+          // These properties are guaranteed to be non-null because this observer is only registered
+          // while attached, and these properties are always non-null while attached.
+          parentRegistryOwner!!.savedStateRegistry.consumeRestoredStateForKey(parentKey!!)
+      } catch (e: IllegalStateException) {
+        // Exception thrown by SavedStateRegistryOwner is pretty useless.
+        throw IllegalStateException("Error consuming $parentKey from $parentRegistryOwner", e)
+      }
+      restoreFromBundle(restoredState)
     }
   }
 
@@ -235,7 +241,7 @@ public class WorkflowSavedStateRegistryAggregator {
    */
   public fun saveAndPruneChildRegistryOwner(key: String) {
     children.remove(key)?.let { saveIfOwnerReady(it) }
-      ?: throw IllegalArgumentException("No such child: $key")
+      ?: throw IllegalArgumentException("No such child: $key, on parent $parentKey")
   }
 
   private fun saveIfOwnerReady(child: KeyedSavedStateRegistryOwner) {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/CoveredByModal.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/CoveredByModal.kt
@@ -5,7 +5,11 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
 /**
  * True in views managed by [BodyAndOverlaysScreen] when their events are being blocked
- * by a [ModalOverlay].
+ * by a [ModalOverlay], giving covered views a signal that they should ignore events.
+ * This is necessary so that we can ignore events that happen in the time between calls
+ * to `Dialog.show()` and the actual appearance of the Dialog window.
+ *
+ * https://stackoverflow.com/questions/2886407/dealing-with-rapid-tapping-on-buttons
  */
 @WorkflowUiExperimentalApi
 internal object CoveredByModal : ViewEnvironmentKey<Boolean>(type = Boolean::class) {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogCollator.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogCollator.kt
@@ -1,0 +1,261 @@
+package com.squareup.workflow1.ui.container
+
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.ViewEnvironmentKey
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.container.DialogCollator.IdAndSessions
+import java.util.UUID
+
+/**
+ * Helper provided to [DialogSessionUpdate.doUpdate] to give access
+ * to an existing [DialogSession] able to display a given [Overlay].
+ */
+@WorkflowUiExperimentalApi
+internal fun interface OldSessionFinder {
+  /**
+   * Returns the existing [DialogSession] that can be [updated][DialogSession.show]
+   * to display [overlay], or `null` if there is none.
+   */
+  fun find(overlay: Overlay): DialogSession?
+}
+
+/**
+ * Provided by [LayeredDialogSessions] to [DialogCollator.scheduleUpdates].
+ * Knows how to create a [DialogSession] for [overlay], or to update an existing
+ * one.
+ *
+ * @param overlay rendering to be shown in a new or existing Dialog window
+ *
+ * @param doUpdate function to create or update a [DialogSession] to display
+ * [overlay]. Provided with an [OldSessionFinder] instance that gives access to the
+ * existing session, if any, and a `covered: Boolean` param that indicates
+ * if there is a [ModalOverlay] above [overlay]
+ */
+@WorkflowUiExperimentalApi
+internal class DialogSessionUpdate(
+  val overlay: Overlay,
+  val doUpdate: (
+    oldSessionFinder: OldSessionFinder,
+    covered: Boolean
+  ) -> DialogSession
+)
+
+/**
+ * Init method called at the start of [LayeredDialogSessions.update].
+ * Ensures that there is a single [DialogCollator] instance shared by
+ * an entire recursive hierarchy of [LayeredDialogSessions] for each
+ * update pass.
+ *
+ * Each call to [establishDialogCollator] must be matched with a call to
+ * [DialogCollator.scheduleUpdates]. This balance lets us know when a set of recursive
+ * [LayeredDialogSessions.update] calls is complete, so that we can manage
+ * the entire set of [Dialog][android.app.Dialog] windows.
+ *
+ * Returns a new [ViewEnvironment] with a [DialogCollator]
+ * value if none was found, otherwise returns self. Either way,
+ * the given [existingSessions] set is added to the pool
+ * that will be processed by the new or existing [DialogCollator].
+ *
+ * @param id unique runtime-only id used to pair calls to [establishDialogCollator]
+ * and [DialogCollator.scheduleUpdates]
+ *
+ * @param existingSessions [DialogSession] instances that were running before the pending update
+ */
+@WorkflowUiExperimentalApi
+internal fun ViewEnvironment.establishDialogCollator(
+  id: UUID,
+  existingSessions: List<DialogSession>
+): ViewEnvironment {
+  val collatorOrNull = map[DialogCollator]
+  val collator = (collatorOrNull as? DialogCollator) ?: DialogCollator()
+
+  collator.expectedUpdates++
+  collator.establishedSessions.add(
+    IdAndSessions(id, existingSessions)
+  )
+
+  return if (collatorOrNull == null) this + (DialogCollator to collator) else this
+}
+
+/**
+ * Singleton resource shared by a recursive set of [LayeredDialogSessions], used to
+ * ensure that the windows they manage are stacked in the correct order and stay that
+ * way across updates.
+ *
+ * Android notoriously doesn't give us any control over the z order of windows
+ * other than taking care to [show][android.app.Dialog.show] them in the right
+ * order, so keeping a pile of windows in sync with the shifting order of the
+ * defining list of [Overlay] rendering models is hard. [DialogCollator] manages
+ * that process.
+ *
+ * When a workflow UI tree is updated (that is, each time
+ * [WorkflowLayout][com.squareup.workflow1.ui.WorkflowLayout.show] is called), a shared
+ * [DialogCollator] is used across nested [LayeredDialogSessions] to coordinate their work.
+ * Specifically, a [DialogCollator] instance is put in place in the [ViewEnvironment]
+ * when [LayeredDialogSessions.update] calls [ViewEnvironment.establishDialogCollator].
+ * The [LayeredDialogSessions] then loads its [DialogCollator] with functions to create or update
+ * managed [Dialog][android.app.Dialog] instances, by calling [scheduleUpdates].
+ *
+ * Any recursive calls to [LayeredDialogSessions.update] receive the same [DialogCollator]
+ * when they make their own calls to [ViewEnvironment.establishDialogCollator], and so
+ * enqueue their updates in the same place.
+ *
+ * When control returns to the outermost [scheduleUpdates] stack frame, all of the
+ * updates that were enqueued with the shared [DialogCollator] are executed in a single
+ * pass. Because this [DialogCollator] has complete knowledge of the existing stack
+ * of `Dialog` windows and all updates, it is able to decide if any existing instances need to be
+ * [dismissed][android.app.Dialog.dismiss] and [re-shown][android.app.Dialog.show]
+ * to keep them in the correct order.
+ */
+@WorkflowUiExperimentalApi
+internal class DialogCollator {
+  /**
+   * Set of [DialogSession] instances registered by a specific [LayeredDialogSessions],
+   * via [establishDialogCollator].
+   */
+  internal class IdAndSessions(
+    val id: UUID,
+    val sessions: List<DialogSession>
+  )
+
+  /**
+   * The [IdAndSessions] sets accumulated by all calls to [ViewEnvironment.establishDialogCollator].
+   * Can be flattened to the current list of [DialogSession]s / `Dialog`s.
+   */
+  internal val establishedSessions = mutableListOf<IdAndSessions>()
+
+  /**
+   * The number of calls that have been made to [ViewEnvironment.establishDialogCollator].
+   * Decremented when [scheduleUpdates] is called. When this returns to `0`,
+   * [doUpdate] is called.
+   */
+  internal var expectedUpdates = 0
+
+  /**
+   * Set of [DialogSessionUpdate] functions registered by a specific [LayeredDialogSessions],
+   * via [scheduleUpdates].
+   */
+  private class IdAndUpdates(
+    val id: UUID,
+    val updates: List<DialogSessionUpdate>,
+    val onSessionsUpdated: (List<DialogSession>) -> Unit
+  )
+
+  /**
+   * The [IdAndUpdates] instances accumulated by all calls to [scheduleUpdates].
+   * Can be flattened to the list of [Overlay] representing the
+   * `Dialog` windows that will be in place when we're done updating.
+   */
+  private val allUpdates = mutableListOf<IdAndUpdates>()
+
+  /**
+   * Follow up call to [ViewEnvironment.establishDialogCollator]. Adds a set
+   * of update operations to be applied to the [DialogSession] set provided
+   * to that call. The updates are not applied until a matching call
+   * to [scheduleUpdates] has been received for each call to [establishDialogCollator].
+   *
+   * @param id unique runtime-only id used to pair calls to [establishDialogCollator]
+   * and [DialogCollator.scheduleUpdates]
+   *
+   * @param updates list of [DialogSessionUpdate] to be applied to the [DialogSession]
+   * previously registered with [establishedSessions]. This is a list of
+   * [Overlay]s to show, each paired with a function to create or update a
+   * [DialogSession] to show it.
+   *
+   * @param onSessionsUpdated called immediately after the given [updates] are applied.
+   * Provides the updated list of [DialogSession] that should replace those that
+   * were provided to [establishDialogCollator].
+   */
+  internal fun scheduleUpdates(
+    id: UUID,
+    updates: List<DialogSessionUpdate>,
+    onSessionsUpdated: (List<DialogSession>) -> Unit
+  ) {
+    check(expectedUpdates > 0) {
+      "Each update() call must be preceded by a call to ViewEnvironment.establishDialogCollator, " +
+        "but expectedUpdates is $expectedUpdates"
+    }
+
+    this.allUpdates.add(IdAndUpdates(id, updates, onSessionsUpdated))
+    if (--expectedUpdates == 0) doUpdate()
+  }
+
+  private fun doUpdate() {
+    // Flatten establishedSessions into an Iterator across the existing sessions from
+    // bottom to top, each paired with the id of the LayeredDialogSessions that registered it.
+    val establishedSessionsIterator: Iterator<Pair<UUID, DialogSession>> =
+      establishedSessions.asReversed()
+        .asSequence()
+        .flatMap { it.sessions.map { session -> Pair(it.id, session) } }
+        .iterator()
+
+    // Collects members of establishedSessions that are dismissed because they
+    // are out of order, so that we can try to show them again.
+    val hiddenSessions = mutableListOf<Pair<UUID, DialogSession>>()
+
+    // Z index of the uppermost ModalOverlay.
+    val topModalIndex = allUpdates.asSequence()
+      .flatMap { it.updates.asSequence().map { update -> update.overlay } }
+      .indexOfLast { it is ModalOverlay }
+
+    // Z index of the dialog session being updated.
+    var updatingSessionIndex = 0
+
+    allUpdates.forEach { idAndUpdates ->
+      val updatedSessions = mutableListOf<DialogSession>()
+
+      // We're building an object that the next LayeredDialogSessions can use to
+      // find an existing dialog that matches a given Overlay. Any
+      // incompatible dialog that we skip on the way to find a match is dismissed.
+      // If we later find a match for one of the dismissed dialogs, it is re-shown --
+      // which moves it to the front, ensuring the correct Z order.
+      val oldSessionFinder = OldSessionFinder { overlay ->
+
+        // First we iterate through the existing windows to find one that belongs
+        // to this group and matches the overlay.
+        while (establishedSessionsIterator.hasNext()) {
+          val (id, session) = establishedSessionsIterator.next()
+          if (idAndUpdates.id == id && session.canShow(overlay)) return@OldSessionFinder session
+
+          // Can't update this session from this Overlay. Dismiss it (via Dialog.dismiss
+          // under the hood), but hold on to it in case it can except a later Overlay.
+          session.setVisible(false)
+          hiddenSessions.add(Pair(id, session))
+          continue
+        }
+
+        // There are no established windows left. See if any of the ones that were
+        // dismissed because they were out of order can be shown again.
+        return@OldSessionFinder hiddenSessions.indexOfFirst { (hiddenId, dialogSession) ->
+          idAndUpdates.id == hiddenId && dialogSession.canShow(overlay)
+        }.takeUnless { it == -1 }?.let { compatibleIndex ->
+          val restoredSession = hiddenSessions.removeAt(compatibleIndex).second
+          restoredSession.apply { setVisible(true) }
+        }
+      }
+
+      idAndUpdates.updates.forEach { update ->
+        val covered = updatingSessionIndex < topModalIndex
+        updatedSessions += update.doUpdate(oldSessionFinder, covered)
+        updatingSessionIndex++
+      }
+      idAndUpdates.onSessionsUpdated(updatedSessions)
+    }
+
+    establishedSessions.clear()
+    allUpdates.clear()
+  }
+
+  override fun toString(): String {
+    return "DialogCollator(" +
+      "updates=$allUpdates, " +
+      "establishedSessions=$establishedSessions, " +
+      "expectedUpdates=$expectedUpdates" +
+      ")"
+  }
+
+  companion object : ViewEnvironmentKey<DialogCollator>(DialogCollator::class) {
+    override val default: DialogCollator
+      get() = error("Call ViewEnvironment.establishDialogCollator first.")
+  }
+}

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogSession.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogSession.kt
@@ -15,6 +15,7 @@ import androidx.core.view.doOnDetach
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.squareup.workflow1.ui.Compatible
+import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.androidx.WorkflowLifecycleOwner
 import com.squareup.workflow1.ui.androidx.WorkflowSavedStateRegistryAggregator
@@ -26,7 +27,7 @@ import com.squareup.workflow1.ui.androidx.WorkflowSavedStateRegistryAggregator
  */
 @WorkflowUiExperimentalApi
 internal class DialogSession(
-  index: Int,
+  private val stateRegistryAggregator: WorkflowSavedStateRegistryAggregator,
   initialOverlay: Overlay,
   holder: OverlayDialogHolder<Overlay>
 ) {
@@ -55,8 +56,8 @@ internal class DialogSession(
    *   is initialized before it is shown
    * - It is dangerous to call `decorView` before `Dialog.show`.
    *
-   * Fix is that [OverlayDialogHolder.canShow] does not update `Dialog.overlay` if
-   * peekDecorView is null. Which means we have to bootstrap it into place when
+   * Fix is that [OverlayDialogHolder.canShow] does not read `Dialog.overlay` if
+   * peekDecorView is null. Which means we have to bootstrap it into place after
    * we call `Dialog.show`.
    *
    * We keep this nullable pointer to the very first [Overlay] so that we can put it
@@ -67,7 +68,7 @@ internal class DialogSession(
   /**
    * Wrap the given dialog holder to maintain [allowEvents] on each update.
    */
-  val holder: OverlayDialogHolder<Overlay> = OverlayDialogHolder(
+  private val holder: OverlayDialogHolder<Overlay> = OverlayDialogHolder(
     holder.environment,
     holder.dialog,
     holder.onUpdateBounds,
@@ -77,15 +78,26 @@ internal class DialogSession(
     holder.show(overlay, environment)
   }
 
-  val savedStateRegistryKey = Compatible.keyFor(initialOverlay, index.toString())
+  /**
+   * Key used for view state persistence, both classic ([save]) and
+   * newfangled ([stateRegistryAggregator]).
+   */
+  val savedStateKey = Compatible.keyFor(initialOverlay)
 
   private val KeyEvent.isBackPress: Boolean
     get() = (keyCode == KEYCODE_BACK || keyCode == KEYCODE_ESCAPE) && action == ACTION_UP
 
-  fun showDialog(
+  fun initAndShowDialog(
     parentLifecycleOwner: LifecycleOwner,
-    stateRegistryAggregator: WorkflowSavedStateRegistryAggregator
+    initialEnvironment: ViewEnvironment
   ) {
+    // Prime the pump, make the first call to OverlayDialogHolder.show to update
+    // the newly created Dialog to reflect the first rendering. Note that below
+    // in this method we also have to apply initialOverlay to the Dialog itself
+    // _after_ it is shown for the first time. See kdoc on initialOverlay for sordid
+    // details.
+    holder.show(initialOverlay!!, initialEnvironment)
+
     val dialog = holder.dialog
 
     dialog.window?.let { window ->
@@ -115,6 +127,8 @@ internal class DialogSession(
     }
 
     dialog.show()
+    // Fix for https://github.com/square/workflow-kotlin/issues/863, can't set this
+    // until after show() is called. See kdoc in initialOverlay.
     initialOverlay?.let {
       dialog.overlay = it
       initialOverlay = null
@@ -133,7 +147,7 @@ internal class DialogSession(
       // so views in each dialog layer don't clash with other layers.
       stateRegistryAggregator.installChildRegistryOwnerOn(
         view = decorView,
-        key = savedStateRegistryKey
+        key = savedStateKey
       )
 
       decorView.doOnAttach {
@@ -159,11 +173,40 @@ internal class DialogSession(
     }
   }
 
+  fun canShow(overlay: Overlay): Boolean = holder.canShow(overlay)
+
+  fun show(
+    overlay: Overlay,
+    environment: ViewEnvironment
+  ) {
+    check(initialOverlay == null) {
+      "initAndShowDialog() must be called first. show() is for updates only."
+    }
+    holder.show(overlay, environment)
+  }
+
+  /**
+   * Used by [DialogCollator] to *temporarily* [dismiss][android.app.Dialog.dismiss] or
+   * [show][android.app.Dialog.show] an existing [DialogSession] without triggering the
+   * other side effects of [dismiss], as a tool to update its z-index.
+   */
+  fun setVisible(visible: Boolean) {
+    if (visible) {
+      holder.dialog.show()
+    } else {
+      holder.dialog.dismiss()
+    }
+  }
+
+  /**
+   * We are never going to use this `Dialog` again. Tear down our lifecycle hooks
+   * and dismiss it.
+   */
   fun dismiss() {
-    // The dialog's views are about to be detached, and when that happens we want to transition
-    // the dialog view's lifecycle to a terminal state even though the parent is probably still
-    // alive.
     with(holder.dialog) {
+      // The dialog's views are about to be detached, and when that happens we want to transition
+      // the dialog view's lifecycle to a terminal state even though the parent is probably still
+      // alive.
       window?.decorView?.let(WorkflowLifecycleOwner::get)?.destroyOnDetach()
       dismiss()
     }
@@ -171,11 +214,11 @@ internal class DialogSession(
 
   internal fun save(): KeyAndBundle? {
     val saved = holder.dialog.window?.saveHierarchyState() ?: return null
-    return KeyAndBundle(savedStateRegistryKey, saved)
+    return KeyAndBundle(savedStateKey, saved)
   }
 
   internal fun restore(keyAndBundle: KeyAndBundle) {
-    if (savedStateRegistryKey == keyAndBundle.compatibilityKey) {
+    if (savedStateKey == keyAndBundle.compatibilityKey) {
       holder.dialog.window?.restoreHierarchyState(keyAndBundle.bundle)
     }
   }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/OverlayDialogFactoryFinder.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/OverlayDialogFactoryFinder.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KClass
 /**
  * [ViewEnvironment] service object used by [Overlay.toDialogFactory] to find the right
  * [OverlayDialogFactory]. The default implementation makes [AndroidOverlay]
- * work, and provides default bindings for [AlertOverlay] and [FullScreenOverlay].
+ * work, and provides default bindings for [AlertOverlay] and [FullScreenModal].
  */
 @WorkflowUiExperimentalApi
 public interface OverlayDialogFactoryFinder {
@@ -26,8 +26,8 @@ public interface OverlayDialogFactoryFinder {
       ?: (rendering as? AlertOverlay)?.let {
         AlertOverlayDialogFactory() as OverlayDialogFactory<OverlayT>
       }
-      ?: (rendering as? FullScreenOverlay<Screen>)?.let {
-        ScreenOverlayDialogFactory(FullScreenOverlay::class as KClass<FullScreenOverlay<Screen>>)
+      ?: (rendering as? FullScreenModal<Screen>)?.let {
+        ScreenOverlayDialogFactory(FullScreenModal::class as KClass<FullScreenModal<Screen>>)
           as OverlayDialogFactory<OverlayT>
       }
       ?: throw IllegalArgumentException(

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/ScreenOverlayDialogFactory.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/ScreenOverlayDialogFactory.kt
@@ -19,9 +19,9 @@ import kotlin.reflect.KClass
 
 /**
  * Extensible base implementation of [OverlayDialogFactory] for [ScreenOverlay]
- * types. Also serves as the default factory for [FullScreenOverlay].
+ * types. Also serves as the default factory for [FullScreenModal].
  * (Use a custom [OverlayDialogFactoryFinder] to customize the presentation
- * of [FullScreenOverlay].)
+ * of [FullScreenModal].)
  *
  * Dialogs built by this class are compatible with
  * [View.backPressedHandler][com.squareup.workflow1.ui.backPressedHandler],

--- a/workflow-ui/core-common/api/core-common.api
+++ b/workflow-ui/core-common/api/core-common.api
@@ -248,7 +248,7 @@ public final class com/squareup/workflow1/ui/container/EnvironmentScreenKt {
 	public static final fun withRegistry (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/container/EnvironmentScreen;
 }
 
-public final class com/squareup/workflow1/ui/container/FullScreenOverlay : com/squareup/workflow1/ui/container/ScreenOverlay {
+public final class com/squareup/workflow1/ui/container/FullScreenModal : com/squareup/workflow1/ui/container/ModalOverlay, com/squareup/workflow1/ui/container/ScreenOverlay {
 	public fun <init> (Lcom/squareup/workflow1/ui/Screen;)V
 	public fun asSequence ()Lkotlin/sequences/Sequence;
 	public fun getCompatibilityKey ()Ljava/lang/String;
@@ -256,7 +256,7 @@ public final class com/squareup/workflow1/ui/container/FullScreenOverlay : com/s
 	public synthetic fun getContent ()Ljava/lang/Object;
 	public synthetic fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/Container;
 	public synthetic fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/Wrapper;
-	public fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/container/FullScreenOverlay;
+	public fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/container/FullScreenModal;
 	public synthetic fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/container/ScreenOverlay;
 }
 

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/container/FullScreenModal.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/container/FullScreenModal.kt
@@ -9,9 +9,9 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
  * UI kits are expected to provide handling for this class by default.
  */
 @WorkflowUiExperimentalApi
-public class FullScreenOverlay<C : Screen>(
+public class FullScreenModal<C : Screen>(
   public override val content: C
-) : ScreenOverlay<C> {
-  override fun <D : Screen> map(transform: (C) -> D): FullScreenOverlay<D> =
-    FullScreenOverlay(transform(content))
+) : ScreenOverlay<C>, ModalOverlay {
+  override fun <D : Screen> map(transform: (C) -> D): FullScreenModal<D> =
+    FullScreenModal(transform(content))
 }


### PR DESCRIPTION
Android notoriously doesn't give us any control over the z order of Dialog windows
other than taking care to `show()` them in the right order, so keeping a pile
of windows in sync with a list of `Overlay` rendering models is hard.

We've already solved that for individual instances of `LayeredDialogSessions`
(the delegate that does all of the work for `BodyAndOverlaysContainer`), but
it was still a problem when you nested them, e.g. in the style of the
recently introduced Nested Overlays sample. Also, the solution was kind of
nasty because we would replace any out of order Dialogs with brand new ones,
rather than preserving them by calling `dismiss()` and `show()`.

To fix all that we introduce `internal class DialogCollator`. On each view
update pass, a new `DialogCollator` instance is created by the outermost
`LayeredDialogSession` and made available to any nested instances via the
`ViewEnvironment`. The shared collator collects a list of all existing
`DialogSession` instances, and a set of `DialogSessionUpdate` objects to be
asynchronously used to update existing instances or create new ones.

Because a `DialogCollator` has complete knowledge of all the windows managed
by the set of nested `LayerDialogSession` instances it supports, it is able to
ensure that inserts are supported by calling `dismiss()` / `show()` on existing
windows in the sequence needed to reorder them.

One important change to note: our `SavedStateRegistry` code requires that each
window in a set has a unique name, which we derive by applying `Compatible.keyFor` to
its defining `Overlay`. We used to append to that key an `Overlay`'s position in its
`LayeredDialogSessions` list, as a poorly considered hack to simplify showing
several of the same type at once. That approach conflicts with reordering.

With this commit we no longer include the index value in `SavedStateRegistry` keys,
meaning that each `Overlay` shown by a `LayeredDialogSession` must have a unique
key -- `BackStackScreen` has long had a similar requirement. `NamedScreen`
exists to simplify that kind of thing, and in particular can be used to wrap
`ScreenOverlay.content` to meet the new requirement.

Fixes #966