### PR TITLE
Deprecates `LifecycleWorker` in favor of `SessionWorkflow.initialState`

### DIFF
--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/LifecycleWorker.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/LifecycleWorker.kt
@@ -19,6 +19,7 @@ import kotlin.jvm.JvmName
  * which can effect whether a [LifecycleWorker] is ever executed.
  * See more details at [BaseRenderContext.runningSideEffect].
  */
+@Deprecated("Use the CoroutineScope in SessionWorkflow.initialState")
 public abstract class LifecycleWorker : Worker<Nothing> {
 
   /**

--- a/workflow-testing/src/test/java/com/squareup/workflow1/LifecycleWorkerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/LifecycleWorkerTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package com.squareup.workflow1
 
 import com.squareup.workflow1.testing.test
@@ -11,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 class LifecycleWorkerTest {
 
   @Test fun `onStart called immediately`() {

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkerCompositionIntegrationTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkerCompositionIntegrationTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
-
 package com.squareup.workflow1
 
 import com.squareup.workflow1.WorkflowAction.Companion.noAction
@@ -25,6 +23,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
+@Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 internal class WorkerCompositionIntegrationTest {
 
   private class ExpectedException : RuntimeException()
@@ -192,7 +191,7 @@ internal class WorkerCompositionIntegrationTest {
       state += 1
     }
 
-    val workflow = Workflow.stateful<Int, Int, () -> Unit>(
+    val workflow = Workflow.stateful(
       initialState = 0,
       render = { _ ->
         runningWorker(triggerOutput) { action { setOutput(state) } }
@@ -221,7 +220,7 @@ internal class WorkerCompositionIntegrationTest {
 
   @Test fun `runningWorker throws when output emitted`() {
     @Suppress("UNCHECKED_CAST")
-    val worker = Worker.from { Unit } as Worker<Nothing>
+    val worker = Worker.from { } as Worker<Nothing>
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
       // Suppress runningWorker usage because we want to make sure the deprecated
       // method still throws an exception as expected

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow1.testing
 
 import com.squareup.workflow1.ImpostorWorkflow


### PR DESCRIPTION
Fixes #1136