### PR TITLE
DNM: WIP: Keep the same RenderContext through Interceptor

### DIFF
--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
@@ -3,7 +3,6 @@
 
 package com.squareup.workflow1
 
-import kotlin.LazyThreadSafetyMode.NONE
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
@@ -33,7 +32,6 @@ public abstract class StatelessWorkflow<in PropsT, out OutputT, out RenderingT> 
   ) : BaseRenderContext<@UnsafeVariance PropsT, Nothing, @UnsafeVariance OutputT> by
   baseContext as BaseRenderContext<PropsT, Nothing, OutputT>
 
-  @Suppress("UNCHECKED_CAST")
   private val statefulWorkflow = Workflow.stateful<PropsT, Unit, OutputT, RenderingT>(
     initialState = { Unit },
     render = { props, _ -> render(props, RenderContext(this, this@StatelessWorkflow)) }
@@ -122,7 +120,7 @@ public fun <RenderingT> Workflow.Companion.rendering(
  * @param update Function that defines the workflow update.
  */
 public fun <PropsT, OutputT, RenderingT>
-StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
+  StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
   name: String = "",
   update: WorkflowAction<PropsT, *, OutputT>.Updater.() -> Unit
 ): WorkflowAction<PropsT, Nothing, OutputT> = action({ name }, update)
@@ -137,7 +135,7 @@ StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
  * @param update Function that defines the workflow update.
  */
 public fun <PropsT, OutputT, RenderingT>
-StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
+  StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
   name: () -> String,
   update: WorkflowAction<PropsT, *, OutputT>.Updater.() -> Unit
 ): WorkflowAction<PropsT, Nothing, OutputT> = object : WorkflowAction<PropsT, Nothing, OutputT>() {

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
@@ -129,7 +129,7 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
       create = { createChildNode(child, props, key, handler) }
     )
     stagedChild.setHandler(handler)
-    return stagedChild.render(child.asStatefulWorkflow(), props)
+    return stagedChild.render(props)
   }
 
   /**
@@ -151,8 +151,7 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
   fun createChildSnapshots(): Map<WorkflowNodeId, TreeSnapshot> {
     val snapshots = mutableMapOf<WorkflowNodeId, TreeSnapshot>()
     children.forEachActive { child ->
-      val childWorkflow = child.workflow.asStatefulWorkflow()
-      snapshots[child.id] = child.workflowNode.snapshot(childWorkflow)
+      snapshots[child.id] = child.workflowNode.snapshot()
     }
     return snapshots
   }

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowChildNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowChildNode.kt
@@ -1,6 +1,5 @@
 package com.squareup.workflow1.internal
 
-import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
 import com.squareup.workflow1.internal.InlineLinkedList.InlineListNode
@@ -48,12 +47,10 @@ internal class WorkflowChildNode<
    * Wrapper around [WorkflowNode.render] that allows calling it with erased types.
    */
   fun <R> render(
-    workflow: StatefulWorkflow<*, *, *, *>,
     props: Any?
   ): R {
     @Suppress("UNCHECKED_CAST")
     return workflowNode.render(
-      workflow as StatefulWorkflow<ChildPropsT, out Any?, ChildOutputT, Nothing>,
       props as ChildPropsT
     ) as R
   }

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowRunner.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowRunner.kt
@@ -66,8 +66,8 @@ internal class WorkflowRunner<PropsT, OutputT, RenderingT>(
    */
   fun nextRendering(): RenderingAndSnapshot<RenderingT> {
     return interceptor.onRenderAndSnapshot(currentProps, { props ->
-      val rendering = rootNode.render(workflow, props)
-      val snapshot = rootNode.snapshot(workflow)
+      val rendering = rootNode.render(props)
+      val snapshot = rootNode.snapshot()
       RenderingAndSnapshot(rendering, snapshot)
     }, rootNode)
   }

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -1,4 +1,4 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
+@file:Suppress("EXPERIMENTAL_API_USAGE")
 @file:OptIn(ExperimentalCoroutinesApi::class)
 
 package com.squareup.workflow1.internal
@@ -106,7 +106,7 @@ internal class WorkflowNodeTest {
     }
     val node = WorkflowNode(workflow.id(), workflow, "old", null, context)
 
-    node.render(workflow, "new")
+    node.render("new")
 
     assertEquals(listOf("old" to "new"), oldAndNewProps)
   }
@@ -119,7 +119,7 @@ internal class WorkflowNodeTest {
     }
     val node = WorkflowNode(workflow.id(), workflow, "old", null, context)
 
-    node.render(workflow, "old")
+    node.render("old")
 
     assertTrue(oldAndNewProps.isEmpty())
   }
@@ -130,7 +130,7 @@ internal class WorkflowNodeTest {
     }
     val node = WorkflowNode(workflow.id(), workflow, "foo", null, context)
 
-    val rendering = node.render(workflow, "foo2")
+    val rendering = node.render("foo2")
 
     assertEquals(
       """
@@ -140,7 +140,7 @@ internal class WorkflowNodeTest {
       rendering
     )
 
-    val rendering2 = node.render(workflow, "foo3")
+    val rendering2 = node.render("foo3")
 
     assertEquals(
       """
@@ -177,7 +177,7 @@ internal class WorkflowNodeTest {
       context,
       emitOutputToParent = { WorkflowOutput("tick:$it") }
     )
-    node.render(workflow, "")("event")
+    node.render("")("event")
 
     runTest {
       val result = withTimeout(10) {
@@ -215,7 +215,7 @@ internal class WorkflowNodeTest {
       context,
       emitOutputToParent = { WorkflowOutput("tick:$it") }
     )
-    val sink = node.render(workflow, "")
+    val sink = node.render("")
 
     sink("event")
     sink("event2")
@@ -254,7 +254,7 @@ internal class WorkflowNodeTest {
     }
     val node = WorkflowNode(workflow.id(), workflow, "", null, context)
 
-    node.render(workflow, "")
+    node.render("")
     sink.send(action { setOutput("event") })
 
     // Should not throw.
@@ -278,7 +278,7 @@ internal class WorkflowNodeTest {
     )
 
     runTest {
-      node.render(workflow.asStatefulWorkflow(), Unit)
+      node.render(Unit)
       assertTrue(started)
     }
   }
@@ -298,7 +298,7 @@ internal class WorkflowNodeTest {
       baseContext = context
     )
 
-    node.render(workflow.asStatefulWorkflow(), Unit)
+    node.render(Unit)
     assertEquals(WorkflowNodeId(workflow).toString(), node.coroutineContext[CoroutineName]!!.name)
     assertEquals(
       "sideEffect[the key] for ${WorkflowNodeId(workflow)}",
@@ -319,7 +319,7 @@ internal class WorkflowNodeTest {
       snapshot = null,
       baseContext = context
     )
-    node.render(workflow.asStatefulWorkflow(), Unit)
+    node.render(Unit)
 
     runTest {
       // Result should be available instantly, any delay at all indicates something is broken.
@@ -353,12 +353,12 @@ internal class WorkflowNodeTest {
     )
 
     runTest {
-      node.render(workflow.asStatefulWorkflow(), true)
+      node.render(true)
       assertNull(cancellationException)
 
       // Stop running the side effect.
       isRunning.value = false
-      node.render(workflow.asStatefulWorkflow(), false)
+      node.render(false)
 
       assertTrue(cancellationException is CancellationException)
     }
@@ -382,7 +382,7 @@ internal class WorkflowNodeTest {
     )
 
     runTest {
-      node.render(workflow.asStatefulWorkflow(), Unit)
+      node.render(Unit)
       assertNull(cancellationException)
 
       node.cancel()
@@ -411,11 +411,11 @@ internal class WorkflowNodeTest {
     )
 
     runTest {
-      node.render(workflow.asStatefulWorkflow(), 0)
+      node.render(0)
       assertFalse(cancelled)
       assertEquals(1, renderPasses)
 
-      node.render(workflow.asStatefulWorkflow(), 1)
+      node.render(1)
       assertFalse(cancelled)
       assertEquals(2, renderPasses)
     }
@@ -439,11 +439,11 @@ internal class WorkflowNodeTest {
     )
 
     runTest {
-      node.render(workflow.asStatefulWorkflow(), 0)
+      node.render(0)
       assertEquals(listOf(0), seenProps)
       assertEquals(1, renderPasses)
 
-      node.render(workflow.asStatefulWorkflow(), 1)
+      node.render(1)
       assertEquals(listOf(0), seenProps)
       assertEquals(2, renderPasses)
     }
@@ -463,7 +463,7 @@ internal class WorkflowNodeTest {
     )
 
     val error = assertFailsWith<IllegalArgumentException> {
-      node.render(workflow.asStatefulWorkflow(), Unit)
+      node.render(Unit)
     }
     assertEquals("Expected side effect keys to be unique: \"same\"", error.message)
   }
@@ -493,22 +493,22 @@ internal class WorkflowNodeTest {
       baseContext = context
     )
 
-    node.render(workflow, 0)
+    node.render(0)
     assertEquals(listOf("started"), events1)
     assertEquals(emptyList(), events2)
     assertEquals(emptyList(), events3)
 
-    node.render(workflow, 1)
+    node.render(1)
     assertEquals(listOf("started"), events1)
     assertEquals(listOf("started"), events2)
     assertEquals(emptyList(), events3)
 
-    node.render(workflow, 2)
+    node.render(2)
     assertEquals(listOf("started"), events1)
     assertEquals(listOf("started", "cancelled"), events2)
     assertEquals(listOf("started"), events3)
 
-    node.render(workflow, 3)
+    node.render(3)
     assertEquals(listOf("started", "cancelled"), events1)
     assertEquals(listOf("started", "cancelled"), events2)
     assertEquals(listOf("started", "cancelled"), events3)
@@ -531,7 +531,7 @@ internal class WorkflowNodeTest {
 
     assertFalse(started1)
     assertFalse(started2)
-    node.render(workflow.asStatefulWorkflow(), Unit)
+    node.render(Unit)
     assertTrue(started1)
     assertTrue(started2)
   }
@@ -559,8 +559,8 @@ internal class WorkflowNodeTest {
       baseContext = Unconfined
     )
 
-    assertEquals("initial props", originalNode.render(workflow, "foo"))
-    val snapshot = originalNode.snapshot(workflow)
+    assertEquals("initial props", originalNode.render("foo"))
+    val snapshot = originalNode.snapshot()
     assertNotEquals(0, snapshot.toByteString().size)
 
     val restoredNode = WorkflowNode(
@@ -571,7 +571,7 @@ internal class WorkflowNodeTest {
       snapshot = snapshot,
       baseContext = Unconfined
     )
-    assertEquals("initial props", restoredNode.render(workflow, "foo"))
+    assertEquals("initial props", restoredNode.render("foo"))
   }
 
   @Test fun snapshots_empty_without_children() {
@@ -588,8 +588,8 @@ internal class WorkflowNodeTest {
       baseContext = Unconfined
     )
 
-    assertEquals("initial props", originalNode.render(workflow, "foo"))
-    val snapshot = originalNode.snapshot(workflow)
+    assertEquals("initial props", originalNode.render("foo"))
+    val snapshot = originalNode.snapshot()
     assertNotEquals(0, snapshot.toByteString().size)
 
     val restoredNode = WorkflowNode(
@@ -600,7 +600,7 @@ internal class WorkflowNodeTest {
       snapshot = snapshot,
       baseContext = Unconfined
     )
-    assertEquals("restored", restoredNode.render(workflow, "foo"))
+    assertEquals("restored", restoredNode.render("foo"))
   }
 
   @Test fun snapshots_non_empty_with_children() {
@@ -645,8 +645,8 @@ internal class WorkflowNodeTest {
       baseContext = Unconfined
     )
 
-    assertEquals("initial props|child props", originalNode.render(parentWorkflow, "foo"))
-    val snapshot = originalNode.snapshot(parentWorkflow)
+    assertEquals("initial props|child props", originalNode.render("foo"))
+    val snapshot = originalNode.snapshot()
     assertNotEquals(0, snapshot.toByteString().size)
 
     val restoredNode = WorkflowNode(
@@ -657,7 +657,7 @@ internal class WorkflowNodeTest {
       snapshot = snapshot,
       baseContext = Unconfined
     )
-    assertEquals("initial props|child props", restoredNode.render(parentWorkflow, "foo"))
+    assertEquals("initial props|child props", restoredNode.render("foo"))
     assertEquals("child props", restoredChildState)
     assertEquals("initial props", restoredParentState)
   }
@@ -686,7 +686,7 @@ internal class WorkflowNodeTest {
     assertEquals(0, snapshotWrites)
     assertEquals(0, restoreCalls)
 
-    val snapshot = node.snapshot(workflow)
+    val snapshot = node.snapshot()
 
     assertEquals(1, snapshotCalls)
     assertEquals(0, snapshotWrites)
@@ -725,8 +725,8 @@ internal class WorkflowNodeTest {
       baseContext = Unconfined
     )
 
-    assertEquals("initial props", originalNode.render(workflow, "foo"))
-    val snapshot = originalNode.snapshot(workflow)
+    assertEquals("initial props", originalNode.render("foo"))
+    val snapshot = originalNode.snapshot()
     assertNotEquals(0, snapshot.toByteString().size)
 
     val restoredNode = WorkflowNode(
@@ -736,7 +736,7 @@ internal class WorkflowNodeTest {
       snapshot = snapshot,
       baseContext = Unconfined
     )
-    assertEquals("props:new props|state:initial props", restoredNode.render(workflow, "foo"))
+    assertEquals("props:new props|state:initial props", restoredNode.render("foo"))
   }
 
   @Test fun toString_formats_as_WorkflowInstance_without_parent() {
@@ -891,7 +891,7 @@ internal class WorkflowNodeTest {
       baseContext = Unconfined,
       parent = TestSession(42)
     )
-    val rendering = node.render(workflow, "new")
+    val rendering = node.render("new")
 
     assertEquals("old", interceptedOld)
     assertEquals("new", interceptedNew)
@@ -937,7 +937,7 @@ internal class WorkflowNodeTest {
       baseContext = Unconfined,
       parent = TestSession(42)
     )
-    val rendering = node.render(workflow, "props")
+    val rendering = node.render("props")
 
     assertEquals("props", interceptedProps)
     assertEquals("state", interceptedState)
@@ -979,7 +979,7 @@ internal class WorkflowNodeTest {
       baseContext = Unconfined,
       parent = TestSession(42)
     )
-    val snapshot = node.snapshot(workflow)
+    val snapshot = node.snapshot()
 
     assertEquals("state", interceptedState)
     assertEquals(Snapshot.of("snapshot(state)"), interceptedSnapshot)
@@ -1020,7 +1020,7 @@ internal class WorkflowNodeTest {
       baseContext = Unconfined,
       parent = TestSession(42)
     )
-    val snapshot = node.snapshot(workflow)
+    val snapshot = node.snapshot()
 
     assertEquals("state", interceptedState)
     assertNull(interceptedSnapshot)
@@ -1062,7 +1062,7 @@ internal class WorkflowNodeTest {
       parent = TestSession(42),
       idCounter = IdCounter()
     )
-    val rendering = node.render(rootWorkflow.asStatefulWorkflow(), "props")
+    val rendering = node.render("props")
 
     assertEquals("[root([leaf([[props]], [[props]])])]", rendering)
   }
@@ -1081,7 +1081,7 @@ internal class WorkflowNodeTest {
     )
 
     val error = assertFailsWith<UnsupportedOperationException> {
-      node.render(workflow.asStatefulWorkflow(), Unit)
+      node.render(Unit)
     }
     assertTrue(
       error.message!!.startsWith(
@@ -1109,7 +1109,7 @@ internal class WorkflowNodeTest {
     )
 
     val error = assertFailsWith<UnsupportedOperationException> {
-      node.render(workflow.asStatefulWorkflow(), Unit)
+      node.render(Unit)
     }
     assertEquals(
       "Expected sink to not be sent to until after the render pass. " +
@@ -1134,7 +1134,7 @@ internal class WorkflowNodeTest {
       snapshot = null,
       baseContext = Unconfined
     )
-    val (_, sink) = node.render(workflow.asStatefulWorkflow(), Unit)
+    val (_, sink) = node.render(Unit)
 
     sink.send("hello")
 
@@ -1142,7 +1142,7 @@ internal class WorkflowNodeTest {
       node.onNextAction(this)
     } as WorkflowOutput<String>?
 
-    val (state, _) = node.render(workflow.asStatefulWorkflow(), Unit)
+    val (state, _) = node.render(Unit)
     assertEquals("initial->hello", state)
   }
 
@@ -1158,7 +1158,7 @@ internal class WorkflowNodeTest {
       baseContext = Unconfined,
       emitOutputToParent = { WorkflowOutput("output:$it") }
     )
-    val rendering = node.render(workflow.asStatefulWorkflow(), Unit)
+    val rendering = node.render(Unit)
 
     rendering.send("hello")
 
@@ -1182,7 +1182,7 @@ internal class WorkflowNodeTest {
       baseContext = Unconfined,
       emitOutputToParent = { WorkflowOutput(it) }
     )
-    val rendering = node.render(workflow.asStatefulWorkflow(), Unit)
+    val rendering = node.render(Unit)
 
     rendering.send("hello")
 
@@ -1211,13 +1211,13 @@ internal class WorkflowNodeTest {
       snapshot = null,
       baseContext = Unconfined
     )
-    node.render(workflow.asStatefulWorkflow(), Unit)
+    node.render(Unit)
 
     select<ActionProcessingResult?> {
       node.onNextAction(this)
     } as WorkflowOutput<String>?
 
-    val state = node.render(workflow.asStatefulWorkflow(), Unit)
+    val state = node.render(Unit)
     assertEquals("initial->hello", state)
   }
 
@@ -1235,7 +1235,7 @@ internal class WorkflowNodeTest {
       baseContext = Unconfined,
       emitOutputToParent = { WorkflowOutput("output:$it") }
     )
-    node.render(workflow.asStatefulWorkflow(), Unit)
+    node.render(Unit)
 
     runTest {
       val output = select<ActionProcessingResult?> {
@@ -1259,7 +1259,7 @@ internal class WorkflowNodeTest {
       baseContext = Unconfined,
       emitOutputToParent = { WorkflowOutput(it) }
     )
-    node.render(workflow.asStatefulWorkflow(), Unit)
+    node.render(Unit)
 
     runTest {
       val output = select<ActionProcessingResult?> {


### PR DESCRIPTION
As part of #988 I also want to plumb the same `RenderContext` instance through the `WorkflowInterceptor`.

What we can do for this is simply save the RenderContext the first time it is used in `render()` on the `Workflow` that is created to accomplish the intercepting (via `intercept()`).

That is great and all, but we actually _re-create_ this intercepting Workflow _each_ time _each_ of the APIs on `WorkflowNode` is called. So if we want to re-use the same `RenderContext` we also have to re-use the same intercepted Workflow. We can create this once at the init of the `WorkflowNode` since we have it's `Workflow` and then re-use it throughout.

_However_, if we do _that_ then we need to ensure that we keep using that same Workflow throughout the lifetime of the `WorkflowNode`.

In other words, we have a 1 : 1 : 1 : 1 relationship between `WorkflowNode` : `StatefulWorkflow` : `Intercepted Workflow` : `RenderContext`. We don't recreate some combination of the last 3 each time, and we don't need to pass in the 2nd - the `workflow` itself each time we ask the `WorkflowNode` to render. It already has this saved.

Now, thankfully our excellent test coverage caught that this breaks one behavior - 'operators' on Workflows, such as `mapRendering`. With `mapRendering` we actually ask the same `WorkflowNode` to render a new `Workflow` - the one which we have mapped with the `mapRendering` transform. To do this, we actually create a new `Workflow` instance but we pass it to the same `WorkflowNode` to render this modified instance. If we go forward with these changes we can no longer do that. See the failing test `mapRendering_with_same_upstream_workflow_in_two_different_passes_does_not_restart`

@zach-klippenstein - do you know why we cared to do that in the first place? It seems confusing to me as it violates the 'natural' mental model of the 1:1 mapping between `WorkflowNode` and `Workflow`. I can see the use case for being able to map/transform the renderings of a Workflow without needing a new node but I don't see why we can't just encode that as a function that gets called on the _rendering_ produced rather than the _workflow_?

@rjrjr I'm sure you'll have thoughts on this when returning from vacation, so leaving tagging you in this note for that time (and no sooner!).