### PR TITLE
Bump publishing shard to macos-14

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,7 +5,8 @@ on:
 
 jobs:
   publish-release:
-    runs-on: macos-latest
+    # macos-latest is too slow. -14 will become latest in Q2 '24
+    runs-on: macos-14
     if: github.repository == 'square/workflow-kotlin'
     timeout-minutes: 35
 

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   publish-snapshot:
-    runs-on: macos-latest
+    # macos-latest is too slow. -14 will become latest in Q2 '24
+    runs-on: macos-14
     if: github.repository == 'square/workflow-kotlin'
     timeout-minutes: 35
 


### PR DESCRIPTION
macos-latest times out, -14 should be faster.
https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/