### PR TITLE
Add RuntimeConfig through to WorkflowSession in Interceptor

### DIFF
--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -101,6 +101,7 @@ public abstract interface class com/squareup/workflow1/WorkflowInterceptor$Workf
 	public abstract fun getIdentifier ()Lcom/squareup/workflow1/WorkflowIdentifier;
 	public abstract fun getParent ()Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;
 	public abstract fun getRenderKey ()Ljava/lang/String;
+	public abstract fun getRuntimeConfig ()Ljava/util/Set;
 	public abstract fun getSessionId ()J
 }
 

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/WorkflowInterceptor.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/WorkflowInterceptor.kt
@@ -150,6 +150,9 @@ public interface WorkflowInterceptor {
 
     /** The parent [WorkflowSession] of this workflow, or null if this is the root workflow. */
     public val parent: WorkflowSession?
+
+    /** The [RuntimeConfig] of the runtime this session is executing in. */
+    public val runtimeConfig: RuntimeConfig
   }
 
   /**

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
@@ -3,6 +3,7 @@ package com.squareup.workflow1.internal
 import com.squareup.workflow1.ActionApplied
 import com.squareup.workflow1.ActionProcessingResult
 import com.squareup.workflow1.NoopWorkflowInterceptor
+import com.squareup.workflow1.RuntimeConfig
 import com.squareup.workflow1.TreeSnapshot
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
@@ -89,6 +90,7 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
     action: WorkflowAction<PropsT, StateT, OutputT>,
     childResult: ActionApplied<*>
   ) -> ActionProcessingResult,
+  private val runtimeConfig: RuntimeConfig,
   private val workflowSession: WorkflowSession? = null,
   private val interceptor: WorkflowInterceptor = NoopWorkflowInterceptor,
   private val idCounter: IdCounter? = null
@@ -180,14 +182,15 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
     val childTreeSnapshots = snapshotCache?.get(id)
 
     val workflowNode = WorkflowNode(
-      id,
-      child.asStatefulWorkflow(),
-      initialProps,
-      childTreeSnapshots,
-      contextForChildren,
-      ::acceptChildActionResult,
-      workflowSession,
-      interceptor,
+      id = id,
+      workflow = child.asStatefulWorkflow(),
+      initialProps = initialProps,
+      snapshot = childTreeSnapshots,
+      baseContext = contextForChildren,
+      runtimeConfig = runtimeConfig,
+      emitAppliedActionToParent = ::acceptChildActionResult,
+      parent = workflowSession,
+      interceptor = interceptor,
       idCounter = idCounter
     )
     return WorkflowChildNode(child, handler, workflowNode)

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
@@ -4,6 +4,8 @@ import com.squareup.workflow1.ActionApplied
 import com.squareup.workflow1.ActionProcessingResult
 import com.squareup.workflow1.NoopWorkflowInterceptor
 import com.squareup.workflow1.RenderContext
+import com.squareup.workflow1.RuntimeConfig
+import com.squareup.workflow1.RuntimeConfigOptions
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.TreeSnapshot
 import com.squareup.workflow1.Workflow
@@ -44,6 +46,8 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   initialProps: PropsT,
   snapshot: TreeSnapshot?,
   baseContext: CoroutineContext,
+  // Providing default value so we don't need to specify in test.
+  override val runtimeConfig: RuntimeConfig = RuntimeConfigOptions.DEFAULT_CONFIG,
   private val emitAppliedActionToParent: (ActionApplied<OutputT>) -> ActionProcessingResult =
     { it },
   override val parent: WorkflowSession? = null,
@@ -66,6 +70,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
     snapshotCache = snapshot?.childTreeSnapshots,
     contextForChildren = coroutineContext,
     emitActionToParent = ::applyAction,
+    runtimeConfig = runtimeConfig,
     workflowSession = this,
     interceptor = interceptor,
     idCounter = idCounter

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowRunner.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowRunner.kt
@@ -54,6 +54,7 @@ internal class WorkflowRunner<PropsT, OutputT, RenderingT>(
     initialProps = currentProps,
     snapshot = snapshot,
     baseContext = scope.coroutineContext,
+    runtimeConfig = runtimeConfig,
     interceptor = interceptor,
     idCounter = idCounter
   )

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/SimpleLoggingWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/SimpleLoggingWorkflowInterceptorTest.kt
@@ -82,6 +82,7 @@ internal class SimpleLoggingWorkflowInterceptorTest {
     override val renderKey: String get() = "key"
     override val sessionId: Long get() = 42
     override val parent: WorkflowSession? get() = null
+    override val runtimeConfig: RuntimeConfig = RuntimeConfigOptions.DEFAULT_CONFIG
   }
 
   private object FakeRenderContext : BaseRenderContext<Unit, Unit, Unit> {

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
@@ -216,6 +216,7 @@ internal class WorkflowInterceptorTest {
       override val renderKey: String = ""
       override val sessionId: Long = 0
       override val parent: WorkflowSession? = null
+      override val runtimeConfig: RuntimeConfig = RuntimeConfigOptions.DEFAULT_CONFIG
     }
 
   private object TestWorkflow : StatefulWorkflow<String, String, String, String>() {

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
@@ -4,6 +4,8 @@ package com.squareup.workflow1.internal
 
 import com.squareup.workflow1.BaseRenderContext
 import com.squareup.workflow1.NoopWorkflowInterceptor
+import com.squareup.workflow1.RuntimeConfig
+import com.squareup.workflow1.RuntimeConfigOptions
 import com.squareup.workflow1.Sink
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.Workflow
@@ -331,5 +333,6 @@ internal class ChainedWorkflowInterceptorTest {
     override val renderKey: String = ""
     override val sessionId: Long = 0
     override val parent: WorkflowSession? = null
+    override val runtimeConfig: RuntimeConfig = RuntimeConfigOptions.DEFAULT_CONFIG
   }
 }

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
@@ -4,6 +4,7 @@ package com.squareup.workflow1.internal
 
 import com.squareup.workflow1.ActionApplied
 import com.squareup.workflow1.ActionProcessingResult
+import com.squareup.workflow1.RuntimeConfigOptions
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.TreeSnapshot
@@ -307,7 +308,12 @@ internal class SubtreeManagerTest {
 
   private fun <P, S, O : Any> subtreeManagerForTest(
     snapshotCache: Map<WorkflowNodeId, TreeSnapshot>? = null
-  ) = SubtreeManager<P, S, O>(snapshotCache, context, emitActionToParent = { action, childResult ->
-    ActionApplied(WorkflowOutput(action), childResult.stateChanged)
-  })
+  ) = SubtreeManager<P, S, O>(
+    snapshotCache = snapshotCache,
+    contextForChildren = context,
+    runtimeConfig = RuntimeConfigOptions.DEFAULT_CONFIG,
+    emitActionToParent = { action, childResult ->
+      ActionApplied(WorkflowOutput(action), childResult.stateChanged)
+    }
+  )
 }


### PR DESCRIPTION
the `WorkflowInterceptor` may want to make decisions about how to intercept based on the `RuntimeConfig`, so we should deliver it via the `WorkflowSession` and propagate it through the runtime appropriately.