### PR TITLE
update ktlint plugin to `0.1.5` and delete `ktlint_disabled_rules` from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -506,8 +506,6 @@ ktlint_standard_trailing-comma-on-call-site = disabled
 ktlint_standard_trailing-comma-on-declaration-site = disabled
 
 [{*.kt,*.kts}]
-# noinspection EditorConfigKeyCorrectness
-ktlint_disabled_rules = trailing-comma-on-declaration-site,trailing-comma-on-call-site
 ij_continuation_indent_size = 2
 ij_kotlin_align_in_columns_case_branch = false
 ij_kotlin_align_multiline_binary_operation = false

--- a/dependencies/classpath.txt
+++ b/dependencies/classpath.txt
@@ -68,8 +68,8 @@ com.google.protobuf:protobuf-java:3.17.2
 com.google.testing.platform:core-proto:0.0.8-alpha08
 com.googlecode.java-diff-utils:diffutils:1.3.0
 com.googlecode.juniversalchardet:juniversalchardet:1.0.3
-com.rickbusarow.ktlint:com.rickbusarow.ktlint.gradle.plugin:0.1.4
-com.rickbusarow.ktlint:ktlint-gradle-plugin:0.1.4
+com.rickbusarow.ktlint:com.rickbusarow.ktlint.gradle.plugin:0.1.5
+com.rickbusarow.ktlint:ktlint-gradle-plugin:0.1.5
 com.squareup.moshi:moshi-adapters:1.13.0
 com.squareup.moshi:moshi:1.13.0
 com.squareup.okhttp3:okhttp:4.10.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,7 @@ kotlinx-serialization-json = "1.3.2"
 kotlinx-atomicfu = "0.17.2"
 
 ktlint = "0.49.1"
-ktlint-gradle = "0.1.4"
+ktlint-gradle = "0.1.5"
 material = "1.3.0"
 mavenPublish = "0.13.0"
 


### PR DESCRIPTION
KtLint changes for [0.1.5](https://github.com/RBusarow/ktlint-gradle-plugin/releases/tag/0.1.5):

### Fixed

- don't use coroutines from inside the ktlint worker in https://github.com/RBusarow/ktlint-gradle-plugin/pull/74
- make format tasks cacheable in https://github.com/RBusarow/ktlint-gradle-plugin/pull/75
- only register sourceSet-specific tasks after KGP is applied in https://github.com/RBusarow/ktlint-gradle-plugin/pull/76
  ☝️ **this one means that the kotlin-dsl plugin's source set is excluded from the script tasks' source set**

### 🧰 Maintenance

- split up CI jobs in https://github.com/RBusarow/ktlint-gradle-plugin/pull/71

**Full Changelog**: https://github.com/RBusarow/ktlint-gradle-plugin/compare/0.1.4...0.1.5