### PR TITLE
Add CoroutineScope to initialState; SessionWorkflow to aid rollout

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -91,6 +91,21 @@ public final class com/squareup/workflow1/PropsUpdated : com/squareup/workflow1/
 	public static final field INSTANCE Lcom/squareup/workflow1/PropsUpdated;
 }
 
+public abstract class com/squareup/workflow1/SessionWorkflow : com/squareup/workflow1/StatefulWorkflow {
+	public fun <init> ()V
+	public final fun initialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;)Ljava/lang/Object;
+	public abstract fun initialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlinx/coroutines/CoroutineScope;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow1/SessionWorkflowKt {
+	public static final fun sessionWorkflow (Lcom/squareup/workflow1/Workflow$Companion;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow1/SessionWorkflow;
+	public static final fun sessionWorkflow (Lcom/squareup/workflow1/Workflow$Companion;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/SessionWorkflow;
+	public static final fun sessionWorkflow (Lcom/squareup/workflow1/Workflow$Companion;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;)Lcom/squareup/workflow1/SessionWorkflow;
+	public static final fun sessionWorkflow (Lcom/squareup/workflow1/Workflow$Companion;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)Lcom/squareup/workflow1/SessionWorkflow;
+	public static synthetic fun sessionWorkflow$default (Lcom/squareup/workflow1/Workflow$Companion;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lcom/squareup/workflow1/SessionWorkflow;
+	public static synthetic fun sessionWorkflow$default (Lcom/squareup/workflow1/Workflow$Companion;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lcom/squareup/workflow1/SessionWorkflow;
+}
+
 public abstract interface class com/squareup/workflow1/Sink {
 	public abstract fun send (Ljava/lang/Object;)V
 }
@@ -142,6 +157,7 @@ public abstract class com/squareup/workflow1/StatefulWorkflow : com/squareup/wor
 	public final fun asStatefulWorkflow ()Lcom/squareup/workflow1/StatefulWorkflow;
 	public fun getCachedIdentifier ()Lcom/squareup/workflow1/WorkflowIdentifier;
 	public abstract fun initialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;)Ljava/lang/Object;
+	public fun initialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlinx/coroutines/CoroutineScope;)Ljava/lang/Object;
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun render (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/StatefulWorkflow$RenderContext;)Ljava/lang/Object;
 	public fun setCachedIdentifier (Lcom/squareup/workflow1/WorkflowIdentifier;)V
@@ -238,6 +254,9 @@ public final class com/squareup/workflow1/WorkflowAction$Updater {
 	public final fun getState ()Ljava/lang/Object;
 	public final fun setOutput (Ljava/lang/Object;)V
 	public final fun setState (Ljava/lang/Object;)V
+}
+
+public abstract interface annotation class com/squareup/workflow1/WorkflowExperimentalApi : java/lang/annotation/Annotation {
 }
 
 public final class com/squareup/workflow1/WorkflowIdentifier {

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/LifecycleWorker.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/LifecycleWorker.kt
@@ -14,6 +14,10 @@ import kotlin.jvm.JvmName
  *
  * A [Worker] is stopped when its parent [Workflow] finishes a render pass without running the
  * worker, or when the parent workflow is itself torn down.
+ *
+ * Note that there is currently an [issue](https://github.com/square/workflow-kotlin/issues/1093)
+ * which can effect whether a [LifecycleWorker] is ever executed.
+ * See more details at [BaseRenderContext.runningSideEffect].
  */
 public abstract class LifecycleWorker : Worker<Nothing> {
 

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/SessionWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/SessionWorkflow.kt
@@ -1,0 +1,175 @@
+package com.squareup.workflow1
+
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * An extension of [StatefulWorkflow] that gives [initialState] a [CoroutineScope]
+ * that corresponds with the lifetime of _session_ driven by this Workflow.
+ *
+ * A session begins the first time a parent passes a child [Workflow] of a particular type to
+ * [renderChild] with a particular [key] parameter. It ends when the parent executes [render]
+ * without making a matching [renderChild] call. The [CoroutineScope] that is passed to
+ * [initialState] is created when a session starts (when [renderChild] is first called), and
+ * [cancelled][kotlinx.coroutines.Job.cancel] when the session ends.
+ *
+ * This API extension exists on [StatefulWorkflow] as well, but it is confusing because the version
+ * of [initialState] that does not have the [CoroutineScope] must also be implemented as it is
+ * an abstract fun, even though it would never be used.
+ * With this version, that confusion is removed and only the version of [initialState] with the
+ * [CoroutineScope] must be implemented.
+ */
+@WorkflowExperimentalApi
+public abstract class SessionWorkflow<
+  in PropsT,
+  StateT,
+  out OutputT,
+  out RenderingT
+  > : StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>() {
+
+  /**
+   * @see [StatefulWorkflow.initialState] for kdoc on the base function of this method.
+   *
+   * This version adds the following:
+   * @param workflowScope A [CoroutineScope] that has been created when this Workflow is first
+   * rendered and canceled when it is no longer rendered.
+   *
+   * This [CoroutineScope] can be used to:
+   *
+   *  - set reliable teardown hooks, e.g. via [Job.invokeOnCompletion][kotlinx.coroutines.Job.invokeOnCompletion].
+   *
+   *  -  own the transforms on a [StateFlow][kotlinx.coroutines.flow.StateFlow],
+   *     linking them to the lifetime of a Workflow session. For example,
+   *     here is how you might safely combine two `StateFlow`s:
+   *
+   *     data class MyState(
+   *       val derivedValue: String,
+   *       val derivedWorker: Worker<String>
+   *     )
+   *
+   *     override fun initialState(
+   *       props: Unit,
+   *       snapshot: Snapshot?,
+   *       workflowScope: CoroutineScope
+   *     ): MyState {
+   *       val transformedStateFlow = stateFlow1.combine(stateFlow2, {val1, val2 -> val1 - val2}).
+   *         stateIn(workflowScope, SharingStarted.Eagerly, ${stateFlow1.value}-${stateFlow2.value})
+   *
+   *       return MyState(
+   *         transformedStateFlow.value,
+   *         transformedStateFlow.asWorker()
+   *       )
+   *     }
+   *
+   * **Note Carefully**: Neither [workflowScope] nor any of these transformed/computed dependencies
+   * should be stored by this Workflow instance. This could be re-created, or re-used unexpectedly
+   * and should not have its own state. Instead, the transformed/computed dependencies must be
+   * put into the [StateT] of this Workflow in order to be properly maintained.
+   */
+  public abstract override fun initialState(
+    props: PropsT,
+    snapshot: Snapshot?,
+    workflowScope: CoroutineScope
+  ): StateT
+
+  /**
+   * Do not use this in favor of the version of [initialState] above that includes the Workflow's
+   * [CoroutineScope]
+   */
+  public final override fun initialState(
+    props: PropsT,
+    snapshot: Snapshot?
+  ): StateT {
+    error("SessionWorkflow should never call initialState without the CoroutineScope.")
+  }
+}
+
+/**
+ * Returns a [SessionWorkflow] implemented via the given functions.
+ */
+@WorkflowExperimentalApi
+public inline fun <PropsT, StateT, OutputT, RenderingT> Workflow.Companion.sessionWorkflow(
+  crossinline initialState: (PropsT, Snapshot?, CoroutineScope) -> StateT,
+  crossinline render: BaseRenderContext<PropsT, StateT, OutputT>.(
+    props: PropsT,
+    state: StateT
+  ) -> RenderingT,
+  crossinline snapshot: (StateT) -> Snapshot?,
+  crossinline onPropsChanged: (
+    old: PropsT,
+    new: PropsT,
+    state: StateT
+  ) -> StateT = { _, _, state -> state }
+): SessionWorkflow<PropsT, StateT, OutputT, RenderingT> =
+  object : SessionWorkflow<PropsT, StateT, OutputT, RenderingT>() {
+    override fun initialState(
+      props: PropsT,
+      snapshot: Snapshot?,
+      workflowScope: CoroutineScope
+    ): StateT = initialState(props, snapshot, workflowScope)
+
+    override fun onPropsChanged(
+      old: PropsT,
+      new: PropsT,
+      state: StateT
+    ): StateT = onPropsChanged(old, new, state)
+
+    override fun render(
+      renderProps: PropsT,
+      renderState: StateT,
+      context: RenderContext
+    ): RenderingT = render(context, renderProps, renderState)
+
+    override fun snapshotState(state: StateT) = snapshot(state)
+  }
+
+/**
+ * Returns a [SessionWorkflow], with no props, implemented via the given functions.
+ */
+@WorkflowExperimentalApi
+public inline fun <StateT, OutputT, RenderingT> Workflow.Companion.sessionWorkflow(
+  crossinline initialState: (Snapshot?, CoroutineScope) -> StateT,
+  crossinline render: BaseRenderContext<Unit, StateT, OutputT>.(state: StateT) -> RenderingT,
+  crossinline snapshot: (StateT) -> Snapshot?
+): SessionWorkflow<Unit, StateT, OutputT, RenderingT> = sessionWorkflow(
+  { _, initialSnapshot, workflowScope -> initialState(initialSnapshot, workflowScope) },
+  { _, state -> render(state) },
+  snapshot
+)
+
+/**
+ * Returns a [SessionWorkflow] implemented via the given functions.
+ *
+ * This overload does not support snapshotting, but there are other overloads that do.
+ */
+@WorkflowExperimentalApi
+public inline fun <PropsT, StateT, OutputT, RenderingT> Workflow.Companion.sessionWorkflow(
+  crossinline initialState: (PropsT, CoroutineScope) -> StateT,
+  crossinline render: BaseRenderContext<PropsT, StateT, OutputT>.(
+    props: PropsT,
+    state: StateT
+  ) -> RenderingT,
+  crossinline onPropsChanged: (
+    old: PropsT,
+    new: PropsT,
+    state: StateT
+  ) -> StateT = { _, _, state -> state }
+): SessionWorkflow<PropsT, StateT, OutputT, RenderingT> = sessionWorkflow(
+  { props, _, workflowScope -> initialState(props, workflowScope) },
+  render,
+  { null },
+  onPropsChanged
+)
+
+/**
+ * Returns a [SessionWorkflow], with no props, implemented via the given function.
+ *
+ * This overload does not support snapshots, but there are others that do.
+ */
+@WorkflowExperimentalApi
+public inline fun <StateT, OutputT, RenderingT> Workflow.Companion.sessionWorkflow(
+  crossinline initialState: (CoroutineScope) -> StateT,
+  crossinline render: BaseRenderContext<Unit, StateT, OutputT>.(state: StateT) -> RenderingT
+): SessionWorkflow<Unit, StateT, OutputT, RenderingT> = sessionWorkflow(
+  { _, workflowScope -> initialState(workflowScope) },
+  { _, state -> render(state) }
+)

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
@@ -1,4 +1,3 @@
-@file:Suppress("DEPRECATION")
 @file:JvmMultifileClass
 @file:JvmName("Workflows")
 
@@ -6,7 +5,7 @@ package com.squareup.workflow1
 
 import com.squareup.workflow1.StatefulWorkflow.RenderContext
 import com.squareup.workflow1.WorkflowAction.Companion.toString
-import kotlin.LazyThreadSafetyMode.NONE
+import kotlinx.coroutines.CoroutineScope
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
@@ -92,6 +91,18 @@ public abstract class StatefulWorkflow<
     props: PropsT,
     snapshot: Snapshot?
   ): StateT
+
+  /**
+   * @see [SessionWorkflow.initialState].
+   * This method should only be used with a [SessionWorkflow]. It's just a pass through here so
+   * that we can add this behavior for [SessionWorkflow] without disrupting all [StatefulWorkflow]s.
+   */
+  @WorkflowExperimentalApi
+  public open fun initialState(
+    props: PropsT,
+    snapshot: Snapshot?,
+    workflowScope: CoroutineScope
+  ): StateT = initialState(props, snapshot)
 
   /**
    * Called from [RenderContext.renderChild] instead of [initialState] when the workflow is already

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowExperimentApi.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowExperimentApi.kt
@@ -1,0 +1,18 @@
+package com.squareup.workflow1
+
+import kotlin.RequiresOptIn.Level.ERROR
+import kotlin.annotation.AnnotationRetention.BINARY
+
+/**
+ * This is used to mark new core Workflow API that is still considered experimental.
+ */
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.PROPERTY,
+  AnnotationTarget.FUNCTION,
+  AnnotationTarget.TYPEALIAS
+)
+@MustBeDocumented
+@Retention(value = BINARY)
+@RequiresOptIn(level = ERROR)
+public annotation class WorkflowExperimentalApi

--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -1,6 +1,6 @@
 public final class com/squareup/workflow1/NoopWorkflowInterceptor : com/squareup/workflow1/WorkflowInterceptor {
 	public static final field INSTANCE Lcom/squareup/workflow1/NoopWorkflowInterceptor;
-	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRenderAndSnapshot (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/RenderingAndSnapshot;
@@ -41,7 +41,7 @@ public class com/squareup/workflow1/SimpleLoggingWorkflowInterceptor : com/squar
 	protected fun logAfterMethod (Ljava/lang/String;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;[Lkotlin/Pair;)V
 	protected fun logBeforeMethod (Ljava/lang/String;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;[Lkotlin/Pair;)V
 	protected fun logError (Ljava/lang/String;)V
-	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRenderAndSnapshot (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/RenderingAndSnapshot;
@@ -66,7 +66,7 @@ public abstract interface annotation class com/squareup/workflow1/WorkflowExperi
 }
 
 public abstract interface class com/squareup/workflow1/WorkflowInterceptor {
-	public abstract fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public abstract fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public abstract fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public abstract fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public abstract fun onRenderAndSnapshot (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/RenderingAndSnapshot;
@@ -76,7 +76,7 @@ public abstract interface class com/squareup/workflow1/WorkflowInterceptor {
 }
 
 public final class com/squareup/workflow1/WorkflowInterceptor$DefaultImpls {
-	public static fun onInitialState (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public static fun onInitialState (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public static fun onPropsChanged (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public static fun onRender (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public static fun onRenderAndSnapshot (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/RenderingAndSnapshot;

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/SimpleLoggingWorkflowInterceptor.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/SimpleLoggingWorkflowInterceptor.kt
@@ -22,10 +22,11 @@ public open class SimpleLoggingWorkflowInterceptor : WorkflowInterceptor {
   override fun <P, S> onInitialState(
     props: P,
     snapshot: Snapshot?,
-    proceed: (P, Snapshot?) -> S,
+    workflowScope: CoroutineScope,
+    proceed: (P, Snapshot?, CoroutineScope) -> S,
     session: WorkflowSession
   ): S = logMethod("onInitialState", session) {
-    proceed(props, snapshot)
+    proceed(props, snapshot, workflowScope)
   }
 
   override fun <P, S> onPropsChanged(

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptor.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptor.kt
@@ -33,15 +33,16 @@ internal class ChainedWorkflowInterceptor(
   override fun <P, S> onInitialState(
     props: P,
     snapshot: Snapshot?,
-    proceed: (P, Snapshot?) -> S,
+    workflowScope: CoroutineScope,
+    proceed: (P, Snapshot?, CoroutineScope) -> S,
     session: WorkflowSession
   ): S {
     val chainedProceed = interceptors.foldRight(proceed) { workflowInterceptor, proceedAcc ->
-      { props, snapshot ->
-        workflowInterceptor.onInitialState(props, snapshot, proceedAcc, session)
+      { props, snapshot, workflowScope ->
+        workflowInterceptor.onInitialState(props, snapshot, workflowScope, proceedAcc, session)
       }
     }
-    return chainedProceed(props, snapshot)
+    return chainedProceed(props, snapshot, workflowScope)
   }
 
   override fun <P, S> onPropsChanged(

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
@@ -10,6 +10,7 @@ import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.TreeSnapshot
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
+import com.squareup.workflow1.WorkflowExperimentalApi
 import com.squareup.workflow1.WorkflowIdentifier
 import com.squareup.workflow1.WorkflowInterceptor
 import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
@@ -41,6 +42,7 @@ import kotlin.coroutines.CoroutineContext
  * hard-coded values added to worker contexts. It must not contain a [Job] element (it would violate
  * structured concurrency).
  */
+@OptIn(WorkflowExperimentalApi::class)
 internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   val id: WorkflowNodeId,
   workflow: StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>,
@@ -93,7 +95,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
     interceptor.onSessionStarted(this, this)
 
     state = interceptor.intercept(workflow, this)
-      .initialState(initialProps, snapshot?.workflowSnapshot)
+      .initialState(initialProps, snapshot?.workflowSnapshot, this)
   }
 
   override fun toString(): String {

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/SimpleLoggingWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/SimpleLoggingWorkflowInterceptorTest.kt
@@ -22,7 +22,13 @@ internal class SimpleLoggingWorkflowInterceptorTest {
 
   @Test fun onInitialState_handles_logging_exceptions() {
     val interceptor = ErrorLoggingInterceptor()
-    interceptor.onInitialState(Unit, null, { _, _ -> }, TestWorkflowSession)
+    interceptor.onInitialState(
+      Unit,
+      null,
+      CoroutineScope(EmptyCoroutineContext),
+      { _, _, _ -> },
+      TestWorkflowSession
+    )
 
     assertEquals(ErrorLoggingInterceptor.EXPECTED_ERRORS, interceptor.errors)
   }
@@ -77,7 +83,6 @@ internal class SimpleLoggingWorkflowInterceptorTest {
   }
 
   private object TestWorkflowSession : WorkflowSession {
-    @OptIn(ExperimentalStdlibApi::class)
     override val identifier: WorkflowIdentifier = unsnapshottableIdentifier(typeOf<Unit>())
     override val renderKey: String get() = "key"
     override val sessionId: Long get() = 42

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.CoroutineContext.Key
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -30,11 +31,17 @@ internal class WorkflowInterceptorTest {
     assertSame(workflow, intercepted)
   }
 
-  @Test fun intercept_intercepts_calls_to_initialState() {
+  @OptIn(WorkflowExperimentalApi::class)
+  @Test
+  fun intercept_intercepts_calls_to_initialState() {
     val recorder = RecordingWorkflowInterceptor()
     val intercepted = recorder.intercept(TestWorkflow, TestWorkflow.session)
 
-    val state = intercepted.initialState("props", Snapshot.of("snapshot"))
+    val state = intercepted.initialState(
+      "props",
+      Snapshot.of("snapshot"),
+      CoroutineScope(EmptyCoroutineContext)
+    )
 
     assertEquals("props|snapshot", state)
     assertEquals(listOf("BEGIN|onInitialState", "END|onInitialState"), recorder.consumeEventNames())

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -1,5 +1,4 @@
 @file:Suppress("EXPERIMENTAL_API_USAGE")
-@file:OptIn(ExperimentalCoroutinesApi::class)
 
 package com.squareup.workflow1.internal
 
@@ -34,7 +33,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.Unconfined
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -880,13 +878,14 @@ internal class WorkflowNodeTest {
       override fun <P, S> onInitialState(
         props: P,
         snapshot: Snapshot?,
-        proceed: (P, Snapshot?) -> S,
+        workflowScope: CoroutineScope,
+        proceed: (P, Snapshot?, CoroutineScope) -> S,
         session: WorkflowSession
       ): S {
         interceptedProps = props as String
         interceptedSnapshot = snapshot!!
         interceptedSession = session
-        return proceed(props, snapshot)
+        return proceed(props, snapshot, workflowScope)
           .also { interceptedState = it as String }
       }
     }

--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -7,7 +7,7 @@ public final class com/squareup/workflow1/testing/HeadlessIntegrationTestKt {
 
 public final class com/squareup/workflow1/testing/RenderIdempotencyChecker : com/squareup/workflow1/WorkflowInterceptor {
 	public static final field INSTANCE Lcom/squareup/workflow1/testing/RenderIdempotencyChecker;
-	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRenderAndSnapshot (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/RenderingAndSnapshot;

--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -1,3 +1,10 @@
+public final class com/squareup/workflow1/testing/HeadlessIntegrationTestKt {
+	public static final fun headlessIntegrationTest (Lcom/squareup/workflow1/Workflow;Lkotlin/coroutines/CoroutineContext;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function2;JLkotlin/jvm/functions/Function2;)V
+	public static final fun headlessIntegrationTest (Lcom/squareup/workflow1/Workflow;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/coroutines/CoroutineContext;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function2;JLkotlin/jvm/functions/Function2;)V
+	public static synthetic fun headlessIntegrationTest$default (Lcom/squareup/workflow1/Workflow;Lkotlin/coroutines/CoroutineContext;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function2;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun headlessIntegrationTest$default (Lcom/squareup/workflow1/Workflow;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/coroutines/CoroutineContext;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function2;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+}
+
 public final class com/squareup/workflow1/testing/RenderIdempotencyChecker : com/squareup/workflow1/WorkflowInterceptor {
 	public static final field INSTANCE Lcom/squareup/workflow1/testing/RenderIdempotencyChecker;
 	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
@@ -153,5 +160,20 @@ public final class com/squareup/workflow1/testing/WorkflowTestRuntimeKt {
 	public static synthetic fun launchForTestingFromStateWith$default (Lcom/squareup/workflow1/StatefulWorkflow;Ljava/lang/Object;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun launchForTestingWith (Lcom/squareup/workflow1/StatefulWorkflow;Ljava/lang/Object;Lcom/squareup/workflow1/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static synthetic fun launchForTestingWith$default (Lcom/squareup/workflow1/StatefulWorkflow;Ljava/lang/Object;Lcom/squareup/workflow1/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow1/testing/WorkflowTurbine {
+	public static final field Companion Lcom/squareup/workflow1/testing/WorkflowTurbine$Companion;
+	public static final field WORKFLOW_TEST_DEFAULT_TIMEOUT_MS J
+	public fun <init> (Ljava/lang/Object;Lapp/cash/turbine/ReceiveTurbine;)V
+	public final fun awaitNext (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun awaitNext$default (Lcom/squareup/workflow1/testing/WorkflowTurbine;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun awaitNextRendering (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun awaitNextRenderingSatisfying (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getFirstRendering ()Ljava/lang/Object;
+	public final fun skipRenderings (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow1/testing/WorkflowTurbine$Companion {
 }
 

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/HeadlessIntegrationTest.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/HeadlessIntegrationTest.kt
@@ -1,0 +1,189 @@
+package com.squareup.workflow1.testing
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.test
+import com.squareup.workflow1.RuntimeConfig
+import com.squareup.workflow1.RuntimeConfigOptions
+import com.squareup.workflow1.Workflow
+import com.squareup.workflow1.WorkflowInterceptor
+import com.squareup.workflow1.renderWorkflowIn
+import com.squareup.workflow1.testing.WorkflowTurbine.Companion.WORKFLOW_TEST_DEFAULT_TIMEOUT_MS
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * This is a test harness to run integration tests for a Workflow tree. The parameters passed here are
+ * the same as those to start a Workflow runtime with [renderWorkflowIn] except for ignoring
+ * state persistence as that is not needed for this style of test.
+ *
+ * The [coroutineContext] rather than a [CoroutineScope] is passed so that this harness handles the
+ * scope for the Workflow runtime for you but you can still specify context for it.
+ *
+ * A [testTimeout] may be specified to override the default [WORKFLOW_TEST_DEFAULT_TIMEOUT_MS] for
+ * any particular test. This is the max amount of time the test could spend waiting on a rendering.
+ *
+ * This will start the Workflow runtime (with params as passed) rooted at whatever Workflow
+ * it is called on and then create a [WorkflowTurbine] for its renderings and run [testCase] on that.
+ * [testCase] can thus drive the test scenario and assert against renderings.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+public fun <PropsT, OutputT, RenderingT> Workflow<PropsT, OutputT, RenderingT>.headlessIntegrationTest(
+  props: StateFlow<PropsT>,
+  coroutineContext: CoroutineContext = UnconfinedTestDispatcher(),
+  interceptors: List<WorkflowInterceptor> = emptyList(),
+  runtimeConfig: RuntimeConfig = RuntimeConfigOptions.DEFAULT_CONFIG,
+  onOutput: suspend (OutputT) -> Unit = {},
+  testTimeout: Long = WORKFLOW_TEST_DEFAULT_TIMEOUT_MS,
+  testCase: suspend WorkflowTurbine<RenderingT>.() -> Unit
+) {
+  val workflow = this
+
+  runTest(
+    context = coroutineContext,
+    timeout = testTimeout.milliseconds
+  ) {
+    // We use a sub-scope so that we can cancel the Workflow runtime when we are done with it so that
+    // tests don't all have to do that themselves.
+    val workflowRuntimeScope = CoroutineScope(coroutineContext)
+    val renderings = renderWorkflowIn(
+      workflow = workflow,
+      props = props,
+      scope = workflowRuntimeScope,
+      interceptors = interceptors,
+      runtimeConfig = runtimeConfig,
+      onOutput = onOutput
+    )
+
+    val firstRendering = renderings.value.rendering
+
+    // Drop one as its provided separately via `firstRendering`.
+    renderings.drop(1).map {
+      it.rendering
+    }.test {
+      val workflowTurbine = WorkflowTurbine(
+        firstRendering,
+        this
+      )
+      workflowTurbine.testCase()
+      cancelAndIgnoreRemainingEvents()
+    }
+    workflowRuntimeScope.cancel()
+  }
+}
+
+/**
+ * Version of [headlessIntegrationTest] that does not require props. For Workflows that have [Unit]
+ * props type.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+public fun <OutputT, RenderingT> Workflow<Unit, OutputT, RenderingT>.headlessIntegrationTest(
+  coroutineContext: CoroutineContext = UnconfinedTestDispatcher(),
+  interceptors: List<WorkflowInterceptor> = emptyList(),
+  runtimeConfig: RuntimeConfig = RuntimeConfigOptions.DEFAULT_CONFIG,
+  onOutput: suspend (OutputT) -> Unit = {},
+  testTimeout: Long = WORKFLOW_TEST_DEFAULT_TIMEOUT_MS,
+  testCase: suspend WorkflowTurbine<RenderingT>.() -> Unit
+): Unit = headlessIntegrationTest(
+  props = MutableStateFlow(Unit).asStateFlow(),
+  coroutineContext = coroutineContext,
+  interceptors = interceptors,
+  runtimeConfig = runtimeConfig,
+  onOutput = onOutput,
+  testTimeout = testTimeout,
+  testCase = testCase
+)
+
+/**
+ * Simple wrapper around a [ReceiveTurbine] of [RenderingT] to provide convenience helper methods specific
+ * to Workflow renderings.
+ *
+ * @property firstRendering The first rendering of the Workflow runtime is made synchronously. This is
+ *   provided separately if any assertions or operations are needed from it.
+ */
+public class WorkflowTurbine<RenderingT>(
+  public val firstRendering: RenderingT,
+  private val receiveTurbine: ReceiveTurbine<RenderingT>
+) {
+  private var usedFirst = false
+
+  /**
+   * Suspend waiting for the next rendering to be produced by the Workflow runtime. Note this includes
+   * the first (synchronously made) rendering.
+   *
+   * @return the rendering.
+   */
+  public suspend fun awaitNextRendering(): RenderingT {
+    if (!usedFirst) {
+      usedFirst = true
+      return firstRendering
+    }
+    return receiveTurbine.awaitItem()
+  }
+
+  public suspend fun skipRenderings(count: Int) {
+    val skippedCount = if (!usedFirst) {
+      usedFirst = true
+      count - 1
+    } else {
+      count
+    }
+
+    if (skippedCount > 0) {
+      receiveTurbine.skipItems(skippedCount)
+    }
+  }
+
+  /**
+   * Suspend waiting for the next rendering to be produced by the Workflow runtime that satisfies the
+   * [predicate].
+   *
+   * @return the rendering.
+   */
+  public suspend fun awaitNextRenderingSatisfying(
+    predicate: (RenderingT) -> Boolean
+  ): RenderingT {
+    var rendering = awaitNextRendering()
+    while (!predicate(rendering)) {
+      rendering = awaitNextRendering()
+    }
+    return rendering
+  }
+
+  /**
+   * Suspend waiting for the next rendering which satisfies [precondition], can successfully be mapped
+   * using [map] and satisfies the [satisfying] predicate when called on the [T] rendering after it
+   * has been mapped.
+   *
+   * @return the mapped rendering as [T]
+   */
+  public suspend fun <T> awaitNext(
+    precondition: (RenderingT) -> Boolean = { true },
+    map: (RenderingT) -> T,
+    satisfying: T.() -> Boolean = { true }
+  ): T =
+    map(
+      awaitNextRenderingSatisfying {
+        precondition(it) &&
+          with(map(it)) {
+            this.satisfying()
+          }
+      }
+    )
+
+  public companion object {
+    /**
+     * Default timeout to use while waiting for renderings.
+     */
+    public const val WORKFLOW_TEST_DEFAULT_TIMEOUT_MS: Long = 60_000L
+  }
+}

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTestRuntime.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTestRuntime.kt
@@ -308,13 +308,14 @@ private fun WorkflowTestParams<*>.createInterceptors(): List<WorkflowInterceptor
       override fun <P, S> onInitialState(
         props: P,
         snapshot: Snapshot?,
-        proceed: (P, Snapshot?) -> S,
+        workflowScope: CoroutineScope,
+        proceed: (P, Snapshot?, CoroutineScope) -> S,
         session: WorkflowSession
       ): S {
         return if (session.parent == null) {
           startFrom.state as S
         } else {
-          proceed(props, snapshot)
+          proceed(props, snapshot, workflowScope)
         }
       }
     }

--- a/workflow-testing/src/test/java/com/squareup/workflow1/ParameterizedTestRunner.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/ParameterizedTestRunner.kt
@@ -1,0 +1,70 @@
+package com.squareup.workflow1
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * This file is copied from workflow-runtime:commonTest so our tests that test across the runtime
+ * look consistent. We could have used a JUnit library like Jupiter, but didn't.
+ *
+ * This file is copied so as to avoid creating a workflow-core-testing module (for now).
+ *
+ * We do our best to tell you what the parameter was when the failure occured by wrapping
+ * assertions from kotlin.test and injecting our own message.
+ */
+@WorkflowExperimentalApi
+class ParameterizedTestRunner<P : Any> {
+
+  var currentParam: P? = null
+
+  fun runParametrizedTest(
+    paramSource: Sequence<P>,
+    before: () -> Unit = {},
+    after: () -> Unit = {},
+    test: ParameterizedTestRunner<P>.(param: P) -> Unit
+  ) {
+    paramSource.forEach {
+      before()
+      currentParam = it
+      test(it)
+      after()
+    }
+  }
+
+  fun <T> assertEquals(expected: T, actual: T) {
+    assertEquals(expected, actual, message = "Using: ${currentParam?.toString()}")
+  }
+
+  fun <T> assertEquals(expected: T, actual: T, originalMessage: String) {
+    assertEquals(expected, actual, message = "$originalMessage; Using: ${currentParam?.toString()}")
+  }
+
+  fun assertTrue(statement: Boolean) {
+    assertTrue(statement, message = "Using: ${currentParam?.toString()}")
+  }
+
+  fun assertFalse(statement: Boolean) {
+    assertFalse(statement, message = "Using: ${currentParam?.toString()}")
+  }
+
+  inline fun <reified T : Throwable> assertFailsWith(block: () -> Unit) {
+    assertFailsWith<T>(message = "Using: ${currentParam?.toString()}", block)
+  }
+
+  fun <T : Any?> assertNotSame(illegal: T, actual: T) {
+    assertNotSame(illegal, actual, message = "Using: ${currentParam?.toString()}")
+  }
+
+  fun <T : Any> assertNotNull(actual: T?) {
+    assertNotNull(actual, message = "Using: ${currentParam?.toString()}")
+  }
+
+  fun assertNull(actual: Any?) {
+    assertNull(actual, message = "Using: ${currentParam?.toString()}")
+  }
+}

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowsLifecycleTests.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowsLifecycleTests.kt
@@ -1,0 +1,235 @@
+package com.squareup.workflow1
+
+import com.squareup.workflow1.RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS
+import com.squareup.workflow1.RuntimeConfigOptions.RENDER_ONLY_WHEN_STATE_CHANGES
+import com.squareup.workflow1.testing.headlessIntegrationTest
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Ignore
+import kotlin.test.Test
+
+/**
+ * Most of these tests are motivated by [1093](https://github.com/square/workflow-kotlin/issues/1093).
+ */
+@OptIn(WorkflowExperimentalRuntime::class, WorkflowExperimentalApi::class)
+class WorkflowsLifecycleTests {
+
+  private val runtimeOptions: Sequence<RuntimeConfig> = arrayOf(
+    RuntimeConfigOptions.RENDER_PER_ACTION,
+    setOf(RENDER_ONLY_WHEN_STATE_CHANGES),
+    setOf(CONFLATE_STALE_RENDERINGS),
+    setOf(CONFLATE_STALE_RENDERINGS, RENDER_ONLY_WHEN_STATE_CHANGES)
+  ).asSequence()
+
+  private val runtimeTestRunner = ParameterizedTestRunner<RuntimeConfig>()
+  private var started = 0
+  private var cancelled = 0
+  private val workflowWithSideEffects:
+    StatefulWorkflow<Unit, Int, Nothing, Pair<Int, (Int) -> Unit>> =
+    Workflow.stateful(
+      initialState = 0,
+      render = { renderState: Int ->
+        // Run side effect on odd numbered state.
+        if (renderState % 2 == 1) {
+          runningSideEffect("test") {
+            started++
+            try {
+              awaitCancellation()
+            } finally {
+              cancelled++
+            }
+          }
+        }
+        // Rendering pair is current int state and a function to change it.
+        renderState to { newState -> actionSink.send(action { state = newState }) }
+      }
+    )
+
+  private val sessionWorkflow: SessionWorkflow<Unit, Int, Nothing, Int> =
+    Workflow.sessionWorkflow(
+      initialState = { workflowScope ->
+        workflowScope.coroutineContext[Job]!!.invokeOnCompletion {
+          cancelled++
+        }
+        started++
+        0
+      },
+      render = { renderState: Int ->
+        renderState
+      }
+    )
+
+  private val workflowWithChildSession:
+    StatefulWorkflow<Unit, Int, Nothing, Pair<Int, (Int) -> Unit>> =
+    Workflow.stateful(
+      initialState = 0,
+      render = { renderState: Int ->
+        // render child session on odd numbered state.
+        if (renderState % 2 == 1) {
+          renderChild(sessionWorkflow)
+        }
+        // Rendering pair is current int state and a function to change it.
+        renderState to { newState -> actionSink.send(action { state = newState }) }
+      }
+    )
+
+  private fun cleanup() {
+    started = 0
+    cancelled = 0
+  }
+
+  @Test fun sideEffectsStartedWhenExpected() {
+    runtimeTestRunner.runParametrizedTest(
+      paramSource = runtimeOptions,
+      after = ::cleanup,
+    ) { runtimeConfig: RuntimeConfig ->
+
+      workflowWithSideEffects.headlessIntegrationTest(
+        runtimeConfig = runtimeConfig
+      ) {
+        // One time starts but does not stop the side effect.
+        repeat(1) {
+          val (current, setState) = awaitNextRendering()
+          setState.invoke(current + 1)
+        }
+
+        assertEquals(1, started, "Side Effect not started 1 time.")
+      }
+    }
+  }
+
+  @Test fun sideEffectsStoppedWhenExpected() {
+    runtimeTestRunner.runParametrizedTest(
+      paramSource = runtimeOptions,
+      after = ::cleanup,
+    ) { runtimeConfig: RuntimeConfig ->
+
+      workflowWithSideEffects.headlessIntegrationTest(
+        runtimeConfig = runtimeConfig
+      ) {
+        // Twice will start and stop the side effect.
+        repeat(2) {
+          val (current, setState) = awaitNextRendering()
+          setState.invoke(current + 1)
+        }
+        assertEquals(1, started, "Side Effect not started 1 time.")
+        assertEquals(1, cancelled, "Side Effect not cancelled 1 time.")
+      }
+    }
+  }
+
+  /**
+   * @see [1093](https://github.com/square/workflow-kotlin/issues/1093)
+   *
+   * This test ensconces the currently failing behavior of side effects. We are not currently
+   * fixing this but rather working around it with [SessionWorkflow].
+   */
+  @Ignore
+  @Test fun sideEffectsStartAndStoppedWhenHandledSynchronously() {
+    runtimeTestRunner.runParametrizedTest(
+      paramSource = runtimeOptions,
+      after = ::cleanup,
+    ) { runtimeConfig: RuntimeConfig ->
+
+      val dispatcher = StandardTestDispatcher()
+      workflowWithSideEffects.headlessIntegrationTest(
+        coroutineContext = dispatcher,
+        runtimeConfig = runtimeConfig
+      ) {
+
+        val (_, setState) = awaitNextRendering()
+        // 2 actions queued up - should start the side effect and then stop it
+        // on two consecutive render passes.
+        setState.invoke(1)
+        setState.invoke(2)
+        dispatcher.scheduler.runCurrent()
+        awaitNextRendering()
+        dispatcher.scheduler.runCurrent()
+        if (!runtimeConfig.contains(CONFLATE_STALE_RENDERINGS)) {
+          // 2 rendering or 1 depending on runtime config.
+          awaitNextRendering()
+        }
+
+        assertEquals(1, started, "Side Effect not started 1 time.")
+        assertEquals(1, cancelled, "Side Effect not cancelled 1 time.")
+      }
+    }
+  }
+
+  @Test fun childSessionWorkflowStartedWhenExpected() {
+    runtimeTestRunner.runParametrizedTest(
+      paramSource = runtimeOptions,
+      after = ::cleanup,
+    ) { runtimeConfig: RuntimeConfig ->
+
+      workflowWithChildSession.headlessIntegrationTest(
+        runtimeConfig = runtimeConfig
+      ) {
+        // One time starts but does not stop the child session workflow.
+        repeat(1) {
+          val (current, setState) = awaitNextRendering()
+          setState.invoke(current + 1)
+        }
+
+        assertEquals(1, started, "Child Session Workflow not started 1 time.")
+      }
+    }
+  }
+
+  @Test fun childSessionWorkflowStoppedWhenExpected() {
+    runtimeTestRunner.runParametrizedTest(
+      paramSource = runtimeOptions,
+      after = ::cleanup,
+    ) { runtimeConfig: RuntimeConfig ->
+
+      workflowWithChildSession.headlessIntegrationTest(
+        runtimeConfig = runtimeConfig
+      ) {
+        // Twice will start and stop the child session workflow.
+        repeat(2) {
+          val (current, setState) = awaitNextRendering()
+          setState.invoke(current + 1)
+        }
+        assertEquals(1, started, "Child Session Workflow not started 1 time.")
+        assertEquals(1, cancelled, "Child Session Workflow not cancelled 1 time.")
+      }
+    }
+  }
+
+  /**
+   * @see [1093](https://github.com/square/workflow-kotlin/issues/1093)
+   *
+   * This tests show the working behavior when using a [SessionWorkflow] to track the lifetime.
+   */
+  @Test fun childSessionWorkflowStartAndStoppedWhenHandledSynchronously() {
+    runtimeTestRunner.runParametrizedTest(
+      paramSource = runtimeOptions,
+      after = ::cleanup,
+    ) { runtimeConfig: RuntimeConfig ->
+
+      val dispatcher = StandardTestDispatcher()
+      workflowWithChildSession.headlessIntegrationTest(
+        coroutineContext = dispatcher,
+        runtimeConfig = runtimeConfig
+      ) {
+
+        val (_, setState) = awaitNextRendering()
+        // 2 actions queued up - should start the child session workflow and then stop it
+        // on two consecutive render passes, synchronously.
+        setState.invoke(1)
+        setState.invoke(2)
+        dispatcher.scheduler.runCurrent()
+        awaitNextRendering()
+        dispatcher.scheduler.runCurrent()
+        if (!runtimeConfig.contains(CONFLATE_STALE_RENDERINGS)) {
+          // 2 rendering or 1 depending on runtime config.
+          awaitNextRendering()
+        }
+
+        assertEquals(1, started, "Child Session Workflow not started 1 time.")
+        assertEquals(1, cancelled, "Child Session Workflow not cancelled 1 time.")
+      }
+    }
+  }
+}

--- a/workflow-tracing/api/workflow-tracing.api
+++ b/workflow-tracing/api/workflow-tracing.api
@@ -12,7 +12,7 @@ public final class com/squareup/workflow1/diagnostic/tracing/RuntimeMemoryStats 
 public final class com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptor : com/squareup/workflow1/WorkflowInterceptor {
 	public fun <init> (Lcom/squareup/workflow1/diagnostic/tracing/MemoryStats;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Lcom/squareup/workflow1/diagnostic/tracing/MemoryStats;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlin/jvm/functions/Function2;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
+	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRenderAndSnapshot (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/RenderingAndSnapshot;

--- a/workflow-tracing/src/main/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptor.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptor.kt
@@ -146,10 +146,11 @@ public class TracingWorkflowInterceptor internal constructor(
   override fun <P, S> onInitialState(
     props: P,
     snapshot: Snapshot?,
-    proceed: (P, Snapshot?) -> S,
+    workflowScope: CoroutineScope,
+    proceed: (P, Snapshot?, CoroutineScope) -> S,
     session: WorkflowSession
   ): S {
-    val initialState = proceed(props, snapshot)
+    val initialState = proceed(props, snapshot, workflowScope)
 
     onWorkflowStarted(
       workflowId = session.sessionId,


### PR DESCRIPTION
Adds 'Lifecycle' related tests to prove out SessionWorkflow's ability to effectively track lifecycle in the failing scenario. Adds comments describing the failing scenario of issue #1093, and how this can workaround it to fix it.

Also address #990 which has been separately requested.

Also adds `HeadlessIntegrationTest` to the OSS Library, which we have used internally for some time.

Closes #990
Closes #1093