### PR TITLE
2/4 Better support for `View.findViewTreeOnBackPressedDispatcherOwner`.

### DIFF
--- a/workflow-ui/compose-tooling/dependencies/releaseRuntimeClasspath.txt
+++ b/workflow-ui/compose-tooling/dependencies/releaseRuntimeClasspath.txt
@@ -3,6 +3,7 @@
 :workflow-ui:compose
 :workflow-ui:core-android
 :workflow-ui:core-common
+androidx.activity:activity-compose:1.6.1
 androidx.activity:activity-ktx:1.6.1
 androidx.activity:activity:1.6.1
 androidx.annotation:annotation-experimental:1.1.0

--- a/workflow-ui/compose/build.gradle.kts
+++ b/workflow-ui/compose/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
   api(project(":workflow-ui:core-common"))
 
   implementation(composeBom)
+  implementation(libs.androidx.activity.compose)
   implementation(libs.androidx.compose.foundation.layout)
   implementation(libs.androidx.compose.runtime.saveable)
   implementation(libs.androidx.compose.ui)

--- a/workflow-ui/compose/dependencies/releaseRuntimeClasspath.txt
+++ b/workflow-ui/compose/dependencies/releaseRuntimeClasspath.txt
@@ -2,6 +2,7 @@
 :workflow-runtime
 :workflow-ui:core-android
 :workflow-ui:core-common
+androidx.activity:activity-compose:1.6.1
 androidx.activity:activity-ktx:1.6.1
 androidx.activity:activity:1.6.1
 androidx.annotation:annotation-experimental:1.1.0

--- a/workflow-ui/container-android/src/main/java/com/squareup/workflow1/ui/modal/ModalContainer.kt
+++ b/workflow-ui/container-android/src/main/java/com/squareup/workflow1/ui/modal/ModalContainer.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
+import androidx.activity.OnBackPressedDispatcherOwner
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -20,6 +21,7 @@ import com.squareup.workflow1.ui.Compatible
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.WorkflowViewStub
+import com.squareup.workflow1.ui.androidx.WorkflowAndroidXSupport.onBackPressedDispatcherOwner
 import com.squareup.workflow1.ui.androidx.WorkflowAndroidXSupport.stateRegistryOwnerFromViewTreeOrContext
 import com.squareup.workflow1.ui.androidx.WorkflowLifecycleOwner
 import com.squareup.workflow1.ui.androidx.WorkflowSavedStateRegistryAggregator
@@ -88,6 +90,8 @@ public abstract class ModalContainer<ModalRenderingT : Any> @JvmOverloads constr
             // any, and so we can use our lifecycle to destroy-on-detach the dialog hierarchy.
             WorkflowLifecycleOwner.installOn(
               dialogView,
+              (ref.dialog as? OnBackPressedDispatcherOwner)
+                ?: viewEnvironment.onBackPressedDispatcherOwner(this),
               findParentLifecycle = { parentLifecycleOwner.lifecycle }
             )
             // Ensure that each dialog has its own SavedStateRegistryOwner,

--- a/workflow-ui/container-android/src/main/java/com/squareup/workflow1/ui/modal/ModalViewContainer.kt
+++ b/workflow-ui/container-android/src/main/java/com/squareup/workflow1/ui/modal/ModalViewContainer.kt
@@ -18,11 +18,11 @@ import com.squareup.workflow1.ui.ScreenViewHolder
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.androidx.WorkflowAndroidXSupport.onBackPressedDispatcherOwnerOrNull
 import com.squareup.workflow1.ui.asScreen
 import com.squareup.workflow1.ui.bindShowRendering
 import com.squareup.workflow1.ui.container.BackButtonScreen
 import com.squareup.workflow1.ui.modal.ModalViewContainer.Companion.binding
-import com.squareup.workflow1.ui.onBackPressedDispatcherOwnerOrNull
 import com.squareup.workflow1.ui.show
 import com.squareup.workflow1.ui.startShowing
 import com.squareup.workflow1.ui.toViewFactory
@@ -93,7 +93,7 @@ public open class ModalViewContainer @JvmOverloads constructor(
 
         setOnKeyListener { _, keyCode, keyEvent ->
           if (keyCode == KeyEvent.KEYCODE_BACK && keyEvent.action == ACTION_UP) {
-            viewHolder.view.context.onBackPressedDispatcherOwnerOrNull()
+            viewHolder.view.onBackPressedDispatcherOwnerOrNull()
               ?.onBackPressedDispatcher
               ?.let {
                 if (it.hasEnabledCallbacks()) it.onBackPressed()

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -33,7 +33,6 @@ public final class com/squareup/workflow1/ui/BackButtonScreen : com/squareup/wor
 
 public final class com/squareup/workflow1/ui/BackPressHandlerKt {
 	public static final fun getBackPressedHandler (Landroid/view/View;)Lkotlin/jvm/functions/Function0;
-	public static final fun onBackPressedDispatcherOwnerOrNull (Landroid/content/Context;)Landroidx/activity/OnBackPressedDispatcherOwner;
 	public static final fun setBackPressedHandler (Landroid/view/View;Lkotlin/jvm/functions/Function0;)V
 }
 
@@ -75,6 +74,12 @@ public final class com/squareup/workflow1/ui/LayoutScreenViewFactory : com/squar
 	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/jvm/functions/Function1;)V
 	public fun buildView (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Lcom/squareup/workflow1/ui/ScreenViewHolder;
 	public fun getType ()Lkotlin/reflect/KClass;
+}
+
+public final class com/squareup/workflow1/ui/OnBackPressedDispatcherOwnerKey : com/squareup/workflow1/ui/ViewEnvironmentKey {
+	public static final field INSTANCE Lcom/squareup/workflow1/ui/OnBackPressedDispatcherOwnerKey;
+	public fun getDefault ()Landroidx/activity/OnBackPressedDispatcherOwner;
+	public synthetic fun getDefault ()Ljava/lang/Object;
 }
 
 public final class com/squareup/workflow1/ui/ParcelableTextController : android/os/Parcelable, com/squareup/workflow1/ui/TextController {
@@ -275,6 +280,8 @@ public final class com/squareup/workflow1/ui/androidx/WorkflowAndroidXSupport {
 	public static final field INSTANCE Lcom/squareup/workflow1/ui/androidx/WorkflowAndroidXSupport;
 	public final fun lifecycleOwnerFromContext (Landroid/content/Context;)Landroidx/lifecycle/LifecycleOwner;
 	public final fun lifecycleOwnerFromViewTreeOrContextOrNull (Landroid/view/View;)Landroidx/lifecycle/LifecycleOwner;
+	public final fun onBackPressedDispatcherOwner (Lcom/squareup/workflow1/ui/ViewEnvironment;Landroid/view/View;)Landroidx/activity/OnBackPressedDispatcherOwner;
+	public final fun onBackPressedDispatcherOwnerOrNull (Landroid/view/View;)Landroidx/activity/OnBackPressedDispatcherOwner;
 	public final fun stateRegistryOwnerFromViewTreeOrContext (Landroid/view/View;)Landroidx/savedstate/SavedStateRegistryOwner;
 }
 
@@ -285,8 +292,8 @@ public abstract interface class com/squareup/workflow1/ui/androidx/WorkflowLifec
 
 public final class com/squareup/workflow1/ui/androidx/WorkflowLifecycleOwner$Companion {
 	public final fun get (Landroid/view/View;)Lcom/squareup/workflow1/ui/androidx/WorkflowLifecycleOwner;
-	public final fun installOn (Landroid/view/View;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun installOn$default (Lcom/squareup/workflow1/ui/androidx/WorkflowLifecycleOwner$Companion;Landroid/view/View;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun installOn (Landroid/view/View;Landroidx/activity/OnBackPressedDispatcherOwner;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun installOn$default (Lcom/squareup/workflow1/ui/androidx/WorkflowLifecycleOwner$Companion;Landroid/view/View;Landroidx/activity/OnBackPressedDispatcherOwner;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class com/squareup/workflow1/ui/androidx/WorkflowSavedStateRegistryAggregator {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BackPressHandler.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/BackPressHandler.kt
@@ -1,15 +1,13 @@
 package com.squareup.workflow1.ui
 
-import android.content.Context
-import android.content.ContextWrapper
 import android.view.View
 import android.view.View.OnAttachStateChangeListener
 import androidx.activity.OnBackPressedCallback
-import androidx.activity.OnBackPressedDispatcherOwner
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewTreeLifecycleOwner
+import com.squareup.workflow1.ui.androidx.WorkflowAndroidXSupport.onBackPressedDispatcherOwnerOrNull
 
 /**
  * A function passed to [View.backPressedHandler], to be called if the back
@@ -87,7 +85,7 @@ private class AttachStateAndLifecycleObserver(
   private var lifecycleOrNull: Lifecycle? = null
 
   fun start() {
-    view.context.onBackPressedDispatcherOwnerOrNull()
+    view.onBackPressedDispatcherOwnerOrNull()
       ?.let { owner ->
         owner.onBackPressedDispatcher.addCallback(owner, onBackPressedCallback)
         view.addOnAttachStateChangeListener(this)
@@ -138,10 +136,3 @@ internal class NullableOnBackPressedCallback : OnBackPressedCallback(false) {
     handlerOrNull?.invoke()
   }
 }
-
-@WorkflowUiExperimentalApi
-public tailrec fun Context.onBackPressedDispatcherOwnerOrNull(): OnBackPressedDispatcherOwner? =
-  when (this) {
-    is OnBackPressedDispatcherOwner -> this
-    else -> (this as? ContextWrapper)?.baseContext?.onBackPressedDispatcherOwnerOrNull()
-  }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/OnBackPressedDispatcherOwnerKey.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/OnBackPressedDispatcherOwnerKey.kt
@@ -1,0 +1,15 @@
+package com.squareup.workflow1.ui
+
+import androidx.activity.OnBackPressedDispatcherOwner
+
+/**
+ * Used by container classes to ensure that
+ * [View.findViewTreeOnBackPressedDispatcherOwner][androidx.activity.findViewTreeOnBackPressedDispatcherOwner]
+ * works before new views are attached to their parents. Not intended for use by
+ * feature code.
+ */
+@WorkflowUiExperimentalApi
+public object OnBackPressedDispatcherOwnerKey :
+  ViewEnvironmentKey<OnBackPressedDispatcherOwner>() {
+  override val default: OnBackPressedDispatcherOwner get() = error("Unset")
+}

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowViewStub.kt
@@ -9,6 +9,7 @@ import androidx.annotation.IdRes
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.squareup.workflow1.ui.androidx.WorkflowAndroidXSupport.onBackPressedDispatcherOwner
 import com.squareup.workflow1.ui.androidx.WorkflowLifecycleOwner
 
 /**
@@ -231,10 +232,10 @@ public class WorkflowViewStub @JvmOverloads constructor(
 
     holder = rendering.toViewFactory(viewEnvironment)
       .startShowing(rendering, viewEnvironment, parent.context, parent) { view, doStart ->
-        WorkflowLifecycleOwner.installOn(view)
+        WorkflowLifecycleOwner.installOn(view, viewEnvironment.onBackPressedDispatcherOwner(parent))
         doStart()
-      }.also {
-        val newView = it.view
+      }.apply {
+        val newView = view
 
         if (inflatedId != NO_ID) newView.id = inflatedId
         if (updatesVisibility) newView.visibility = visibility

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/WorkflowAndroidXSupport.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/WorkflowAndroidXSupport.kt
@@ -3,10 +3,14 @@ package com.squareup.workflow1.ui.androidx
 import android.content.Context
 import android.content.ContextWrapper
 import android.view.View
+import androidx.activity.OnBackPressedDispatcherOwner
+import androidx.activity.findViewTreeOnBackPressedDispatcherOwner
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewTreeLifecycleOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.findViewTreeSavedStateRegistryOwner
+import com.squareup.workflow1.ui.OnBackPressedDispatcherOwnerKey
+import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import kotlin.reflect.KClass
 import kotlin.reflect.cast
@@ -48,6 +52,44 @@ public object WorkflowAndroidXSupport {
     checkNotNull(stateRegistryOwnerFromViewTreeOrContextOrNull(view)) {
       "Expected to find a SavedStateRegistryOwner either in a parent view or the Context of $view"
     }
+
+  /**
+   * Looks for an [OnBackPressedDispatcherOwner] in the receiving [ViewEnvironment].
+   * Failing that, falls through to [View.onBackPressedDispatcherOwnerOrNull].
+   * Patterned after the heuristic in Compose's `LocalOnBackPressedDispatcherOwner`.
+   *
+   * Mainly intended as support for finding the [OnBackPressedDispatcherOwner] parameter
+   * required by [WorkflowLifecycleOwner.installOn]. That is, this is for
+   * use by custom containers that can't use
+   * [WorkflowViewStub][com.squareup.workflow1.ui.WorkflowViewStub] or other standard
+   * containers, which have this call built in.
+   *
+   * @throws IllegalArgumentException if no [OnBackPressedDispatcherOwner] can be found
+   */
+  @WorkflowUiExperimentalApi
+  public fun ViewEnvironment.onBackPressedDispatcherOwner(
+    container: View
+  ): OnBackPressedDispatcherOwner {
+    return (map[OnBackPressedDispatcherOwnerKey] as? OnBackPressedDispatcherOwner)
+      ?: container.onBackPressedDispatcherOwnerOrNull()
+      ?: throw IllegalArgumentException(
+        "Expected to find an OnBackPressedDispatcherOwner in one of: $this " +
+          "bound to OnBackPressedDispatcherOwnerKey, or " +
+          "$container via findViewTreeOnBackPressedDispatcherOwner(), or " +
+          "up the Context chain of that view."
+      )
+  }
+
+  /**
+   * Looks for a [View]'s [OnBackPressedDispatcherOwner] via the usual
+   * [findViewTreeOnBackPressedDispatcherOwner] method, and if that fails
+   * checks its [Context][View.getContext].
+   */
+  @WorkflowUiExperimentalApi
+  public fun View.onBackPressedDispatcherOwnerOrNull(): OnBackPressedDispatcherOwner? {
+    return findViewTreeOnBackPressedDispatcherOwner()
+      ?: context.ownerOrNull(OnBackPressedDispatcherOwner::class)
+  }
 
   /**
    * Tries to get the parent [SavedStateRegistryOwner] from the current view via

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BackStackContainer.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BackStackContainer.kt
@@ -23,6 +23,7 @@ import com.squareup.workflow1.ui.R
 import com.squareup.workflow1.ui.ScreenViewHolder
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.androidx.WorkflowAndroidXSupport.onBackPressedDispatcherOwner
 import com.squareup.workflow1.ui.androidx.WorkflowAndroidXSupport.stateRegistryOwnerFromViewTreeOrContext
 import com.squareup.workflow1.ui.androidx.WorkflowLifecycleOwner
 import com.squareup.workflow1.ui.canShow
@@ -94,7 +95,7 @@ public open class BackStackContainer @JvmOverloads constructor(
       contextForNewView = this.context,
       container = this,
       viewStarter = { view, doStart ->
-        WorkflowLifecycleOwner.installOn(view)
+        WorkflowLifecycleOwner.installOn(view, environment.onBackPressedDispatcherOwner(this))
         doStart()
       }
     )

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogSession.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/DialogSession.kt
@@ -10,13 +10,18 @@ import android.view.KeyEvent.KEYCODE_BACK
 import android.view.KeyEvent.KEYCODE_ESCAPE
 import android.view.MotionEvent
 import android.view.Window.Callback
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.OnBackPressedDispatcherOwner
 import androidx.core.view.doOnAttach
 import androidx.core.view.doOnDetach
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.squareup.workflow1.ui.Compatible
+import com.squareup.workflow1.ui.OnBackPressedDispatcherOwnerKey
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.androidx.WorkflowAndroidXSupport.onBackPressedDispatcherOwnerOrNull
 import com.squareup.workflow1.ui.androidx.WorkflowLifecycleOwner
 import com.squareup.workflow1.ui.androidx.WorkflowSavedStateRegistryAggregator
 
@@ -150,12 +155,29 @@ internal class DialogSession(
     }
 
     dialog.decorView.also { decorView ->
+      // We are more defensive than usual about this to ease migration of existing apps
+      // to ComponentDialog. Perhaps we will never enforce that rigorously. It really only
+      // matters for ScreenOverlay, and that's enforced via ComponentDialog.setContent.
+      // Note that onBackPressedDispatcherOwnerOrNull() searches through Context as well,
+      // so 99% chance we'll hit the Activity before the stub.
+      val onBack = (dialog as? OnBackPressedDispatcherOwner)
+        ?: holder.environment.map[OnBackPressedDispatcherOwnerKey] as? OnBackPressedDispatcherOwner
+        ?: decorView.onBackPressedDispatcherOwnerOrNull()
+        ?: object : OnBackPressedDispatcherOwner {
+          override fun getLifecycle(): Lifecycle =
+            error("To support back press handling extend ComponentDialog: $dialog")
+
+          override fun getOnBackPressedDispatcher(): OnBackPressedDispatcher =
+            error("To support back press handling extend ComponentDialog: $dialog")
+        }
+
       // Implementations of buildDialog may set their own WorkflowLifecycleOwner on the
       // content view, so to avoid interfering with them we also set it here. When the views
       // are attached, this will become the parent lifecycle of the one from buildDialog if
       // any, and so we can use our lifecycle to destroy-on-detach the dialog hierarchy.
       WorkflowLifecycleOwner.installOn(
         decorView,
+        onBack,
         findParentLifecycle = { parentLifecycleOwner.lifecycle }
       )
       // Ensure that each dialog has its own SavedStateRegistryOwner,

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/OverlayDialogHolder.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/OverlayDialogHolder.kt
@@ -4,8 +4,8 @@ import android.app.Dialog
 import android.graphics.Rect
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.androidx.WorkflowAndroidXSupport.onBackPressedDispatcherOwnerOrNull
 import com.squareup.workflow1.ui.compatible
-import com.squareup.workflow1.ui.onBackPressedDispatcherOwnerOrNull
 import com.squareup.workflow1.ui.show
 
 /**
@@ -50,13 +50,11 @@ public interface OverlayDialogHolder<in OverlayT : Overlay> {
    * instead of [Dialog.onBackPressed].
    *
    * The default implementation provided by the factory function below looks for the
-   * [OnBackPressedDispatcherOwner][com.squareup.workflow1.ui.onBackPressedDispatcherOwnerOrNull]
+   * [OnBackPressedDispatcherOwner][onBackPressedDispatcherOwnerOrNull]
    * and invokes its [onBackPressed][androidx.activity.OnBackPressedDispatcher.onBackPressed]
    * method.
    */
-  @Deprecated(
-    "This will be deleted in the next release, use ComponentDialog and OnBackPressedDispatcher."
-  )
+  @Deprecated("This will soon be deleted. Use ComponentDialog and OnBackPressedDispatcher.")
   public val onBackPressed: (() -> Unit)?
 
   public companion object {
@@ -65,7 +63,7 @@ public interface OverlayDialogHolder<in OverlayT : Overlay> {
       dialog: Dialog,
       onUpdateBounds: ((Rect) -> Unit)? = { dialog.setBounds(it) },
       onBackPressed: (() -> Unit)? = {
-        dialog.context.onBackPressedDispatcherOwnerOrNull()
+        dialog.decorView.onBackPressedDispatcherOwnerOrNull()
           ?.onBackPressedDispatcher
           ?.let {
             if (it.hasEnabledCallbacks()) it.onBackPressed()


### PR DESCRIPTION
`fun View.findViewTreeOnBackPressedDispatcherOwner()` is AndroidX's preferred entry point to the exciting new world of `OnBackPressedDispatcherOwner`. With this PR we support it explicitly, in particular taking care to ensure that it can be called by newly constructed views before they have been attached to a parent. That is, we take care to make eager calls `View.setViewTreeSavedStateRegistryOwner` on every view we build.

We accomplish this mainly by riding the rails previously laid down via `WorkflowLifecycleOwner.installOn`, which now requires an `OnBackPressedDispatcherOwner` parameter. (This is the method used by `WorkflowViewStub` _et al_ to ensure that we're managing the JetPack Lifecycle correctly, and `OnBackPressedDispatcherOwner` is just another piece of that puzzle.)

In aid of that, we introduce a new `ViewEnvironmentKey`, `OnBackPressedDispatcherOwnerKey`. It is initialized by `WorkflowLayout`, our new `ComponentDialog.setContent` extension, and `@Composable fun WorkflowRendering()`. This key is not intended for use by feature code, it's more of an implementation detail that has to stay public to allow custom containers to be built. It ensures that `WorkflowViewStub` and friends will have access to the correct `OnBackPressedDispatcherOwner` before they have access to a parent view.

- [ ] TODO: add tests of `@Composable fun BackHandler()`, in both activity and dialog windows.