### PR TITLE
Do not show `Dialog`s before `Activity` content view is attached.

### DIFF
--- a/samples/nested-overlays/src/androidTest/java/com/squareup/sample/nestedoverlays/NestedOverlaysAppTest.kt
+++ b/samples/nested-overlays/src/androidTest/java/com/squareup/sample/nestedoverlays/NestedOverlaysAppTest.kt
@@ -3,6 +3,7 @@ package com.squareup.sample.nestedoverlays
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.pressBack
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -54,6 +55,28 @@ class NestedOverlaysAppTest {
     onTopCoverEverything().assertNotDisplayed()
     onBottomCoverBody().assertNotDisplayed()
     onBottomCoverEverything().assertNotDisplayed()
+  }
+
+  @Test fun backButtonWorks() {
+    onTopCoverEverything().perform(click())
+    onView(withText("Cover Body")).inRoot(isDialog()).perform(click())
+
+    onView(withText("Reveal Body")).inRoot(isDialog()).perform(pressBack())
+    onView(withId(R.id.button_bar_text)).inRoot(isDialog()).perform(pressBack())
+
+    onTopCoverBody().assertDisplayed()
+  }
+
+  @Test fun backButtonWorksAfterConfigChange() {
+    onTopCoverEverything().perform(click())
+    onView(withText("Cover Body")).inRoot(isDialog()).perform(click())
+
+    scenarioRule.scenario.recreate()
+
+    onView(withText("Reveal Body")).inRoot(isDialog()).perform(pressBack())
+    onView(withId(R.id.button_bar_text)).inRoot(isDialog()).perform(pressBack())
+
+    onTopCoverBody().assertDisplayed()
   }
 
   // https://github.com/square/workflow-kotlin/issues/966

--- a/samples/nested-overlays/src/androidTest/java/com/squareup/sample/nestedoverlays/NestedOverlaysAppTest.kt
+++ b/samples/nested-overlays/src/androidTest/java/com/squareup/sample/nestedoverlays/NestedOverlaysAppTest.kt
@@ -107,6 +107,20 @@ class NestedOverlaysAppTest {
       .check(matches(withText("banana")))
   }
 
+  @Test fun orderPreservedOnConfigChange() {
+    // Show the outer dialog
+    onTopCoverEverything().perform(click())
+
+    // Click the outer dialog's button to show the inner dialog.
+    onView(withText("Cover Body")).inRoot(isDialog()).perform(click())
+
+    // "Config change"
+    scenarioRule.scenario.recreate()
+
+    // The green "Cover Everything" dialog is on top.
+    onView(withText("Reveal Body")).inRoot(isDialog()).check(matches(isDisplayed()))
+  }
+
   // https://github.com/square/workflow-kotlin/issues/314
   @Test fun whenBodyAndOverlaysStopsBeingRenderedDialogsAreDismissed() {
     onBottomCoverBody().perform(click())

--- a/samples/nested-overlays/src/main/java/com/squareup/sample/nestedoverlays/NestedOverlaysWorkflow.kt
+++ b/samples/nested-overlays/src/main/java/com/squareup/sample/nestedoverlays/NestedOverlaysWorkflow.kt
@@ -7,9 +7,11 @@ import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.container.BackButtonScreen
 import com.squareup.workflow1.ui.container.BodyAndOverlaysScreen
 import com.squareup.workflow1.ui.container.FullScreenModal
 
+@OptIn(WorkflowUiExperimentalApi::class)
 object NestedOverlaysWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>() {
   data class State(
     val showTopBar: Boolean = true,
@@ -46,15 +48,19 @@ object NestedOverlaysWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>()
     val outerSheet = if (!renderState.showOuterSheet) {
       null
     } else {
+      val closeOuter = context.eventHandler { state = state.copy(showOuterSheet = false) }
       FullScreenModal(
-        ButtonBar(
-          Button(
-            name = R.string.close,
-            onClick = context.eventHandler { state = state.copy(showOuterSheet = false) }
+        BackButtonScreen(
+          ButtonBar(
+            Button(
+              name = R.string.close,
+              onClick = closeOuter
+            ),
+            context.toggleInnerSheetButton(renderState),
+            color = android.R.color.holo_green_light,
+            showEditText = true,
           ),
-          context.toggleInnerSheetButton(renderState),
-          color = android.R.color.holo_green_light,
-          showEditText = true
+          onBackPressed = closeOuter
         )
       )
     }
@@ -62,20 +68,24 @@ object NestedOverlaysWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>()
     val innerSheet = if (!renderState.showInnerSheet) {
       null
     } else {
+      val closeInner = context.eventHandler { state = state.copy(showInnerSheet = false) }
       FullScreenModal(
-        ButtonBar(
-          Button(
-            name = R.string.close,
-            onClick = context.eventHandler { state = state.copy(showInnerSheet = false) }
+        BackButtonScreen(
+          ButtonBar(
+            Button(
+              name = R.string.close,
+              onClick = closeInner
+            ),
+            toggleTopBarButton,
+            toggleBottomBarButton,
+            Button(
+              name = R.string.nuke,
+              onClick = context.eventHandler { state = State(nuked = true) }
+            ),
+            color = android.R.color.holo_red_light,
+            showEditText = true
           ),
-          toggleTopBarButton,
-          toggleBottomBarButton,
-          Button(
-            name = R.string.nuke,
-            onClick = context.eventHandler { state = State(nuked = true) }
-          ),
-          color = android.R.color.holo_red_light,
-          showEditText = true
+          onBackPressed = closeInner
         )
       )
     }

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -366,7 +366,7 @@ public final class com/squareup/workflow1/ui/container/BackStackContainer$SavedS
 public final class com/squareup/workflow1/ui/container/LayeredDialogSessions {
 	public static final field Companion Lcom/squareup/workflow1/ui/container/LayeredDialogSessions$Companion;
 	public synthetic fun <init> (Landroid/content/Context;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getAllowEvents ()Z
+	public final fun getAllowBodyEvents ()Z
 	public final fun onAttachedToWindow (Ljava/lang/String;Landroid/view/View;)V
 	public final fun onDetachedFromWindow ()V
 	public final fun onRestoreInstanceState (Lcom/squareup/workflow1/ui/container/LayeredDialogSessions$SavedState;)V

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BodyAndOverlaysContainer.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BodyAndOverlaysContainer.kt
@@ -84,11 +84,11 @@ internal class BodyAndOverlaysContainer @JvmOverloads constructor(
   }
 
   override fun dispatchTouchEvent(event: MotionEvent): Boolean {
-    return !dialogs.allowEvents || super.dispatchTouchEvent(event)
+    return !dialogs.allowBodyEvents || super.dispatchTouchEvent(event)
   }
 
   override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-    return !dialogs.allowEvents || super.dispatchKeyEvent(event)
+    return !dialogs.allowBodyEvents || super.dispatchKeyEvent(event)
   }
 
   override fun onSaveInstanceState(): Parcelable {


### PR DESCRIPTION
If the very first rendering would instantiate `Dialog` windows, their content views were getting attached before the `Activity`'s content view. This would cause us to restore saved view state in the wrong order. If a `ComposeView` is in a `Dialog` in this situation, we would crash with an `IllegalStateException` from `SavedStateRegistry.consumeRestoredStateForKey`.

The fix is for `LayeredDialogSessions` and `DialogCollator` to conspire to decouple created `Dialog` instances from showing them the first time. Normally we go ahead and do both at once. But if `LayeredDialogSessions.update` is called before the corresponding `BodyAndOverlaysContainer` view is attached to the `Activity` window, we defer showing until it is.

Fixes #1001
