### PR TITLE
Update Turbine to 0.13.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,7 +82,7 @@ squareup-workflow = "1.0.0"
 
 timber = "4.7.1"
 truth = "1.1.3"
-turbine = "0.12.1"
+turbine = "0.13.0"
 vanniktech-publish = "0.22.0"
 
 [plugins]

--- a/workflow-testing/dependencies/runtimeClasspath.txt
+++ b/workflow-testing/dependencies/runtimeClasspath.txt
@@ -2,13 +2,13 @@
 :workflow-config:config-jvm
 :workflow-core
 :workflow-runtime
-app.cash.turbine:turbine-jvm:0.12.1
-app.cash.turbine:turbine:0.12.1
+app.cash.turbine:turbine-jvm:0.13.0
+app.cash.turbine:turbine:0.13.0
 com.squareup.okio:okio-jvm:3.0.0
 com.squareup.okio:okio:3.0.0
 org.jetbrains.kotlin:kotlin-bom:1.8.10
 org.jetbrains.kotlin:kotlin-reflect:1.8.10
-org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20
+org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10
 org.jetbrains.kotlin:kotlin-stdlib:1.8.10

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkerTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkerTester.kt
@@ -34,7 +34,8 @@ public interface WorkerTester<T> {
   public suspend fun nextOutput(): T
 
   /**
-   * Throws an [AssertionError] if an output has been emitted since the last call to [nextOutput].
+   * Throws an [AssertionError] if an output, error, or completion has been emitted since the last
+   * call to [nextOutput].
    */
   public fun assertNoOutput()
 
@@ -83,7 +84,9 @@ public fun <T> Worker<T>.test(
           try {
             expectNoEvents()
           } catch (e: AssertionError) {
-            throw AssertionError("Expected no output to have been emitted.")
+            throw AssertionError(
+              "Expected no output, completion, or error to have been emitted."
+            )
           }
         }
 

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/WorkerTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/WorkerTesterTest.kt
@@ -15,11 +15,26 @@ import kotlin.test.assertFalse
 @OptIn(ExperimentalCoroutinesApi::class)
 class WorkerTesterTest {
 
-  @Test fun `assertNoOutput passes after worker finishes without emitting`() {
-    val worker = Worker.finished<Unit>()
+  @Test fun `assertNoOutput succeeds in live flow without output`() {
+    val worker = Worker.create<Unit> {
+      suspendCancellableCoroutine { }
+    }
     worker.test {
       assertNoOutput()
     }
+  }
+
+  @Test fun `assertNoOutput fails after worker finishes without emitting`() {
+    val worker = Worker.finished<Unit>()
+    val error = assertFailsWith<AssertionError> {
+      worker.test {
+        assertNoOutput()
+      }
+    }
+    assertEquals(
+      expected = "Expected no output, completion, or error to have been emitted.",
+      actual = error.message
+    )
   }
 
   @Test fun `assertNotFinished fails after worker finished`() {
@@ -46,7 +61,10 @@ class WorkerTesterTest {
         assertNoOutput()
       }
     }
-    assertEquals("Expected no output to have been emitted.", error.message)
+    assertEquals(
+      expected = "Expected no output, completion, or error to have been emitted.",
+      actual = error.message
+    )
   }
 
   @Test fun `assertFinished passes when worker finishes without emitting`() {


### PR DESCRIPTION
Update Turbine to 0.13.0; Update WorkerTester

assertNoOutput now fails if there is a completion of the WOrker's flow.