### PR TITLE
Mark runningWorker with no output as @Deprecated

### DIFF
--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/BaseRenderContext.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/BaseRenderContext.kt
@@ -249,10 +249,14 @@ public fun <PropsT, StateT, OutputT, ChildRenderingT>
  * Ensures a [Worker] that never emits anything is running. Since [worker] can't emit anything,
  * it can't trigger any [WorkflowAction]s.
  *
- * If your [Worker] does not output anything, then simply use [runningSideEffect].
+ * If your [Worker] does not output anything, then simply use [BaseRenderContext.runningSideEffect].
  *
  * @param key An optional string key that is used to distinguish between identical [Worker]s.
  */
+@Deprecated(
+  message = "Use [BaseRenderContext.runningSideEffect] instead.",
+  replaceWith = ReplaceWith(expression = "runningSideEffect(key) { ... }", "")
+)
 public inline fun <reified W : Worker<Nothing>, PropsT, StateT, OutputT>
   BaseRenderContext<PropsT, StateT, OutputT>.runningWorker(
     worker: W,

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkerCompositionIntegrationTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkerCompositionIntegrationTest.kt
@@ -51,6 +51,9 @@ internal class WorkerCompositionIntegrationTest {
       }
     }
     val workflow = Workflow.stateless<Boolean, Nothing, Unit> { props ->
+      // Suppress runningWorker usage because we want to make sure this
+      // test still properly tests usage with LifecycleWorker
+      @Suppress("DEPRECATION")
       if (props) runningWorker(worker)
     }
 
@@ -73,7 +76,12 @@ internal class WorkerCompositionIntegrationTest {
         stops++
       }
     }
-    val workflow = Workflow.stateless<Unit, Nothing, Unit> { runningWorker(worker) }
+    val workflow = Workflow.stateless<Unit, Nothing, Unit> {
+      // Suppress runningWorker usage because we want to make sure this
+      // test still properly tests usage with LifecycleWorker
+      @Suppress("DEPRECATION")
+      runningWorker(worker)
+    }
 
     workflow.launchForTestingFromStartWith {
       assertEquals(1, starts)
@@ -102,6 +110,9 @@ internal class WorkerCompositionIntegrationTest {
       }
     }
     val workflow = Workflow.stateless<Boolean, Nothing, Unit> { props ->
+      // Suppress runningWorker usage because we want to make sure this
+      // test still properly tests usage with LifecycleWorker
+      @Suppress("DEPRECATION")
       if (props) runningWorker(worker)
     }
 
@@ -212,6 +223,9 @@ internal class WorkerCompositionIntegrationTest {
     @Suppress("UNCHECKED_CAST")
     val worker = Worker.from { Unit } as Worker<Nothing>
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
+      // Suppress runningWorker usage because we want to make sure the deprecated
+      // method still throws an exception as expected
+      @Suppress("DEPRECATION")
       runningWorker(worker)
     }
 

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
@@ -744,7 +744,8 @@ internal class RealRenderTesterTest {
   // Suppress runningWorker in this test as we are testing the
   // uniqueness of workers using similar objects as keys
   @Suppress("DEPRECATION")
-  @Test fun `runningWorker distinguishes between specific Nothing workers`() {
+  @Test
+  fun `runningWorker distinguishes between specific Nothing workers`() {
     val workerA = object : LifecycleWorker() {}
     val workerB = object : LifecycleWorker() {}
 

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
@@ -543,6 +543,9 @@ internal class RealRenderTesterTest {
     }
 
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
+      // Suppress runningWorker usage because we want to make sure the internal exception
+      // is not thrown when we don't expect an output
+      @Suppress("DEPRECATION")
       runningWorker(worker)
     }
     val tester = workflow.testRender(Unit)
@@ -584,6 +587,9 @@ internal class RealRenderTesterTest {
     val worker = MySpecialWorker()
 
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
+      // Suppress runningWorker usage because we are testing/validating the internal
+      // exception that is thrown
+      @Suppress("DEPRECATION")
       runningWorker(worker)
     }
     val tester = workflow.testRender(Unit).requireExplicitWorkerExpectations()
@@ -626,6 +632,9 @@ internal class RealRenderTesterTest {
     }
 
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
+      // Suppress runningWorker usage because we want to make sure the internal exception
+      // is not thrown when we don't expect an output, even with a unique key specified
+      @Suppress("DEPRECATION")
       runningWorker(worker, key = "key")
     }
     val tester = workflow.testRender(Unit)
@@ -641,6 +650,9 @@ internal class RealRenderTesterTest {
     }
 
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
+      // Suppress runningWorker usage because we are
+      // testing/validating the internal exception that is thrown
+      @Suppress("DEPRECATION")
       runningWorker(worker, key = "key")
     }
     val tester = workflow.testRender(Unit)
@@ -662,6 +674,9 @@ internal class RealRenderTesterTest {
     }
 
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
+      // Suppress runningWorker usage because we are
+      // expecting an exception to be thrown with mismatched keys
+      @Suppress("DEPRECATION")
       runningWorker(worker, key = "key")
     }
     val tester = workflow.testRender(Unit)
@@ -687,6 +702,7 @@ internal class RealRenderTesterTest {
 
     val worker = EmptyWorker()
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
+      @Suppress("DEPRECATION")
       runningWorker(worker)
     }
     val tester = workflow.testRender(Unit)
@@ -711,6 +727,9 @@ internal class RealRenderTesterTest {
     val stringWorker: Worker<String> = emptyFlow<String>().asWorker()
 
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
+      // Suppress usage as we are testing a comparisons of unique workers
+      // even though they have the same key.
+      @Suppress("DEPRECATION")
       runningWorker(lifecycleWorker)
       runningWorker(stringWorker) { noAction() }
     }
@@ -722,6 +741,9 @@ internal class RealRenderTesterTest {
     // No exception, no bug.
   }
 
+  // Suppress runningWorker in this test as we are testing the
+  // uniqueness of workers using similar objects as keys
+  @Suppress("DEPRECATION")
   @Test fun `runningWorker distinguishes between specific Nothing workers`() {
     val workerA = object : LifecycleWorker() {}
     val workerB = object : LifecycleWorker() {}


### PR DESCRIPTION
This addresses https://github.com/square/workflow-kotlin/issues/994