### PR TITLE
Improves legibility of `Compatible.keyFor`, `NamedScreen`, `Named`.

### DIFF
--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Compatible.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Compatible.kt
@@ -36,14 +36,19 @@ public interface Compatible {
 
   public companion object {
     /**
-     * Calculates a suitable [Compatible.compatibilityKey] for a given [value] and [name].
+     * Calculates a suitable [Compatible.compatibilityKey] for a given [value], incorporating
+     * [name] if that is not blank. Includes the [compatibilityKey] for [value] if it
+     * implements [Compatible], to support recursion from wrapping.
+     *
+     * Style note: [name] is given more prominence than the key generate
      */
     public fun keyFor(
       value: Any,
       name: String = ""
     ): String {
-      return ((value as? Compatible)?.compatibilityKey ?: value::class.java.name) +
-        if (name.isEmpty()) "" else "+$name"
+      val key = (value as? Compatible)?.compatibilityKey ?: value::class.java.name
+
+      return name.takeIf { it.isNotEmpty() }?.let { "$name($key)" } ?: key
     }
   }
 }

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Named.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Named.kt
@@ -15,7 +15,7 @@ public data class Named<W : Any>(
     require(name.isNotBlank()) { "name must not be blank." }
   }
 
-  override val compatibilityKey: String = Compatible.keyFor(wrapped, "Named($name)")
+  override val compatibilityKey: String = Compatible.keyFor(wrapped, "Named:$name")
 
   override fun toString(): String {
     return "${super.toString()}: $compatibilityKey"

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/NamedScreen.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/NamedScreen.kt
@@ -16,7 +16,7 @@ public data class NamedScreen<C : Screen>(
     require(name.isNotBlank()) { "name must not be blank." }
   }
 
-  override val compatibilityKey: String = Compatible.keyFor(content, "NamedScreen($name)")
+  override val compatibilityKey: String = Compatible.keyFor(content, "NamedScreen:$name")
 
   @Deprecated("Use content", ReplaceWith("content"))
   public val wrapped: C = content

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/NamedScreenTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/NamedScreenTest.kt
@@ -57,7 +57,7 @@ internal class NamedScreenTest {
 
   @Test fun `recursive keys are legible`() {
     assertThat(NamedScreen(NamedScreen(Hey, "one"), "ho").compatibilityKey)
-      .isEqualTo("com.squareup.workflow1.ui.NamedScreenTest\$Hey+NamedScreen(one)+NamedScreen(ho)")
+      .isEqualTo("NamedScreen:ho(NamedScreen:one(com.squareup.workflow1.ui.NamedScreenTest\$Hey))")
   }
 
   private class Foo(override val compatibilityKey: String) : Compatible, Screen

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/NamedTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/NamedTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 
 // If you try to replace isTrue() with isTrue compilation fails.
 @OptIn(WorkflowUiExperimentalApi::class)
-@Suppress("UsePropertyAccessSyntax", "DEPRECATION")
+@Suppress("DEPRECATION")
 internal class NamedTest {
   object Whut
   object Hey
@@ -58,7 +58,7 @@ internal class NamedTest {
 
   @Test fun `recursive keys are legible`() {
     assertThat(Named(Named(Hey, "one"), "ho").compatibilityKey)
-      .isEqualTo("com.squareup.workflow1.ui.NamedTest\$Hey+Named(one)+Named(ho)")
+      .isEqualTo("Named:ho(Named:one(com.squareup.workflow1.ui.NamedTest\$Hey))")
   }
 
   private class Foo(override val compatibilityKey: String) : Compatible


### PR DESCRIPTION
This:

```
object Hey : Screen
NamedScreen(NamedScreen(Hey, "one"), "ho")
```

is now logged as this:

```
NamedScreen:ho(NamedScreen:one(com.squareup.workflow1.ui.NamedScreenTest$Hey))
```

instead of this:

```
com.squareup.workflow1.ui.NamedScreenTest$Hey+NamedScreen(one)+NamedScreen(ho)
```