### PR TITLE
Introduces `ScreenTransitionLogger`

### DIFF
--- a/samples/tictactoe/app/src/main/java/com/squareup/sample/mainactivity/TicTacToeActivity.kt
+++ b/samples/tictactoe/app/src/main/java/com/squareup/sample/mainactivity/TicTacToeActivity.kt
@@ -10,18 +10,20 @@ import androidx.test.espresso.IdlingResource
 import com.squareup.sample.authworkflow.AuthViewFactories
 import com.squareup.sample.container.SampleContainers
 import com.squareup.sample.gameworkflow.TicTacToeViewFactories
+import com.squareup.workflow1.ui.ScreenTransitionLogger
+import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.container.withRegistry
+import com.squareup.workflow1.ui.container.withEnvironment
 import com.squareup.workflow1.ui.modal.AlertContainer
 import com.squareup.workflow1.ui.plus
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @OptIn(WorkflowUiExperimentalApi::class)
 class TicTacToeActivity : AppCompatActivity() {
+
   /** Exposed for use by espresso tests. */
   lateinit var idlingResource: IdlingResource
 
@@ -35,13 +37,13 @@ class TicTacToeActivity : AppCompatActivity() {
 
     setContentView(
       WorkflowLayout(this).apply {
-        take(lifecycle, model.renderings.map { it.withRegistry(viewRegistry) })
+        take(
+          lifecycle,
+          model.renderings.map { it.withEnvironment(environment) }
+        )
       }
     )
 
-    lifecycleScope.launch {
-      model.renderings.collect { Timber.d("rendering: %s", it) }
-    }
     lifecycleScope.launch {
       model.waitForExit()
       finish()
@@ -49,9 +51,18 @@ class TicTacToeActivity : AppCompatActivity() {
   }
 
   private companion object {
+    val logger = ScreenTransitionLogger { fromOrNull, to ->
+      Timber.d(
+        fromOrNull?.let { from -> "Transition to $to from $from" }
+          ?: "Transition to $to"
+      )
+    }
+
     val viewRegistry = SampleContainers +
       AuthViewFactories +
       TicTacToeViewFactories +
       AlertContainer
+
+    val environment = ViewEnvironment.EMPTY + viewRegistry + (ScreenTransitionLogger to logger)
   }
 }

--- a/samples/tictactoe/app/src/main/java/com/squareup/sample/mainactivity/TicTacToeModel.kt
+++ b/samples/tictactoe/app/src/main/java/com/squareup/sample/mainactivity/TicTacToeModel.kt
@@ -34,10 +34,12 @@ class TicTacToeModel(
       scope = viewModelScope,
       savedStateHandle = savedState,
       interceptors = listOf(TracingWorkflowInterceptor(traceFile)),
-      runtimeConfig = AndroidRuntimeConfigTools.getAppWorkflowRuntimeConfig()
-    ) {
-      running.complete()
-    }
+      runtimeConfig = AndroidRuntimeConfigTools.getAppWorkflowRuntimeConfig(),
+      onOutput = {
+        // The root workflow emits output to signal that it's time to quit.
+        running.complete()
+      }
+    )
   }
 
   suspend fun waitForExit() = running.join()

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
@@ -229,18 +229,21 @@ public class WorkflowViewStub @JvmOverloads constructor(
       WorkflowLifecycleOwner.get(it)?.destroyOnDetach()
     }
 
+    val fromOrNull = holder?.showing
+
     holder = rendering.toViewFactory(viewEnvironment)
       .startShowing(rendering, viewEnvironment, parent.context, parent) { view, doStart ->
         WorkflowLifecycleOwner.installOn(view)
         doStart()
-      }.also {
-        val newView = it.view
+      }.also { newHolder ->
+        val newView = newHolder.view
 
         if (inflatedId != NO_ID) newView.id = inflatedId
         if (updatesVisibility) newView.visibility = visibility
         background?.let { newView.background = it }
         propagateSavedStateRegistryOwner(newView)
         replaceOldViewInParent(parent, newView)
+        viewEnvironment[ScreenTransitionLogger].onTransition(fromOrNull, rendering, viewEnvironment)
       }
   }
 

--- a/workflow-ui/core-common/api/core-common.api
+++ b/workflow-ui/core-common/api/core-common.api
@@ -69,6 +69,16 @@ public final class com/squareup/workflow1/ui/NamedScreen : com/squareup/workflow
 public abstract interface class com/squareup/workflow1/ui/Screen {
 }
 
+public abstract interface class com/squareup/workflow1/ui/ScreenTransitionLogger {
+	public static final field Companion Lcom/squareup/workflow1/ui/ScreenTransitionLogger$Companion;
+	public abstract fun onTransition (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
+}
+
+public final class com/squareup/workflow1/ui/ScreenTransitionLogger$Companion : com/squareup/workflow1/ui/ViewEnvironmentKey {
+	public fun getDefault ()Lcom/squareup/workflow1/ui/ScreenTransitionLogger;
+	public synthetic fun getDefault ()Ljava/lang/Object;
+}
+
 public abstract interface class com/squareup/workflow1/ui/TextController {
 	public abstract fun getOnTextChanged ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getTextValue ()Ljava/lang/String;
@@ -263,6 +273,7 @@ public final class com/squareup/workflow1/ui/container/EnvironmentScreen : com/s
 public final class com/squareup/workflow1/ui/container/EnvironmentScreenKt {
 	public static final fun withEnvironment (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/container/EnvironmentScreen;
 	public static synthetic fun withEnvironment$default (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/container/EnvironmentScreen;
+	public static final fun withEnvironmentValue (Lcom/squareup/workflow1/ui/Screen;Lkotlin/Pair;)Lcom/squareup/workflow1/ui/container/EnvironmentScreen;
 	public static final fun withRegistry (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewRegistry;)Lcom/squareup/workflow1/ui/container/EnvironmentScreen;
 }
 

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/ScreenTransitionLogger.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/ScreenTransitionLogger.kt
@@ -1,0 +1,30 @@
+package com.squareup.workflow1.ui
+
+/**
+ * [ViewEnvironment][com.squareup.workflow1.ui.ViewEnvironment] helper invoked by
+ * standard placeholders like `WorkflowViewStub` and `@Composable fun WorkflowRendering`
+ * as they transition between [incompatible][Compatible] [Screen]s.
+ */
+@WorkflowUiExperimentalApi
+public fun interface ScreenTransitionLogger {
+  /**
+   * Invoked by the placeholder whenever a new view object is created and shown.
+   * Parameters are weakly typed to allow [Screen],
+   * [Overlay][com.squareup.workflow1.ui.container.Overlay], or any custom
+   * rendering types to be logged.
+   *
+   * @param fromOrNull the rendering that was displayed previously, or null if there
+   * wasn't one
+   *
+   * @param to the rendering whose view is being shown for the first time
+   */
+  public fun onTransition(
+    fromOrNull: Screen?,
+    to: Screen,
+    environment: ViewEnvironment
+  )
+
+  public companion object : ViewEnvironmentKey<ScreenTransitionLogger>() {
+    override val default: ScreenTransitionLogger = ScreenTransitionLogger { _, _, _ -> }
+  }
+}

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/ViewEnvironment.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/ViewEnvironment.kt
@@ -21,16 +21,23 @@ constructor(
 ) {
   public operator fun <T : Any> get(key: ViewEnvironmentKey<T>): T = getOrNull(key) ?: key.default
 
-  public operator fun <T : Any> plus(pair: Pair<ViewEnvironmentKey<T>, T>): ViewEnvironment {
-    val (newKey, newValue) = pair
+  /**
+   * Transforms the receiver to include the given [keyAndValue], taking care to apply
+   * [ViewEnvironmentKey.combine] to merge the existing value, if any.
+   */
+  public operator fun <T : Any> plus(keyAndValue: Pair<ViewEnvironmentKey<T>, T>): ViewEnvironment {
+    val (newKey, newValue) = keyAndValue
     val newPair = getOrNull(newKey)
       ?.let { oldValue -> newKey to newKey.combine(oldValue, newValue) }
-      ?: pair
+      ?: keyAndValue
     @Suppress("DEPRECATION")
     return ViewEnvironment(map + newPair)
   }
 
-  @Suppress("DEPRECATION")
+  /**
+   * Transforms the receiver to include the values of [other], taking care to apply
+   * [ViewEnvironmentKey.combine] to merge any existing values.
+   */
   public operator fun plus(other: ViewEnvironment): ViewEnvironment {
     if (this == other) return this
     if (other.map.isEmpty()) return this
@@ -42,6 +49,7 @@ constructor(
         ?.let { oldValue -> key.combine(oldValue, value) }
         ?: value
     }
+    @Suppress("DEPRECATION")
     return ViewEnvironment(newMap)
   }
 

--- a/workflow-ui/internal-testing-android/api/internal-testing-android.api
+++ b/workflow-ui/internal-testing-android/api/internal-testing-android.api
@@ -1,6 +1,7 @@
 public abstract class com/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity : com/squareup/workflow1/ui/internal/test/WorkflowUiTestActivity {
 	public fun <init> ()V
 	public final fun consumeLifecycleEvents ()Ljava/util/List;
+	public final fun getLogged ()Ljava/util/List;
 	protected abstract fun getViewRegistry ()Lcom/squareup/workflow1/ui/ViewRegistry;
 	protected final fun leafViewBinding (Lkotlin/reflect/KClass;Lcom/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity$ViewObserver;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/ScreenViewFactory;
 	public static synthetic fun leafViewBinding$default (Lcom/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity;Lkotlin/reflect/KClass;Lcom/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity$ViewObserver;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/ScreenViewFactory;
@@ -25,6 +26,21 @@ public class com/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivi
 	protected fun onSaveInstanceState ()Landroid/os/Parcelable;
 	public final fun setRendering (Ljava/lang/Object;)V
 	public final fun setViewObserver (Lcom/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity$ViewObserver;)V
+}
+
+public final class com/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity$TransitionLogEntry {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity$TransitionLogEntry;
+	public static synthetic fun copy$default (Lcom/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity$TransitionLogEntry;Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/ui/ViewEnvironment;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity$TransitionLogEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnv ()Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public final fun getFrom ()Ljava/lang/Object;
+	public final fun getTo ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/squareup/workflow1/ui/internal/test/AbstractLifecycleTestActivity$ViewObserver {


### PR DESCRIPTION
`ScreenTransitionLogger` provides extremely minimal hooks to allow apps to implement whatever it is that "navigation logging" means to them. It is a `ViewEnvironment` service with a default no-op implementation.

`ScreenTransitionLogger.onTransition` is called whenever one of our stock stub views (`WorkflowViewStub` and `@Composable fun WorkflowRendering()`) is updated to:
- show its first `Screen` rendering, or to
- show one that is incompatible with whatever was last shown

Both the incoming and outgoing `Screen` are provided to `onTransition`. The latter may be null when the function is called with the first `Screen` a stub is showing.

For this first stab, we are very intentionally providing a very unambitious mechanism.
- We make no attempt to report the entire AndroidX lifecycle -- e.g., we do not report when stubs are set up or torn down, only when they show something new.
- We focus only on `Screen`, not `Overlay`. In practice we have found that all of our interesting `Overlay` implementations are based on `ScreenOverlay` and stubs anyway.
- We do not attempt to report that view code is "done" updating, only that we have determined that a new view is required.

Note that this approach _will_ log updates under `BackStackScreen`, because `BackStackContainer` is built around `WorkflowViewStub`. Updates to the UI root will also be reported, because `WorkflowLayout` wraps `WorkflowViewStub` as well.

It is worth noting what _is_ supported: `onTransition` is provided with the `ViewEnvironment` in addition to the incoming and outgoing `Screen`s. This should allow more complex apps to set up logging systems that reflect more complex structures. For example, a custom container tiling or layering multiple stubs could provide `ViewEnvironment` values naming these separate navigation contexts. Or if a particular custom container is very fine grained in its use of stubs, it can seed its children's environments with a no-op `ScreenTransitionLogger` to eliminate noise.