### PR TITLE
adding custom composite actions for CI

### DIFF
--- a/.github/actions/gradle-args/action.yml
+++ b/.github/actions/gradle-args/action.yml
@@ -1,0 +1,46 @@
+name : Set Gradle Args for runner OS
+description : Sets gradle property and jvm arguments based on runner OS
+
+# This action sets JVM arguments based upon the runner's operating system,
+# since they all have different hardware and different memory footprints.
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+
+outputs :
+  gradle-property-args :
+    description : "ex: -Dfile.encoding=UTF-8"
+    value : ${{ steps.set-args.outputs.gradle-property-args }}
+  gradle-jvm-args :
+    description : "ex: -Xmx5g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+    value : ${{ steps.set-args.outputs.gradle-jvm-args }}
+
+runs :
+  using : composite
+  steps :
+    - id : set-args
+      shell : bash
+      run : |
+        runnerOS=$RUNNER_OS
+
+        # Set common JVM arguments
+        jvmArgs="-XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+
+        case $runnerOS in
+          macOS)
+            jvmArgs="-Xmx10g -XX:MaxMetaspaceSize=5g $jvmArgs"
+            ;;
+          Linux)
+            jvmArgs="-Xmx4g -XX:MaxMetaspaceSize=3g $jvmArgs"
+            ;;
+          Windows)
+            jvmArgs="-Xmx3g -XX:MaxMetaspaceSize=756m $jvmArgs"
+            ;;
+          *)
+            echo "Unsupported runner OS: $runnerOS"
+            exit 1
+            ;;
+        esac
+
+        propertyArgs="-Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false"
+
+        echo "gradle-property-args=$propertyArgs" >> $GITHUB_OUTPUT
+        echo "gradle-jvm-args=$jvmArgs" >> $GITHUB_OUTPUT

--- a/.github/actions/gradle-task-with-commit/action.yml
+++ b/.github/actions/gradle-task-with-commit/action.yml
@@ -1,0 +1,89 @@
+name : Set Up Gradle and Run Task
+description : This action performs a "fix"-type Gradle task and commits/pushes changes if possible.
+
+inputs :
+  java-version :
+    description : 'The Java version to set up'
+    default : '11'
+  distribution :
+    description : 'The JDK distribution to use'
+    default : 'zulu'
+  fix-task :
+    description: 'The task to be executed if the user has a PAT and the branch is not a fork'
+    required: true
+  check-task:
+    description: 'The task to be executed if the user does not have a PAT or the branch is a fork'
+    required: true
+  commit-message:
+    description: 'The commit message to use if changes are generated'
+    default: ''
+  personal-access-token:
+    description: 'The personal access token to use for checkouts'
+  restore-cache-key:
+    description: 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
+    default: 'null'
+  write-cache-key:
+    description: 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
+    default: 'null'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check if PERSONAL_ACCESS_TOKEN is set
+      id: can-push
+      shell: bash
+      run: |
+        if [[ "${{ inputs.personal-access-token }}" == '' ]]; then
+          echo "can_push=false" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+          echo "can_push=false" >> $GITHUB_OUTPUT
+        else
+          echo "can_push=true" >> $GITHUB_OUTPUT
+        fi
+
+    # ensure that we have the actual branch checked out.  By default, actions/checkout is headless.
+    - name: check out with PAT
+      uses: actions/checkout@v3
+      if: steps.can-push.outputs.can_push == 'true'
+      with:
+        token: ${{ inputs.personal-access-token }}
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+
+    - name: Run ${{ inputs.fix-task }}
+      if: steps.can-push.outputs.can_push == 'true'
+      uses: ./.github/actions/gradle-task
+      with:
+        task: ${{ inputs.fix-task }}
+        distribution: ${{ inputs.distribution }}
+        java-version: ${{ inputs.java-version }}
+        restore-cache-key: ${{ inputs.restore-cache-key }}
+        write-cache-key: ${{ inputs.write-cache-key }}
+
+    - name: Set Commit Message
+      id: set-commit-message
+      if: steps.can-push.outputs.can_push == 'true'
+      shell: bash
+      run: |
+        if [[ -z "${{ inputs.commit-message }}" ]]; then
+          echo "commit-message=Apply changes from ${{ inputs.fix-task }}" >> $GITHUB_OUTPUT
+        else
+          echo "commit-message=${{ inputs.commit-message }}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: commit ${{ inputs.fix-task }} changes
+      if: steps.can-push.outputs.can_push == 'true'
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: ${{ steps.set-commit-message.outputs.commit-message }}
+        commit_options: '--no-verify --signoff'
+
+    - name: Run ${{ inputs.check-task }}
+      if: steps.can-push.outputs.can_push != 'true'
+      uses: ./.github/actions/gradle-task
+      with:
+        task: ${{ inputs.check-task }}
+        distribution: ${{ inputs.distribution }}
+        java-version: ${{ inputs.java-version }}
+        restore-cache-key: ${{ inputs.restore-cache-key }}
+        write-cache-key: ${{ inputs.write-cache-key }}

--- a/.github/actions/gradle-task/action.yml
+++ b/.github/actions/gradle-task/action.yml
@@ -1,0 +1,104 @@
+name : 'Set up Gradle and some task(s) with caching'
+description : 'This action performs common steps for a Gradle task.'
+
+inputs :
+  task :
+    description : 'Gradle command line arguments (supports multi-line input)'
+    required : true
+  build-root-directory :
+    description : 'Path to the root directory of the build'
+    required : false
+  java-version :
+    description : 'The Java version to set up.'
+    default : '11'
+  distribution :
+    description : 'The JDK distribution to use.'
+    default : 'zulu'
+  restore-cache-key :
+    description : 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
+  write-cache-key :
+    description : 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
+
+runs :
+  using : 'composite'
+  steps :
+
+    - name : Set up JDK
+      uses : actions/setup-java@v3
+      with :
+        distribution : ${{ inputs.distribution }}
+        java-version : ${{ inputs.java-version }}
+
+    - name : Set Gradle Args for runner OS
+      id : gradle-args
+      uses : ./.github/actions/gradle-args
+
+    - name : Gradle build action
+      uses : gradle/gradle-build-action@v2
+      with :
+        cache-read-only : false
+        gradle-home-cache-cleanup : true
+
+    # Attempt to restore from the write-cache-key, or fall back to a partial match for the write key.
+    # Skipped if the write-cache-key wasn't set.
+    # This step's "cache_hit" output will only be true if an exact match was found.
+    - name: restore cache for ${{inputs.write-cache-key}}
+      id: restore-write-cache
+      if: ${{inputs.write-cache-key}} != ''
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.gradle/caches/build-cache-1
+          ~/.gradle/wrapper
+        key: ${{inputs.write-cache-key}}-${{ hashFiles('**/*.gradle.kt*') }}-${{ hashFiles('**/libs.versions.toml') }}-${{ hashFiles('**/gradle.properties') }}
+        restore-keys: ${{inputs.write-cache-key}}
+        enableCrossOsArchive: true
+        lookup-only: true
+
+    # Attempt to restore from the restore-cache-key, or fall back to a partial match for the restore key.
+    # Skipped if the restore-cache-key wasn't set, or if the write-cache-key restore had an exact match.
+    - name: restore cache for ${{inputs.restore-cache-key}}
+      if: ${{inputs.restore-cache-key}} != '' && steps.restore-write-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.gradle/caches/build-cache-1
+          ~/.gradle/wrapper
+        key: ${{inputs.restore-cache-key}}-${{ hashFiles('**/*.gradle.kt*') }}-${{ hashFiles('**/libs.versions.toml') }}-${{ hashFiles('**/gradle.properties') }}
+        restore-keys: ${{inputs.restore-cache-key}}
+        enableCrossOsArchive: true
+
+    - uses: gradle/wrapper-validation-action@v1
+
+    # Run the actual task.  Note that this still uses gradle-build-action for more fine-grained caching.
+    - name : Run ${{ inputs.task }}
+      uses : gradle/gradle-build-action@v2
+      with :
+        # These arguments need to be on a single line. If they're defined with wrapping (using `|`),
+        # something along the way to the actual CLI invocation gets confused and the jvmargs list
+        # winds up getting parsed as a single argument.
+        arguments : ${{ steps.gradle-args.outputs.gradle-property-args }} ${{ inputs.task }} '-Dorg.gradle.jvmargs=${{ steps.gradle-args.outputs.gradle-jvm-args }}'
+        cache-read-only : false
+        build-root-directory : ${{ inputs.build-root-directory }}
+        gradle-home-cache-cleanup : true
+
+    # Save the build cache to `write-cache-key`.
+    # Skip if we already had an exact match, or if the key is not set, or if this is a Windows runner.
+    # Windows runners are welcome to *read* the cross-OS cache, but the directories get weird if
+    # they try to write to it.
+    - name: save the '${{inputs.write-cache-key}}' cache
+      uses: actions/cache/save@v3
+      id: save-write-cache-key
+      if: ${{inputs.write-cache-key}} != '' && steps.restore-write-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
+      with:
+        path: |
+          ~/.gradle/caches/build-cache-1
+          ~/.gradle/wrapper
+        key: ${{inputs.write-cache-key}}-${{ hashFiles('**/*.gradle.kt*') }}-${{ hashFiles('**/libs.versions.toml') }}-${{ hashFiles('**/gradle.properties') }}
+
+    - name : Upload heap dump
+      if : failure()
+      uses : actions/upload-artifact@v3
+      with :
+        name : heap-dump
+        path : ${{ github.workspace }}/**/*{.hprof,.log}

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -5,136 +5,131 @@ on :
     branches :
       - main
   pull_request :
-    paths-ignore :
-      # Don't build the entire app when just changing tutorials, which have their own workflow.
-      - 'samples/tutorial/**'
   merge_group :
-    paths-ignore :
-      # Don't build the entire app when just changing tutorials, which have their own workflow.
-      - 'samples/tutorial/**'
-
-env :
-  GRADLE_OPTS : "-Dorg.gradle.jvmargs=-Xmx5g -Dorg.gradle.daemon=false -Dorg.gradle.logging.stacktrace=all"
 
 # If CI is already running for a branch when that branch is updated, cancel the older jobs.
-concurrency:
-  group: ci-${{ github.ref }}-${{ github.head_ref }}
-  cancel-in-progress: true
+concurrency :
+  group : ci-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress : true
 
 jobs :
+
+  build-all:
+    name: Build all
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: main build
+        uses: ./.github/actions/gradle-task
+        with:
+          task: compileKotlin compileDebugKotlin
+          write-cache-key: main-build-artifacts
 
   dokka :
     name : Assemble & Dokka
     runs-on : ubuntu-latest
-    timeout-minutes : 20
+    needs: build-all
     steps :
       - uses : actions/checkout@v3
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : 11
 
-      ## Actual task
-      - uses : gradle/gradle-build-action@v2
-        name : Assemble with gradle — make sure everything builds
+      - name : Run dokka to validate kdoc
+        uses : ./.github/actions/gradle-task
         with :
-          arguments : |
-            assemble
-          cache-read-only : false
+          task : siteDokka
+          write-cache-key : main-build-artifacts
 
-      # This should ideally be done as a Check job below, but it needs to be done as a separate
-      # step after running assemble. Heckin' ridikalus.
-      # Probably fixed in dokka 1.4.10, but we can't move to kotlin 1.4 yet.
-      #  https://github.com/square/workflow/issues/1152.
-      - uses : gradle/gradle-build-action@v2
-        name : Run dokka to validate kdoc
-        with :
-          arguments : |
-            siteDokka --build-cache
-          cache-read-only : false
-
-  # the `artifactsCheck` task has to run on macOS in order to see the iOS KMP artifacts
   artifacts-check :
     name : ArtifactsCheck
+    # the `artifactsCheck` task has to run on macOS in order to see the iOS KMP artifacts
     runs-on : macos-latest
-    timeout-minutes : 20
     steps :
       - uses : actions/checkout@v3
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : 11
 
-      ## Actual task
-      - uses : gradle/gradle-build-action@v2
-        name : check published artifacts
+      - name : check published artifacts
+        uses : ./.github/actions/gradle-task-with-commit
         with :
-          arguments : artifactsCheck
-          cache-read-only : false
+          check-task : artifactsCheck
+          fix-task : artifactsDump
+          write-cache-key : build-logic
 
   dependency-guard :
     name : Dependency Guard
     runs-on : ubuntu-latest
+    steps :
+      - uses : actions/checkout@v3
+
+      # If the PR was made by a maintainer or Renovate, automatically update baselines and push
+      # so that no one has to check out the branch and update the baselines manually.
+      - name : dependency-guard
+        uses : ./.github/actions/gradle-task-with-commit
+        with :
+          check-task : dependencyGuard --refresh-dependencies
+          fix-task : dependencyGuardBaseline --refresh-dependencies
+          write-cache-key : build-logic
+
+  ktlint :
+    name : KtLint
+    runs-on : ubuntu-latest
+    steps :
+      - uses : actions/checkout@v3
+
+      # If the PR was made by a maintainer or Renovate, automatically format and push
+      # so that no one has to check out the branch and do it manually.
+      - name : KtLint
+        uses : ./.github/actions/gradle-task-with-commit
+        with :
+          check-task : ktLintCheck
+          fix-task : ktLintFormat
+          write-cache-key : build-logic
+
+  api-check :
+    name : Api check
+    runs-on : ubuntu-latest
+    steps :
+      - uses : actions/checkout@v3
+
+      # If the PR was made by a maintainer or Renovate, automatically format and push
+      # so that no one has to check out the branch and do it manually.
+      - name : binary compatibility
+        uses : ./.github/actions/gradle-task-with-commit
+        with :
+          check-task : apiCheck
+          fix-task : apiDump
+          write-cache-key : build-logic
+
+  android-lint :
+    name : Android Lint
+    runs-on : ubuntu-latest
+    needs: build-all
     timeout-minutes : 20
     steps :
       - uses : actions/checkout@v3
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
+      - name : Check with Gradle
+        uses : ./.github/actions/gradle-task
         with :
-          distribution : 'zulu'
-          java-version : 11
+          task : lint
+          write-cache-key : main-build-artifacts
 
-      # If the PR was made by Renovate, automatically update baselines and push so that no one has
-      # to check out the branch and update the baselines manually.
-      - name : dependency-guard baseline (used by Renovate)
-        if : github.actor == 'renovate[bot]'
-        uses : gradle/gradle-build-action@v2
-        with :
-          arguments : dependencyGuardBaseline
-          cache-read-only : false --refresh-dependencies
-
-      # If a non-bot made the pull request, run the non-baseline task which fails on changes.
-      - name : dependency-guard check (used by everyone but Renovate)
-        if : github.actor != 'renovate[bot]'
-        uses : gradle/gradle-build-action@v2
-        with :
-          arguments : dependencyGuard
-          cache-read-only : false --refresh-dependencies
-
-      # If dependency-guard generated changes, commit and push those changes. This relies upon the
-      # 'cancel-stale-jobs' job to cancel the rest of the jobs for the now-stale commit.
-      - name : commit dependency-guard baseline changes (used by main repo)
-        if : github.actor == 'renovate[bot]'
-        uses : stefanzweifel/git-auto-commit-action@v4
-        with :
-          commit_message : update dependency-guard baseline
-          commit_options : '--no-verify --signoff'
-
-  # These are all pretty quick so we run them on a single shard. Fewer shards, less queueing.
   check :
     name : Check
     runs-on : ubuntu-latest
+    needs: build-all
     timeout-minutes : 20
     steps :
       - uses : actions/checkout@v3
-      - uses : gradle/wrapper-validation-action@v1
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
+      - name : Check with Gradle
+        uses : ./.github/actions/gradle-task
         with :
-          distribution : 'zulu'
-          java-version : 11
+          task : |
+            checkVersionIsSnapshot
+            allTests
+            test 
+            --continue
+          restore-cache-key : build-logic
+          write-cache-key : main-build-artifacts
 
-      ## Actual task
-      - uses : gradle/gradle-build-action@v2
-        name : Check with Gradle
-        with :
-          arguments : |
-            allTests test apiCheck checkVersionIsSnapshot lint ktlintCheck --continue
-          cache-read-only : false
-
-      # Report as Github Pull Request Check.
+      # Report as GitHub Pull Request Check.
       - name : Publish Test Report
         uses : mikepenz/action-junit-report@v3
         if : always() # always run even if the previous step fails
@@ -148,17 +143,12 @@ jobs :
     steps :
       # These setup steps should be common across all jobs in this workflow.
       - uses : actions/checkout@v3
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : 11
       - name : build tutorials
-        uses : gradle/gradle-build-action@v2
+        uses : ./.github/actions/gradle-task
         with :
-          arguments : build
-          cache-read-only : false
+          task : build
           build-root-directory : samples/tutorial
+          restore-cache-key : main-build-artifacts
 
   jvm-conflate-runtime-test :
     name : Conflate Stale Renderings Runtime JVM Tests
@@ -166,22 +156,13 @@ jobs :
     timeout-minutes : 20
     steps :
       - uses : actions/checkout@v3
-      - uses : gradle/wrapper-validation-action@v1
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
+      - name : Check with Gradle
+        uses : ./.github/actions/gradle-task
         with :
-          distribution : 'zulu'
-          java-version : 11
+          task : jvmTest --continue -Pworkflow.runtime=conflate
+          restore-cache-key : main-build-artifacts
 
-      ## Actual task
-      - uses : gradle/gradle-build-action@v2
-        name : Check with Gradle
-        with :
-          arguments : |
-            jvmTest --continue -Pworkflow.runtime=conflate
-          cache-read-only : false
-
-      # Report as Github Pull Request Check.
+      # Report as GitHub Pull Request Check.
       - name : Publish Test Report
         uses : mikepenz/action-junit-report@v3
         if : always() # always run even if the previous step fails
@@ -194,22 +175,13 @@ jobs :
     timeout-minutes : 20
     steps :
       - uses : actions/checkout@v3
-      - uses : gradle/wrapper-validation-action@v1
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
+      - name : Check with Gradle
+        uses : ./.github/actions/gradle-task
         with :
-          distribution : 'zulu'
-          java-version : 11
+          task : jvmTest --continue -Pworkflow.runtime=baseline-stateChange
+          restore-cache-key : main-build-artifacts
 
-      ## Actual task
-      - uses : gradle/gradle-build-action@v2
-        name : Check with Gradle
-        with :
-          arguments : |
-            jvmTest --continue -Pworkflow.runtime=baseline-stateChange
-          cache-read-only : false
-
-      # Report as Github Pull Request Check.
+      # Report as GitHub Pull Request Check.
       - name : Publish Test Report
         uses : mikepenz/action-junit-report@v3
         if : always() # always run even if the previous step fails
@@ -222,22 +194,13 @@ jobs :
     timeout-minutes : 20
     steps :
       - uses : actions/checkout@v3
-      - uses : gradle/wrapper-validation-action@v1
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
+      - name : Check with Gradle
+        uses : ./.github/actions/gradle-task
         with :
-          distribution : 'zulu'
-          java-version : 11
+          task : jvmTest --continue -Pworkflow.runtime=conflate-stateChange
+          restore-cache-key : main-build-artifacts
 
-      ## Actual task
-      - uses : gradle/gradle-build-action@v2
-        name : Check with Gradle
-        with :
-          arguments : |
-            jvmTest --continue -Pworkflow.runtime=conflate-stateChange
-          cache-read-only : false
-
-      # Report as Github Pull Request Check.
+      # Report as GitHub Pull Request Check.
       - name : Publish Test Report
         uses : mikepenz/action-junit-report@v3
         if : always() # always run even if the previous step fails
@@ -250,22 +213,13 @@ jobs :
     timeout-minutes : 30
     steps :
       - uses : actions/checkout@v3
-      - uses : gradle/wrapper-validation-action@v1
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
+      - name : Check with Gradle
+        uses : ./.github/actions/gradle-task
         with :
-          distribution : 'zulu'
-          java-version : 11
+          task : iosX64Test
+          restore-cache-key : main-build-artifacts
 
-      ## iOS Specific Tests (for KMP ios actuals in core and runtime).
-      - uses : gradle/gradle-build-action@v2
-        name : Check with Gradle
-        with :
-          arguments : |
-            iosX64Test
-          cache-read-only : false
-
-      # Report as Github Pull Request Check.
+      # Report as GitHub Pull Request Check.
       - name : Publish Test Report
         uses : mikepenz/action-junit-report@v3
         if : always() # always run even if the previous step fails
@@ -278,22 +232,15 @@ jobs :
     timeout-minutes : 20
     steps :
       - uses : actions/checkout@v3
-      - uses : gradle/wrapper-validation-action@v1
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : 11
 
       ## JS Specific Tests (for KMP js actuals in core and runtime).
-      - uses : gradle/gradle-build-action@v2
-        name : Check with Gradle
+      - name : Check with Gradle
+        uses : ./.github/actions/gradle-task
         with :
-          arguments : |
-            jsTest
-          cache-read-only : false
+          task : jsTest
+          restore-cache-key : main-build-artifacts
 
-      # Report as Github Pull Request Check.
+      # Report as GitHub Pull Request Check.
       - name : Publish Test Report
         uses : mikepenz/action-junit-report@v3
         if : always() # always run even if the previous step fails
@@ -314,19 +261,13 @@ jobs :
       # Newer versions are reputed to be too slow: https://github.com/ReactiveCircus/android-emulator-runner/issues/222
     steps :
       - uses : actions/checkout@v3
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : 11
 
       ## Build before running tests, using cache.
-      - uses : gradle/gradle-build-action@v2
-        name : Build instrumented tests
+      - name : Build instrumented tests
+        uses : ./.github/actions/gradle-task
         with :
-          arguments : |
-            :benchmarks:performance-poetry:complex-poetry:assembleDebugAndroidTest
-          cache-read-only : false
+          task : :benchmarks:performance-poetry:complex-poetry:assembleDebugAndroidTest
+          restore-cache-key : main-build-artifacts
 
       ## Actual task
       - name : Render Pass Counting Test
@@ -345,8 +286,24 @@ jobs :
           name : renderpass-counting-results-${{ matrix.api-level }}
           path : ./**/build/reports/androidTests/connected/**
 
+  build-instrumentation-tests :
+    name : Build Instrumentation tests
+    runs-on : macos-latest
+    needs: build-all
+    timeout-minutes : 45
+    steps :
+      - uses : actions/checkout@v3
+
+      - name : Build instrumented tests
+        uses : ./.github/actions/gradle-task
+        with :
+          task : assembleDebugAndroidTest
+          restore-cache-key : main-build-artifacts
+          write-cache-key : androidTest-build-artifacts
+
   instrumentation-tests :
     name : Instrumentation tests
+    needs: build-instrumentation-tests
     runs-on : macos-latest
     timeout-minutes : 45
     strategy :
@@ -359,19 +316,13 @@ jobs :
       # Newer versions are reputed to be too slow: https://github.com/ReactiveCircus/android-emulator-runner/issues/222
     steps :
       - uses : actions/checkout@v3
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : 11
 
-      ## Build before running tests, using cache.
-      - uses : gradle/gradle-build-action@v2
-        name : Build instrumented tests
+      # This really just pulls the cache from the dependency job
+      - name : Build instrumented tests
+        uses : ./.github/actions/gradle-task
         with :
-          arguments : |
-            assembleDebugAndroidTest
-          cache-read-only : false
+          task : assembleDebugAndroidTest
+          restore-cache-key : androidTest-build-artifacts
 
       ## Actual task
       - name : Instrumentation Tests
@@ -405,21 +356,14 @@ jobs :
       # Newer versions are reputed to be too slow: https://github.com/ReactiveCircus/android-emulator-runner/issues/222
     steps :
       - uses : actions/checkout@v3
-      - name : set up JDK 11
-        uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : 11
 
       ## Build before running tests, using cache.
-      - uses : gradle/gradle-build-action@v2
-        name : Build instrumented tests
+      - name : Build instrumented tests
+        uses : ./.github/actions/gradle-task
         with :
           # Unfortunately I don't think we can key this cache based on our project property so
           # we clean and rebuild.
-          arguments : |
-            clean assembleDebugAndroidTest -Pworkflow.runtime=conflate
-          cache-read-only : false
+          task : clean assembleDebugAndroidTest -Pworkflow.runtime=conflate
 
       ## Actual task
       - name : Instrumentation Tests
@@ -436,7 +380,7 @@ jobs :
         if : ${{ always() }}
         uses : actions/upload-artifact@v3
         with :
-          name : conflate-instrumentation-test-results-${{ matrix.api-level }}
+          name : instrumentation-test-results-${{ matrix.api-level }}
           path : ./**/build/reports/androidTests/connected/**
 
   stateChange-runtime-instrumentation-tests :
@@ -460,14 +404,12 @@ jobs :
           java-version : 11
 
       ## Build before running tests, using cache.
-      - uses : gradle/gradle-build-action@v2
-        name : Build instrumented tests
+      - name : Build instrumented tests
+        uses : ./.github/actions/gradle-task
         with :
           # Unfortunately I don't think we can key this cache based on our project property so
           # we clean and rebuild.
-          arguments : |
-            clean assembleDebugAndroidTest -Pworkflow.runtime=baseline-stateChange
-          cache-read-only : false
+          task : clean assembleDebugAndroidTest -Pworkflow.runtime=baseline-stateChange
 
       ## Actual task
       - name : Instrumentation Tests
@@ -508,14 +450,12 @@ jobs :
           java-version : 11
 
       ## Build before running tests, using cache.
-      - uses : gradle/gradle-build-action@v2
-        name : Build instrumented tests
+      - name : Build instrumented tests
+        uses : ./.github/actions/gradle-task
         with :
           # Unfortunately I don't think we can key this cache based on our project property so
           # we clean and rebuild.
-          arguments : |
-            clean assembleDebugAndroidTest -Pworkflow.runtime=conflate-stateChange
-          cache-read-only : false
+          task : clean assembleDebugAndroidTest -Pworkflow.runtime=conflate-stateChange
 
       ## Actual task
       - name : Instrumentation Tests
@@ -539,6 +479,8 @@ jobs :
     if : always()
     runs-on : ubuntu-latest
     needs :
+      - android-lint
+      - api-check
       - artifacts-check
       - check
       - conflate-renderings-instrumentation-tests
@@ -551,6 +493,7 @@ jobs :
       - jvm-conflate-runtime-test
       - jvm-conflate-stateChange-runtime-test
       - jvm-stateChange-runtime-test
+      - ktlint
       - performance-tests
       - stateChange-runtime-instrumentation-tests
       - tutorials

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -18,36 +18,26 @@ jobs:
 
     steps :
       - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
-      - name: set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: 11
 
       - name : Check for -SNAPSHOT version
-        uses : gradle/gradle-build-action@v2
+        uses : ./.github/actions/gradle-task
         with :
-          arguments : checkVersionIsSnapshot
-          cache-read-only: false
+          task : checkVersionIsSnapshot
 
       - name : Assemble
-        uses : gradle/gradle-build-action@v2
+        uses : ./.github/actions/gradle-task
         with :
-          arguments : assemble
-          cache-read-only: false
+          task : assemble
 
       - name : Check
-        uses : gradle/gradle-build-action@v2
+        uses : ./.github/actions/gradle-task
         with :
-          arguments : check
-          cache-read-only: false
+          task : check
 
       - name : Publish Snapshots
-        uses : gradle/gradle-build-action@v2
+        uses : ./.github/actions/gradle-task
         with :
-          arguments : publish
-          cache-read-only: false
+          task : publish
         env :
           ORG_GRADLE_PROJECT_mavenCentralUsername : ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword : ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/samples/tutorial/build.gradle
+++ b/samples/tutorial/build.gradle
@@ -54,6 +54,14 @@ subprojects {
       freeCompilerArgs += '-opt-in=kotlin.RequiresOptIn'
     }
   }
+
+  plugins.withId("org.jetbrains.kotlin.android")  {
+    java {
+      toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+      }
+    }
+  }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
This adds some custom internal actions, which removes some boilerplate from job definitions and ensures that everything's consistent.

For each step which invokes a Gradle task, we will:

- set up JDK 11 (zulu)
- set Gradle properties and jvm args, where the memory settings are OS-specific
  - `-Xmx10g` for MacOS
  - `-Xmx5g` for Ubuntu
  - `-Xmx3g` for Windows
- use `gradle-build-action@v2` for caching
- invoke whatever Gradle task(s)
- upload a heap dump in the event of a memory error

This also adds a `gradle-task-with-commit` action which also does all the above.  In the future, it will automagically run format/baseline tasks before a "check" task if it has permissions to push to the PR branch.  **For the moment, this is not actually set up.**  I need to get us a service token with the appropriate permissions first.  So for now, the jobs which use `gradle-task-with-comment` will just execute the "check" version for everyone.