### PR TITLE
ScreenViewFactoryFinder main error message mentions Compose.

### DIFF
--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewFactoryFinder.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ScreenViewFactoryFinder.kt
@@ -96,6 +96,9 @@ public fun <ScreenT : Screen> ScreenViewFactoryFinder.requireViewFactoryForRende
         "${
           environment[ViewRegistry]
             .getEntryFor(Key(rendering::class, ScreenViewFactory::class))
-        }."
+        }. If this rendering is Compose based, you may be missing a call to " +
+        "ViewEnvironment.withComposeInteropSupport() " +
+        "from module com.squareup.workflow1:workflow-ui-compose at the top " +
+        "of your Android view hierarchy."
     )
 }


### PR DESCRIPTION
Fixes the error message you see when missing a call to `ViewEnvironment.withComposeInteropSupport()`. A little odd since this module has no dependency on Compose, but the requirement is otherwise much too hard to discover.