### PR TITLE
Makes `CoveredByModal` public.

### DIFF
--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -260,6 +260,12 @@ public final class com/squareup/workflow1/ui/navigation/BackStackContainer$Saved
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/squareup/workflow1/ui/navigation/CoveredByModal : com/squareup/workflow1/ui/ViewEnvironmentKey {
+	public static final field INSTANCE Lcom/squareup/workflow1/ui/navigation/CoveredByModal;
+	public fun getDefault ()Ljava/lang/Boolean;
+	public synthetic fun getDefault ()Ljava/lang/Object;
+}
+
 public final class com/squareup/workflow1/ui/navigation/LayeredDialogSessions {
 	public static final field Companion Lcom/squareup/workflow1/ui/navigation/LayeredDialogSessions$Companion;
 	public synthetic fun <init> (Landroid/content/Context;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/navigation/CoveredByModal.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/navigation/CoveredByModal.kt
@@ -12,6 +12,6 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
  * https://stackoverflow.com/questions/2886407/dealing-with-rapid-tapping-on-buttons
  */
 @WorkflowUiExperimentalApi
-internal object CoveredByModal : ViewEnvironmentKey<Boolean>() {
+public object CoveredByModal : ViewEnvironmentKey<Boolean>() {
   override val default: Boolean = false
 }


### PR DESCRIPTION
Held off on this originally because we didn't have a use case. Now we do -- trying to keep a non-workflow system that does its own window management well behaved.