### PR TITLE
BREAKING: Stop stomping `View.layoutParams`, new parameter for `replaceViewInParent`

### DIFF
--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -270,13 +270,15 @@ public final class com/squareup/workflow1/ui/WorkflowViewStub : android/view/Vie
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getActual ()Landroid/view/View;
 	public final fun getInflatedId ()I
-	public final fun getReplaceOldViewInParent ()Lkotlin/jvm/functions/Function2;
+	public final fun getPropagatesLayoutParams ()Z
+	public final fun getReplaceOldViewInParent ()Lkotlin/jvm/functions/Function3;
 	public final fun getUpdatesVisibility ()Z
 	public fun getVisibility ()I
 	public fun setBackground (Landroid/graphics/drawable/Drawable;)V
 	public fun setId (I)V
 	public final fun setInflatedId (I)V
-	public final fun setReplaceOldViewInParent (Lkotlin/jvm/functions/Function2;)V
+	public final fun setPropagatesLayoutParams (Z)V
+	public final fun setReplaceOldViewInParent (Lkotlin/jvm/functions/Function3;)V
 	public final fun setUpdatesVisibility (Z)V
 	public fun setVisibility (I)V
 	public final fun show (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;)V

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewFactoryFinder.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewFactoryFinder.kt
@@ -20,7 +20,6 @@ import com.squareup.workflow1.ui.container.EnvironmentScreen
  *    by ScreenViewFactory(
  *      buildView = { environment, context, _ ->
  *        val view = MyBackStackContainer(context)
- *          .apply { layoutParams = (LayoutParams(MATCH_PARENT, MATCH_PARENT)) }
  *        ScreenViewHolder(environment, view) { rendering, environment ->
  *          view.update(rendering, environment)
  *        }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/WorkflowLayout.kt
@@ -8,8 +8,6 @@ import android.os.Parcelable.Creator
 import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.View
-import android.view.ViewGroup
-import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.State
@@ -51,7 +49,8 @@ public class WorkflowLayout(
 
   private val showing: WorkflowViewStub = WorkflowViewStub(context).also { rootStub ->
     rootStub.updatesVisibility = false
-    addView(rootStub, ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
+    rootStub.propagatesLayoutParams = false
+    addView(rootStub)
   }
 
   private var restoredChildState: SparseArray<Parcelable>? = null

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BodyAndOverlaysContainer.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/container/BodyAndOverlaysContainer.kt
@@ -9,7 +9,6 @@ import android.os.Parcelable.Creator
 import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.MotionEvent
-import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import com.squareup.workflow1.ui.Compatible
@@ -42,8 +41,9 @@ internal class BodyAndOverlaysContainer @JvmOverloads constructor(
    */
   private lateinit var savedStateParentKey: String
 
-  private val baseViewStub: WorkflowViewStub = WorkflowViewStub(context).also {
-    addView(it, ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
+  private val baseViewStub: WorkflowViewStub = WorkflowViewStub(context).apply {
+    propagatesLayoutParams = false
+    addView(this)
   }
 
   private val dialogs = LayeredDialogSessions.forView(


### PR DESCRIPTION
`WorkflowViewStub.replaceViewInParent` now can be configured not to propagate `layoutParams`, by setting new property `propagatesLayoutParams` to `false`. When it's `true` (the default), the stub's `layoutParams` are passed as a new third argument to the (customizable) `replaceViewInParent` function, to make it clearer that this function bears responsibility for applying them.

Motivated because `BodyAndOverlaysContainer` and `WorkflowLayout` were being dictatorial about the body view's layout params for no clear reason, leading to layout surprises. They're the first to opt out of `propagatesLayoutParams`.