### PR TITLE
Revert "Run publish-snapshot on larger runner"

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -8,11 +8,11 @@ on:
       - ray/ui-update
 
 env:
-  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx12g -Dorg.gradle.daemon=false -Dorg.gradle.logging.stacktrace=all"
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx5g -Dorg.gradle.daemon=false -Dorg.gradle.logging.stacktrace=all"
 
 jobs:
   publish-snapshot :
-    runs-on : workflow-kotlin-test-runner-ubuntu-4core
+    runs-on : macos-latest
     if : github.repository == 'square/workflow-kotlin'
     timeout-minutes : 35
 


### PR DESCRIPTION
Reverts square/workflow-kotlin#1149

HOld off until we decide what to do with `artifactsCheck` which can only run on `macos`