### PR TITLE
Readability tweaks to runtime

### DIFF
--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
@@ -84,7 +84,9 @@ import kotlin.coroutines.CoroutineContext
 internal class SubtreeManager<PropsT, StateT, OutputT>(
   private var snapshotCache: Map<WorkflowNodeId, TreeSnapshot>?,
   private val contextForChildren: CoroutineContext,
-  private val emitActionToParent: (WorkflowAction<PropsT, StateT, OutputT>) -> Any?,
+  private val emitActionToParent: (
+    action: WorkflowAction<PropsT, StateT, OutputT>
+  ) -> ActionProcessingResult?,
   private val workflowSession: WorkflowSession? = null,
   private val interceptor: WorkflowInterceptor = NoopWorkflowInterceptor,
   private val idCounter: IdCounter? = null
@@ -164,7 +166,7 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
     val id = child.id(key)
     lateinit var node: WorkflowChildNode<ChildPropsT, ChildOutputT, PropsT, StateT, OutputT>
 
-    fun acceptChildOutput(output: ChildOutputT): Any? {
+    fun acceptChildOutput(output: ChildOutputT): ActionProcessingResult? {
       val action = node.acceptChildOutput(output)
       return emitActionToParent(action)
     }

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
@@ -131,16 +131,16 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
   }
 
   /**
-   * Uses [selector] to invoke [WorkflowNode.tick] for every running child workflow this instance
+   * Uses [selector] to invoke [WorkflowNode.onNextAction] for every running child workflow this instance
    * is managing.
    *
    * @return [Boolean] whether or not the children action queues are empty.
    */
-  fun tickChildren(selector: SelectBuilder<ActionProcessingResult?>): Boolean {
+  fun onNextChildAction(selector: SelectBuilder<ActionProcessingResult?>): Boolean {
     var empty = true
     children.forEachActive { child ->
       // Do this separately so the compiler doesn't avoid it if empty is already false.
-      val childEmpty = child.workflowNode.tick(selector)
+      val childEmpty = child.workflowNode.onNextAction(selector)
       empty = childEmpty && empty
     }
     return empty

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
@@ -44,7 +44,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   initialProps: PropsT,
   snapshot: TreeSnapshot?,
   baseContext: CoroutineContext,
-  private val emitOutputToParent: (OutputT) -> Any? = { WorkflowOutput(it) },
+  private val emitOutputToParent: (OutputT) -> ActionProcessingResult? = { WorkflowOutput(it) },
   override val parent: WorkflowSession? = null,
   private val interceptor: WorkflowInterceptor = NoopWorkflowInterceptor,
   idCounter: IdCounter? = null
@@ -228,11 +228,12 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
    * Applies [action] to this workflow's [state] and
    * [emits an output to its parent][emitOutputToParent] if necessary.
    */
-  private fun <T : Any> applyAction(action: WorkflowAction<PropsT, StateT, OutputT>): T? {
+  private fun applyAction(
+    action: WorkflowAction<PropsT, StateT, OutputT>
+  ): ActionProcessingResult? {
     val (newState, outputOrNull) = action.applyTo(lastProps, state)
     state = newState
-    @Suppress("UNCHECKED_CAST")
-    return outputOrNull?.let { emitOutputToParent(it.value) } as T?
+    return outputOrNull?.let { emitOutputToParent(it.value) }
   }
 
   private fun createSideEffectNode(

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
@@ -158,9 +158,9 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
    *    time of suspending.
    */
   @OptIn(ExperimentalCoroutinesApi::class)
-  fun tick(selector: SelectBuilder<ActionProcessingResult?>): Boolean {
+  fun onNextAction(selector: SelectBuilder<ActionProcessingResult?>): Boolean {
     // Listen for any child workflow updates.
-    var empty = subtreeManager.tickChildren(selector)
+    var empty = subtreeManager.onNextChildAction(selector)
 
     empty = empty && (eventActionsChannel.isEmpty || eventActionsChannel.isClosedForReceive)
 
@@ -176,7 +176,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   /**
    * Cancels this state machine host, and any coroutines started as children of it.
    *
-   * This must be called when the caller will no longer call [tick]. It is an error to call [tick]
+   * This must be called when the caller will no longer call [onNextAction]. It is an error to call [onNextAction]
    * after calling this method.
    */
   fun cancel(cause: CancellationException? = null) {
@@ -229,10 +229,10 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
    * [emits an output to its parent][emitOutputToParent] if necessary.
    */
   private fun <T : Any> applyAction(action: WorkflowAction<PropsT, StateT, OutputT>): T? {
-    val (newState, tickResult) = action.applyTo(lastProps, state)
+    val (newState, outputOrNull) = action.applyTo(lastProps, state)
     state = newState
     @Suppress("UNCHECKED_CAST")
-    return tickResult?.let { emitOutputToParent(it.value) } as T?
+    return outputOrNull?.let { emitOutputToParent(it.value) } as T?
   }
 
   private fun createSideEffectNode(

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowRunner.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowRunner.kt
@@ -85,7 +85,7 @@ internal class WorkflowRunner<PropsT, OutputT, RenderingT>(
     return select {
       onPropsUpdated()
       // Have the workflow tree build the select to wait for an event/output from Worker.
-      val empty = rootNode.tick(this)
+      val empty = rootNode.onNextAction(this)
       if (!waitForAnAction && runtimeConfig == ConflateStaleRenderings && empty) {
         // With the ConflateStaleRenderings if there are no queued actions and we are not
         // waiting for one, then return ActionsExhausted and pass the rendering on.

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
@@ -262,7 +262,7 @@ internal class SubtreeManagerTest {
   @Suppress("UNCHECKED_CAST")
   private suspend fun <P, S, O : Any> SubtreeManager<P, S, O>.tickAction() =
     select<ActionProcessingResult?> {
-      tickChildren(this)
+      onNextChildAction(this)
     } as WorkflowOutput<WorkflowAction<P, S, O>?>
 
   private fun <P, S, O : Any> subtreeManagerForTest(

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -182,7 +182,7 @@ internal class WorkflowNodeTest {
     runTest {
       val result = withTimeout(10) {
         select<ActionProcessingResult?> {
-          node.tick(this)
+          node.onNextAction(this)
         } as WorkflowOutput<String>?
       }
       assertEquals("tick:event", result?.value)
@@ -224,7 +224,7 @@ internal class WorkflowNodeTest {
       val result = withTimeout(10) {
         List(2) {
           select<ActionProcessingResult?> {
-            node.tick(this)
+            node.onNextAction(this)
           } as WorkflowOutput<String>?
         }
       }
@@ -325,7 +325,7 @@ internal class WorkflowNodeTest {
       // Result should be available instantly, any delay at all indicates something is broken.
       val result = withTimeout(1) {
         select<ActionProcessingResult?> {
-          node.tick(this)
+          node.onNextAction(this)
         } as WorkflowOutput<String>?
       }
       assertEquals("result", result?.value)
@@ -1139,7 +1139,7 @@ internal class WorkflowNodeTest {
     sink.send("hello")
 
     select<ActionProcessingResult?> {
-      node.tick(this)
+      node.onNextAction(this)
     } as WorkflowOutput<String>?
 
     val (state, _) = node.render(workflow.asStatefulWorkflow(), Unit)
@@ -1164,7 +1164,7 @@ internal class WorkflowNodeTest {
 
     runTest {
       val output = select<ActionProcessingResult?> {
-        node.tick(this)
+        node.onNextAction(this)
       } as WorkflowOutput<String>?
       assertEquals("output:hello", output?.value)
     }
@@ -1188,7 +1188,7 @@ internal class WorkflowNodeTest {
 
     runTest {
       val output = select<ActionProcessingResult?> {
-        node.tick(this)
+        node.onNextAction(this)
       } as WorkflowOutput<String>?
       assertNull(output?.value)
     }
@@ -1214,7 +1214,7 @@ internal class WorkflowNodeTest {
     node.render(workflow.asStatefulWorkflow(), Unit)
 
     select<ActionProcessingResult?> {
-      node.tick(this)
+      node.onNextAction(this)
     } as WorkflowOutput<String>?
 
     val state = node.render(workflow.asStatefulWorkflow(), Unit)
@@ -1239,7 +1239,7 @@ internal class WorkflowNodeTest {
 
     runTest {
       val output = select<ActionProcessingResult?> {
-        node.tick(this)
+        node.onNextAction(this)
       } as WorkflowOutput<String>?
       assertEquals("output:child:hello", output?.value)
     }
@@ -1263,7 +1263,7 @@ internal class WorkflowNodeTest {
 
     runTest {
       val output = select<ActionProcessingResult?> {
-        node.tick(this)
+        node.onNextAction(this)
       } as WorkflowOutput<String>?
       assertNull(output?.value)
     }


### PR DESCRIPTION
1. Rename tick to onNextAction
2. Less confusing and slightly less hacky action handling return types