### PR TITLE
Changing CI Emulator & Action Config

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -7,6 +7,9 @@ on :
   pull_request :
   merge_group :
 
+env:
+  ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: 720 # 12 minutes; default is 20s
+
 # If CI is already running for a branch when that branch is updated, cancel the older jobs.
 concurrency :
   group : ci-${{ github.ref }}-${{ github.head_ref }}

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -270,7 +270,7 @@ jobs :
   performance-tests :
     name : Performance tests
     runs-on : macos-latest
-    timeout-minutes : 30
+    timeout-minutes : 45
     strategy :
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast : false
@@ -293,7 +293,7 @@ jobs :
   instrumentation-tests :
     name : Instrumentation tests
     runs-on : macos-latest
-    timeout-minutes : 45
+    timeout-minutes : 60
     strategy :
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast : false
@@ -320,7 +320,7 @@ jobs :
   runtime-instrumentation-tests :
     name : Conflate Stale Renderings Instrumentation tests
     runs-on : macos-latest
-    timeout-minutes : 45
+    timeout-minutes : 60
     strategy :
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast : false

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -276,9 +276,7 @@ jobs :
       fail-fast : false
       matrix :
         api-level :
-          - 29
-      # Unclear that older versions actually honor command to disable animation.
-      # Newer versions are reputed to be too slow: https://github.com/ReactiveCircus/android-emulator-runner/issues/222
+          - 31
     steps :
       - uses : actions/checkout@v3
 
@@ -298,10 +296,8 @@ jobs :
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast : false
       matrix :
-        # Unclear that older versions actually honor command to disable animation.
-        # Newer versions are reputed to be too slow: https://github.com/ReactiveCircus/android-emulator-runner/issues/222
         api-level :
-          - 29
+          - 31
         ### <start-connected-check-shards>
         shardNum : [ 1, 2, 3 ]
         ### <end-connected-check-shards>
@@ -326,7 +322,7 @@ jobs :
       fail-fast : false
       matrix :
         api-level :
-          - 29
+          - 31
         ### <start-connected-check-shards>
         shardNum : [ 1, 2, 3 ]
         ### <end-connected-check-shards>


### PR DESCRIPTION
1. use `ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL` value of 720 - 12 minutes
2. Change perf tests shard timeout to 60m (was 45); instrumentation tests shard timeout to 45m (was 60);
3. Move tests and perf shards from running on API 29 to API 31