### PR TITLE
BREAKING: Compose overhaul makes ViewEnvironment less in your face.

### DIFF
--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/App.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/App.kt
@@ -30,7 +30,6 @@ private val viewEnvironment = ViewEnvironment.EMPTY.withComposeInteropSupport()
     )
     WorkflowRendering(
       rendering,
-      viewEnvironment,
       Modifier.border(
         shape = RoundedCornerShape(10.dp),
         width = 10.dp,

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/HelloComposeScreen.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/HelloComposeScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.ComposeScreen
 import com.squareup.workflow1.ui.compose.tooling.Preview
@@ -18,7 +17,7 @@ data class HelloComposeScreen(
   val message: String,
   val onClick: () -> Unit
 ) : ComposeScreen {
-  @Composable override fun Content(viewEnvironment: ViewEnvironment) {
+  @Composable override fun Content() {
     Text(
       message,
       modifier = Modifier

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloBinding.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloBinding.kt
@@ -13,7 +13,7 @@ import com.squareup.workflow1.ui.compose.ScreenComposableFactory
 import com.squareup.workflow1.ui.compose.tooling.Preview
 
 @OptIn(WorkflowUiExperimentalApi::class)
-val HelloBinding = ScreenComposableFactory<Rendering> { rendering, _ ->
+val HelloBinding = ScreenComposableFactory<Rendering> { rendering ->
   Text(
     rendering.message,
     modifier = Modifier

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloBindingActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloBindingActivity.kt
@@ -18,7 +18,6 @@ import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.withComposeInteropSupport
-import com.squareup.workflow1.ui.compose.withCompositionRoot
 import com.squareup.workflow1.ui.plus
 import com.squareup.workflow1.ui.renderWorkflowIn
 import com.squareup.workflow1.ui.withEnvironment
@@ -27,10 +26,9 @@ import kotlinx.coroutines.flow.StateFlow
 @OptIn(WorkflowUiExperimentalApi::class)
 private val viewEnvironment =
   (ViewEnvironment.EMPTY + ViewRegistry(HelloBinding))
-    .withCompositionRoot { content ->
+    .withComposeInteropSupport { content ->
       MaterialTheme(content = content)
     }
-    .withComposeInteropSupport()
 
 /**
  * Demonstrates how to create and display a view factory with

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/ComposeWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/ComposeWorkflow.kt
@@ -7,7 +7,6 @@ import com.squareup.workflow1.Sink
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowIdentifier
-import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.ComposeScreen
 
@@ -35,17 +34,15 @@ abstract class ComposeWorkflow<in PropsT, out OutputT : Any> :
 
   /**
    * Renders [props] by emitting Compose UI. This function will be called to update the UI whenever
-   * the [props] or [viewEnvironment] change.
+   * the [props] change.
    *
    * @param props The data to render.
    * @param outputSink A [Sink] that can be used from UI event handlers to send outputs to this
    * workflow's parent.
-   * @param viewEnvironment The [ViewEnvironment] passed down through the `ViewBinding` pipeline.
    */
   @Composable abstract fun RenderingContent(
     props: PropsT,
     outputSink: Sink<OutputT>,
-    viewEnvironment: ViewEnvironment
   )
 
   override fun asStatefulWorkflow(): StatefulWorkflow<PropsT, *, OutputT, ComposeScreen> =
@@ -62,14 +59,12 @@ inline fun <PropsT, OutputT : Any> Workflow.Companion.composed(
   crossinline render: @Composable (
     props: PropsT,
     outputSink: Sink<OutputT>,
-    environment: ViewEnvironment
   ) -> Unit
 ): ComposeWorkflow<PropsT, OutputT> = object : ComposeWorkflow<PropsT, OutputT>() {
   @Composable override fun RenderingContent(
     props: PropsT,
     outputSink: Sink<OutputT>,
-    viewEnvironment: ViewEnvironment
   ) {
-    render(props, outputSink, viewEnvironment)
+    render(props, outputSink)
   }
 }

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/ComposeWorkflowImpl.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/ComposeWorkflowImpl.kt
@@ -10,7 +10,6 @@ import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.action
 import com.squareup.workflow1.contraMap
-import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.ComposeScreen
 
@@ -39,12 +38,12 @@ internal class ComposeWorkflowImpl<PropsT, OutputT : Any>(
       propsHolder,
       sinkHolder,
       object : ComposeScreen {
-        @Composable override fun Content(viewEnvironment: ViewEnvironment) {
+        @Composable override fun Content() {
           // The sink will get set on the first render pass, which must happen before this is first
           // composed, so it should never be null.
           val sink = sinkHolder.sink!!
           // Important: Use the props from the MutableState, _not_ the one passed into render.
-          workflow.RenderingContent(propsHolder.value, sink, viewEnvironment)
+          workflow.RenderingContent(propsHolder.value, sink)
         }
       }
     )

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/HelloComposeWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/HelloComposeWorkflow.kt
@@ -16,7 +16,6 @@ import com.squareup.sample.compose.hellocomposeworkflow.HelloComposeWorkflow.Tog
 import com.squareup.workflow1.Sink
 import com.squareup.workflow1.WorkflowExperimentalRuntime
 import com.squareup.workflow1.config.AndroidRuntimeConfigTools
-import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.WorkflowRendering
 import com.squareup.workflow1.ui.compose.renderAsState
@@ -34,7 +33,6 @@ object HelloComposeWorkflow : ComposeWorkflow<String, Toggle>() {
   @Composable override fun RenderingContent(
     props: String,
     outputSink: Sink<Toggle>,
-    viewEnvironment: ViewEnvironment
   ) {
     MaterialTheme {
       Text(
@@ -57,5 +55,5 @@ fun HelloComposeWorkflowPreview() {
     onOutput = {},
     runtimeConfig = AndroidRuntimeConfigTools.getAppWorkflowRuntimeConfig()
   )
-  WorkflowRendering(rendering, ViewEnvironment.EMPTY)
+  WorkflowRendering(rendering)
 }

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
@@ -22,7 +22,6 @@ import com.squareup.workflow1.WorkflowExperimentalRuntime
 import com.squareup.workflow1.config.AndroidRuntimeConfigTools
 import com.squareup.workflow1.parse
 import com.squareup.workflow1.ui.Screen
-import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.ComposeScreen
 import com.squareup.workflow1.ui.compose.WorkflowRendering
@@ -60,7 +59,7 @@ fun InlineRenderingWorkflowRendering() {
     onOutput = {},
     runtimeConfig = AndroidRuntimeConfigTools.getAppWorkflowRuntimeConfig()
   )
-  WorkflowRendering(rendering, ViewEnvironment.EMPTY)
+  WorkflowRendering(rendering)
 }
 
 @Preview(showBackground = true)

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsActivity.kt
@@ -19,24 +19,22 @@ import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.withComposeInteropSupport
-import com.squareup.workflow1.ui.compose.withCompositionRoot
 import com.squareup.workflow1.ui.plus
 import com.squareup.workflow1.ui.renderWorkflowIn
 import com.squareup.workflow1.ui.withEnvironment
 import kotlinx.coroutines.flow.StateFlow
 
 @OptIn(WorkflowUiExperimentalApi::class)
-private val viewRegistry = ViewRegistry(RecursiveViewFactory)
+private val viewRegistry = ViewRegistry(RecursiveComposableFactory)
 
 @OptIn(WorkflowUiExperimentalApi::class)
 private val viewEnvironment =
   (ViewEnvironment.EMPTY + viewRegistry)
-    .withCompositionRoot { content ->
+    .withComposeInteropSupport { content ->
       CompositionLocalProvider(LocalBackgroundColor provides Color.Green) {
         content()
       }
     }
-    .withComposeInteropSupport()
 
 @WorkflowUiExperimentalApi
 class NestedRenderingsActivity : AppCompatActivity() {

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/RecursiveViewFactory.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/RecursiveViewFactory.kt
@@ -24,14 +24,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.squareup.sample.compose.R
 import com.squareup.sample.compose.nestedrenderings.RecursiveWorkflow.Rendering
 import com.squareup.workflow1.ui.Screen
-import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.ScreenComposableFactory
 import com.squareup.workflow1.ui.compose.WorkflowRendering
 import com.squareup.workflow1.ui.compose.tooling.Preview
 
 /**
- * Composition local of [Color] to use as the background color for a [RecursiveViewFactory].
+ * Composition local of [Color] to use as the background color for a [RecursiveComposableFactory].
  */
 val LocalBackgroundColor = compositionLocalOf<Color> { error("No background color specified") }
 
@@ -39,7 +38,7 @@ val LocalBackgroundColor = compositionLocalOf<Color> { error("No background colo
  * A `ViewFactory` that renders [RecursiveWorkflow.Rendering]s.
  */
 @OptIn(WorkflowUiExperimentalApi::class)
-val RecursiveViewFactory = ScreenComposableFactory<Rendering> { rendering, viewEnvironment ->
+val RecursiveComposableFactory = ScreenComposableFactory<Rendering> { rendering ->
   // Every child should be drawn with a slightly-darker background color.
   val color = LocalBackgroundColor.current
   val childColor = remember(color) {
@@ -57,7 +56,6 @@ val RecursiveViewFactory = ScreenComposableFactory<Rendering> { rendering, viewE
       CompositionLocalProvider(LocalBackgroundColor provides childColor) {
         Children(
           rendering.children,
-          viewEnvironment,
           // Pass a weight so that the column fills all the space not occupied by the buttons.
           modifier = Modifier.weight(1f, fill = true)
         )
@@ -75,7 +73,7 @@ val RecursiveViewFactory = ScreenComposableFactory<Rendering> { rendering, viewE
 @Composable
 fun RecursiveViewFactoryPreview() {
   CompositionLocalProvider(LocalBackgroundColor provides Color.Green) {
-    RecursiveViewFactory.Preview(
+    RecursiveComposableFactory.Preview(
       Rendering(
         children = listOf(
           StringRendering("foo"),
@@ -97,7 +95,6 @@ fun RecursiveViewFactoryPreview() {
 @Composable
 private fun Children(
   children: List<Screen>,
-  viewEnvironment: ViewEnvironment,
   modifier: Modifier
 ) {
   Column(
@@ -110,7 +107,6 @@ private fun Children(
         childRendering,
         // Pass a weight so all children are partitioned evenly within the total column space.
         // Without the weight, each child is the full size of the parent.
-        viewEnvironment,
         modifier = Modifier
           .weight(1f, fill = true)
           .fillMaxWidth()

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/preview/PreviewActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/preview/PreviewActivity.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.squareup.workflow1.ui.Screen
-import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import com.squareup.workflow1.ui.compose.ComposeScreen
 import com.squareup.workflow1.ui.compose.WorkflowRendering
@@ -59,8 +58,8 @@ data class ContactRendering(
   val name: String,
   val details: ContactDetailsRendering
 ) : ComposeScreen {
-  @Composable override fun Content(viewEnvironment: ViewEnvironment) {
-    ContactDetails(this, viewEnvironment)
+  @Composable override fun Content() {
+    ContactDetails(this)
   }
 }
 
@@ -70,10 +69,7 @@ data class ContactDetailsRendering(
 ) : Screen
 
 @Composable
-private fun ContactDetails(
-  rendering: ContactRendering,
-  environment: ViewEnvironment
-) {
+private fun ContactDetails(rendering: ContactRendering) {
   Card(
     modifier = Modifier
       .padding(8.dp)
@@ -86,7 +82,6 @@ private fun ContactDetails(
       Text(rendering.name, style = MaterialTheme.typography.body1)
       WorkflowRendering(
         rendering = rendering.details,
-        viewEnvironment = environment,
         modifier = Modifier
           .aspectRatio(1f)
           .border(0.dp, Color.LightGray)

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/App.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/App.kt
@@ -11,11 +11,11 @@ import com.squareup.workflow1.config.AndroidRuntimeConfigTools
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
-import com.squareup.workflow1.ui.compose.WorkflowRendering
+import com.squareup.workflow1.ui.compose.RootScreen
 import com.squareup.workflow1.ui.compose.renderAsState
 import com.squareup.workflow1.ui.plus
 
-private val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(TextInputViewFactory)
+private val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(TextInputComposableFactory)
 
 @Composable fun TextInputApp() {
   MaterialTheme {
@@ -24,7 +24,7 @@ private val viewEnvironment = ViewEnvironment.EMPTY + ViewRegistry(TextInputView
       onOutput = {},
       runtimeConfig = AndroidRuntimeConfigTools.getAppWorkflowRuntimeConfig()
     )
-    WorkflowRendering(rendering, viewEnvironment)
+    viewEnvironment.RootScreen(rendering)
   }
 }
 

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/TextInputViewFactory.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/TextInputViewFactory.kt
@@ -24,7 +24,7 @@ import com.squareup.workflow1.ui.compose.asMutableState
 import com.squareup.workflow1.ui.compose.tooling.Preview
 
 @OptIn(WorkflowUiExperimentalApi::class)
-val TextInputViewFactory = ScreenComposableFactory<Rendering> { rendering, _ ->
+val TextInputComposableFactory = ScreenComposableFactory<Rendering> { rendering ->
   Column(
     modifier = Modifier
       .fillMaxSize()
@@ -52,7 +52,7 @@ val TextInputViewFactory = ScreenComposableFactory<Rendering> { rendering, _ ->
 @Preview(showBackground = true)
 @Composable
 private fun TextInputViewFactoryPreview() {
-  TextInputViewFactory.Preview(
+  TextInputComposableFactory.Preview(
     Rendering(
       textController = TextController("Hello world"),
       onSwapText = {}

--- a/workflow-ui/compose-tooling/src/androidTest/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewFactoryTest.kt
+++ b/workflow-ui/compose-tooling/src/androidTest/java/com/squareup/workflow1/ui/compose/tooling/PreviewViewFactoryTest.kt
@@ -17,6 +17,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ViewEnvironmentKey
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.compose.LocalWorkflowEnvironment
 import com.squareup.workflow1.ui.compose.ScreenComposableFactory
 import com.squareup.workflow1.ui.compose.WorkflowRendering
 import com.squareup.workflow1.ui.internal.test.IdleAfterTestRule
@@ -96,10 +97,10 @@ internal class PreviewViewFactoryTest {
   }
 
   private val ParentWithOneChild =
-    ScreenComposableFactory<TwoStrings> { rendering, environment ->
+    ScreenComposableFactory<TwoStrings> { rendering ->
       Column {
         BasicText(rendering.first.text)
-        WorkflowRendering(rendering.second, environment)
+        WorkflowRendering(rendering.second)
       }
     }
 
@@ -109,11 +110,11 @@ internal class PreviewViewFactoryTest {
   }
 
   private val ParentWithTwoChildren =
-    ScreenComposableFactory<ThreeStrings> { rendering, environment ->
+    ScreenComposableFactory<ThreeStrings> { rendering ->
       Column {
-        WorkflowRendering(rendering.first, environment)
+        WorkflowRendering(rendering.first)
         BasicText(rendering.second.text)
-        WorkflowRendering(rendering.third, environment)
+        WorkflowRendering(rendering.third)
       }
     }
 
@@ -156,11 +157,11 @@ internal class PreviewViewFactoryTest {
   ) : Screen
 
   private val ParentRecursive =
-    ScreenComposableFactory<RecursiveRendering> { rendering, environment ->
+    ScreenComposableFactory<RecursiveRendering> { rendering ->
       Column {
         BasicText(rendering.text)
         rendering.child?.let { child ->
-          WorkflowRendering(rendering = child, viewEnvironment = environment)
+          WorkflowRendering(rendering = child)
         }
       }
     }
@@ -198,8 +199,8 @@ internal class PreviewViewFactoryTest {
     override val default: String get() = error("Not specified")
   }
 
-  private val ParentConsumesCustomKey = ScreenComposableFactory<TwoStrings> { _, environment ->
-    BasicText(environment[TestEnvironmentKey])
+  private val ParentConsumesCustomKey = ScreenComposableFactory<TwoStrings> { _ ->
+    BasicText(LocalWorkflowEnvironment.current[TestEnvironmentKey])
   }
 
   @Preview @Composable

--- a/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/PlaceholderViewFactory.kt
+++ b/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/PlaceholderViewFactory.kt
@@ -34,7 +34,7 @@ import com.squareup.workflow1.ui.compose.ScreenComposableFactory
 internal fun placeholderScreenComposableFactory(
   modifier: Modifier
 ): ScreenComposableFactory<Screen> =
-  ScreenComposableFactory { rendering, _ ->
+  ScreenComposableFactory { rendering ->
     BoxWithConstraints {
       BasicText(
         modifier = modifier

--- a/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/Previews.kt
+++ b/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow1/ui/compose/tooling/Previews.kt
@@ -7,9 +7,9 @@ import com.squareup.workflow1.ui.ScreenViewFactory
 import com.squareup.workflow1.ui.ScreenViewFactoryFinder
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+import com.squareup.workflow1.ui.compose.RootScreen
 import com.squareup.workflow1.ui.compose.ScreenComposableFactory
 import com.squareup.workflow1.ui.compose.ScreenComposableFactoryFinder
-import com.squareup.workflow1.ui.compose.WorkflowRendering
 import com.squareup.workflow1.ui.compose.asComposableFactory
 
 /**
@@ -82,7 +82,7 @@ public fun <RenderingT : Screen> ScreenComposableFactory<RenderingT>.Preview(
 ) {
   val previewEnvironment =
     rememberPreviewViewEnvironment(placeholderModifier, viewEnvironmentUpdater, mainFactory = this)
-  WorkflowRendering(rendering, previewEnvironment, modifier)
+  previewEnvironment.RootScreen(rendering, modifier)
 }
 
 /**

--- a/workflow-ui/compose/api/compose.api
+++ b/workflow-ui/compose/api/compose.api
@@ -1,25 +1,28 @@
 public final class com/squareup/workflow1/ui/compose/ComposableSingletons$ScreenComposableFactoryFinderKt {
 	public static final field INSTANCE Lcom/squareup/workflow1/ui/compose/ComposableSingletons$ScreenComposableFactoryFinderKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function4;
-	public static field lambda-2 Lkotlin/jvm/functions/Function4;
-	public static field lambda-3 Lkotlin/jvm/functions/Function4;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public static field lambda-3 Lkotlin/jvm/functions/Function3;
 	public fun <init> ()V
-	public final fun getLambda-1$wf1_compose ()Lkotlin/jvm/functions/Function4;
-	public final fun getLambda-2$wf1_compose ()Lkotlin/jvm/functions/Function4;
-	public final fun getLambda-3$wf1_compose ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda-1$wf1_compose ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$wf1_compose ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-3$wf1_compose ()Lkotlin/jvm/functions/Function3;
 }
 
 public abstract interface class com/squareup/workflow1/ui/compose/ComposeScreen : com/squareup/workflow1/ui/Screen {
-	public abstract fun Content (Lcom/squareup/workflow1/ui/ViewEnvironment;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun Content (Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class com/squareup/workflow1/ui/compose/ComposeScreenKt {
-	public static final fun ComposeScreen (Lkotlin/jvm/functions/Function3;)Lcom/squareup/workflow1/ui/compose/ComposeScreen;
+	public static final fun ComposeScreen (Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow1/ui/compose/ComposeScreen;
 }
 
 public final class com/squareup/workflow1/ui/compose/CompositionRootKt {
-	public static final fun withCompositionRoot (Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function3;)Lcom/squareup/workflow1/ui/ViewEnvironment;
 	public static final fun withCompositionRoot (Lcom/squareup/workflow1/ui/compose/ScreenComposableFactoryFinder;Lkotlin/jvm/functions/Function3;)Lcom/squareup/workflow1/ui/compose/ScreenComposableFactoryFinder;
+}
+
+public final class com/squareup/workflow1/ui/compose/LocalWorkflowEnvironmentKt {
+	public static final fun getLocalWorkflowEnvironment ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 
 public final class com/squareup/workflow1/ui/compose/RenderAsStateKt {
@@ -27,7 +30,7 @@ public final class com/squareup/workflow1/ui/compose/RenderAsStateKt {
 }
 
 public abstract interface class com/squareup/workflow1/ui/compose/ScreenComposableFactory : com/squareup/workflow1/ui/ViewRegistry$Entry {
-	public abstract fun Content (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun Content (Lcom/squareup/workflow1/ui/Screen;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun getKey ()Lcom/squareup/workflow1/ui/ViewRegistry$Key;
 	public abstract fun getType ()Lkotlin/reflect/KClass;
 }
@@ -55,7 +58,7 @@ public final class com/squareup/workflow1/ui/compose/ScreenComposableFactoryFind
 }
 
 public final class com/squareup/workflow1/ui/compose/ScreenComposableFactoryKt {
-	public static final fun ScreenComposableFactory (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function4;)Lcom/squareup/workflow1/ui/compose/ScreenComposableFactory;
+	public static final fun ScreenComposableFactory (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function3;)Lcom/squareup/workflow1/ui/compose/ScreenComposableFactory;
 	public static final fun asComposableFactory (Lcom/squareup/workflow1/ui/ScreenViewFactory;)Lcom/squareup/workflow1/ui/compose/ScreenComposableFactory;
 	public static final fun asViewFactory (Lcom/squareup/workflow1/ui/compose/ScreenComposableFactory;)Lcom/squareup/workflow1/ui/ScreenViewFactory;
 	public static final fun toComposableFactory (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/compose/ScreenComposableFactory;
@@ -66,10 +69,12 @@ public final class com/squareup/workflow1/ui/compose/TextControllerAsMutableStat
 }
 
 public final class com/squareup/workflow1/ui/compose/ViewEnvironmentWithComposeSupportKt {
-	public static final fun withComposeInteropSupport (Lcom/squareup/workflow1/ui/ViewEnvironment;)Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public static final fun RootScreen (Lcom/squareup/workflow1/ui/ViewEnvironment;Lcom/squareup/workflow1/ui/Screen;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun withComposeInteropSupport (Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function3;)Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public static synthetic fun withComposeInteropSupport$default (Lcom/squareup/workflow1/ui/ViewEnvironment;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/ViewEnvironment;
 }
 
 public final class com/squareup/workflow1/ui/compose/WorkflowRenderingKt {
-	public static final fun WorkflowRendering (Lcom/squareup/workflow1/ui/Screen;Lcom/squareup/workflow1/ui/ViewEnvironment;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun WorkflowRendering (Lcom/squareup/workflow1/ui/Screen;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ScreenComposableFactoryTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ScreenComposableFactoryTest.kt
@@ -44,10 +44,10 @@ internal class ScreenComposableFactoryTest {
       .around(IdlingDispatcherRule)
 
   @Test fun showsComposeContent() {
-    val viewFactory = ScreenComposableFactory<TestRendering> { _, _ ->
+    val composableFactory = ScreenComposableFactory<TestRendering> { _ ->
       BasicText("Hello, world!")
     }
-    val viewEnvironment = (ViewEnvironment.EMPTY + ViewRegistry(viewFactory))
+    val viewEnvironment = (ViewEnvironment.EMPTY + ViewRegistry(composableFactory))
       .withComposeInteropSupport()
 
     composeRule.setContent {
@@ -60,10 +60,10 @@ internal class ScreenComposableFactoryTest {
   }
 
   @Test fun getsRenderingUpdates() {
-    val viewFactory = ScreenComposableFactory<TestRendering> { rendering, _ ->
+    val composableFactory = ScreenComposableFactory<TestRendering> { rendering ->
       BasicText(rendering.text, Modifier.testTag("text"))
     }
-    val viewEnvironment = (ViewEnvironment.EMPTY + ViewRegistry(viewFactory))
+    val viewEnvironment = (ViewEnvironment.EMPTY + ViewRegistry(composableFactory))
       .withComposeInteropSupport()
     var rendering by mutableStateOf(TestRendering("hello"))
 
@@ -84,11 +84,11 @@ internal class ScreenComposableFactoryTest {
       override val default: String get() = error("No default")
     }
 
-    val viewFactory = ScreenComposableFactory<TestRendering> { _, environment ->
-      val text = environment[testEnvironmentKey]
+    val composableFactory = ScreenComposableFactory<TestRendering> { _ ->
+      val text = LocalWorkflowEnvironment.current[testEnvironmentKey]
       BasicText(text, Modifier.testTag("text"))
     }
-    val viewRegistry = ViewRegistry(viewFactory)
+    val viewRegistry = ViewRegistry(composableFactory)
     var viewEnvironment by mutableStateOf(
       (ViewEnvironment.EMPTY + viewRegistry + (testEnvironmentKey to "hello"))
         .withComposeInteropSupport()
@@ -109,7 +109,7 @@ internal class ScreenComposableFactoryTest {
   @Test fun wrapsFactoryWithRoot() {
     val wrapperText = mutableStateOf("one")
     val viewEnvironment = (ViewEnvironment.EMPTY + ViewRegistry(TestFactory))
-      .withCompositionRoot { content ->
+      .withComposeInteropSupport { content ->
         Column {
           BasicText(wrapperText.value)
           content()
@@ -141,7 +141,7 @@ internal class ScreenComposableFactoryTest {
   private data class TestRendering(val text: String = "") : Screen
 
   private companion object {
-    val TestFactory = ScreenComposableFactory<TestRendering> { rendering, _ ->
+    val TestFactory = ScreenComposableFactory<TestRendering> { rendering ->
       BasicText(rendering.text)
     }
   }

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeScreen.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeScreen.kt
@@ -15,10 +15,10 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
  * [ComposeScreen], like [AndroidScreen][com.squareup.workflow1.ui.AndroidScreen],
  * is strictly a possible implementation detail of [Screen]. It is a convenience to
  * minimize the boilerplate required to set up a [ScreenComposableFactory].
- * That interface is the fundamental unit of Compose tooling for Workflow UI.
+ * (That interface is the fundamental unit of Compose tooling for Workflow UI.
  * But in day to day use, most developer will work with [ComposeScreen] and be only
  * vaguely aware of the existence of [ScreenComposableFactory],
- * so the bulk of our description of working with Compose is here.
+ * so the bulk of our description of working with Compose is here.)
  *
  * **NB**: A Workflow app that relies on Compose must call [withComposeInteropSupport]
  * on its top-level [ViewEnvironment]. See that function for details.
@@ -77,11 +77,10 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 public interface ComposeScreen : Screen {
 
   /**
-   * The composable content of this rendering. This method will be called with the current rendering
-   * instance as the receiver, any time a new rendering is emitted, or the [viewEnvironment]
-   * changes.
+   * The composable content of this rendering. This method will be called with the
+   * current rendering instance as the receiver any time a new rendering is emitted.
    */
-  @Composable public fun Content(viewEnvironment: ViewEnvironment)
+  @Composable public fun Content()
 }
 
 /**
@@ -90,9 +89,9 @@ public interface ComposeScreen : Screen {
  */
 @WorkflowUiExperimentalApi
 public inline fun ComposeScreen(
-  crossinline content: @Composable (ViewEnvironment) -> Unit
+  crossinline content: @Composable () -> Unit
 ): ComposeScreen = object : ComposeScreen {
-  @Composable override fun Content(viewEnvironment: ViewEnvironment) {
-    content(viewEnvironment)
+  @Composable override fun Content() {
+    content()
   }
 }

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/CompositionRoot.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/CompositionRoot.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.staticCompositionLocalOf
 import com.squareup.workflow1.ui.Screen
-import com.squareup.workflow1.ui.ScreenViewFactoryFinder
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
@@ -23,7 +22,7 @@ private val LocalHasViewFactoryRootBeenApplied = staticCompositionLocalOf { fals
  * [composition locals][androidx.compose.runtime.CompositionLocal] that all
  * [ScreenComposableFactory] factories need access to, such as UI themes.
  *
- * This function will called once, to wrap the _highest-level_ [ScreenComposableFactory]
+ * This function will be called once, to wrap the _highest-level_ [ScreenComposableFactory]
  * in the tree. However, composition locals are propagated down to child [ScreenComposableFactory]
  * compositions, so any locals provided here will be available in _all_ [ScreenComposableFactory]
  * compositions.
@@ -31,19 +30,11 @@ private val LocalHasViewFactoryRootBeenApplied = staticCompositionLocalOf { fals
 public typealias CompositionRoot = @Composable (content: @Composable () -> Unit) -> Unit
 
 /**
- * Convenience function for applying a [CompositionRoot] to this [ViewEnvironment]'s
- * [ScreenComposableFactoryFinder]. See [ScreenComposableFactoryFinder.withCompositionRoot].
- */
-@WorkflowUiExperimentalApi
-public fun ViewEnvironment.withCompositionRoot(root: CompositionRoot): ViewEnvironment {
-  return this +
-    (ScreenComposableFactoryFinder to this[ScreenComposableFactoryFinder].withCompositionRoot(root))
-}
-
-/**
- * Returns a [ScreenViewFactoryFinder] that ensures that any [ScreenComposableFactory]
+ * Returns a [ScreenComposableFactoryFinder] that ensures that any [ScreenComposableFactory]
  * factories registered in this registry will be wrapped exactly once with a [CompositionRoot]
  * wrapper. See [CompositionRoot] for more information.
+ *
+ * You will rarely use this directly, prefer [ViewEnvironment.withComposeInteropSupport]
  */
 @WorkflowUiExperimentalApi
 public fun ScreenComposableFactoryFinder.withCompositionRoot(
@@ -52,8 +43,8 @@ public fun ScreenComposableFactoryFinder.withCompositionRoot(
   return mapFactories { factory ->
     @Suppress("UNCHECKED_CAST")
     (factory as? ScreenComposableFactory<Screen>)?.let { composeFactory ->
-      ScreenComposableFactory(composeFactory.type) { rendering, environment ->
-        WrappedWithRootIfNecessary(root) { composeFactory.Content(rendering, environment) }
+      ScreenComposableFactory(composeFactory.type) { rendering ->
+        WrappedWithRootIfNecessary(root) { composeFactory.Content(rendering) }
       }
     } ?: factory
   }

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/LocalWorkflowEnvironment.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/LocalWorkflowEnvironment.kt
@@ -1,0 +1,10 @@
+package com.squareup.workflow1.ui.compose
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import com.squareup.workflow1.ui.ViewEnvironment
+import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+
+@WorkflowUiExperimentalApi
+public val LocalWorkflowEnvironment: ProvidableCompositionLocal<ViewEnvironment> =
+  compositionLocalOf { ViewEnvironment.EMPTY }

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ViewEnvironmentWithComposeSupport.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ViewEnvironmentWithComposeSupport.kt
@@ -1,10 +1,33 @@
 package com.squareup.workflow1.ui.compose
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ScreenViewFactory
 import com.squareup.workflow1.ui.ScreenViewFactoryFinder
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
+
+/**
+ * Alternative to [WorkflowLayout][com.squareup.workflow1.ui.WorkflowLayout]
+ * for a pure Compose application. Makes the receiver available via [LocalWorkflowEnvironment]
+ * and runs the composition bound to [screen].
+ *
+ * Note that any app relying on stock navigation classes like
+ * [BackStackScreen][com.squareup.workflow1.ui.navigation.BackStackScreen] or
+ * [BodyAndOverlaysScreen][com.squareup.workflow1.ui.navigation.BodyAndOverlaysScreen]
+ * are not pure Compose, and must call [ViewEnvironment.withComposeInteropSupport] first.
+ */
+@WorkflowUiExperimentalApi
+@Composable public fun ViewEnvironment.RootScreen(
+  screen: Screen,
+  modifier: Modifier = Modifier
+) {
+  CompositionLocalProvider(LocalWorkflowEnvironment provides this) {
+    WorkflowRendering(screen, modifier)
+  }
+}
 
 /**
  * Replaces the [ScreenComposableFactoryFinder] and [ScreenViewFactoryFinder]
@@ -14,18 +37,28 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
  * to handle renderings bound to `@Composable` functions, and to allow
  * [WorkflowRendering] to handle renderings bound to [ScreenViewFactory].
  *
- * Note that the standard navigation related [Screen] types
- * (e.g. [BackStackScreen][com.squareup.workflow1.ui.navigation.BackStackScreen])
- * are mainly bound to [View][android.view.View]-based implementations.
+ * Note that the standard navigation [Screen] types
+ * ([BackStackScreen][com.squareup.workflow1.ui.navigation.BackStackScreen] and
+ * [BodyAndOverlaysScreen][com.squareup.workflow1.ui.navigation.BodyAndOverlaysScreen])
+ * are bound to [View][android.view.View]-based implementations.
  * Until that changes, effectively every Compose-based app must call this method.
  *
  * App-specific customizations of [ScreenComposableFactoryFinder] and [ScreenViewFactoryFinder]
  * must be placed in the [ViewEnvironment] before calling this method.
+ *
+ * @param compositionRootOrNull optional [CompositionRoot] to be applied whenever
+ * we create a Compose context, useful hook for applying
+ * [composition locals][androidx.compose.runtime.CompositionLocal] that all
+ * [ScreenComposableFactory] factories need access to, such as UI themes.
  */
 @WorkflowUiExperimentalApi
-public fun ViewEnvironment.withComposeInteropSupport(): ViewEnvironment {
+public fun ViewEnvironment.withComposeInteropSupport(
+  compositionRootOrNull: CompositionRoot? = null
+): ViewEnvironment {
   val rawViewFactoryFinder = get(ScreenViewFactoryFinder)
-  val rawComposableFactoryFinder = get(ScreenComposableFactoryFinder)
+  val rawComposableFactoryFinder = get(ScreenComposableFactoryFinder).let { finder ->
+    compositionRootOrNull?.let { finder.withCompositionRoot(it) } ?: finder
+  }
 
   val convertingViewFactoryFinder = object : ScreenViewFactoryFinder {
     override fun <ScreenT : Screen> getViewFactoryForRendering(
@@ -44,8 +77,8 @@ public fun ViewEnvironment.withComposeInteropSupport(): ViewEnvironment {
       rendering: ScreenT
     ): ScreenComposableFactory<ScreenT>? {
       return rawComposableFactoryFinder.getComposableFactoryForRendering(environment, rendering)
-        ?: rawViewFactoryFinder.getViewFactoryForRendering(environment, rendering)
-          ?.asComposableFactory()
+        ?: rawViewFactoryFinder
+          .getViewFactoryForRendering(environment, rendering)?.asComposableFactory()
     }
   }
 

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/WorkflowRendering.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/WorkflowRendering.kt
@@ -16,7 +16,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import com.squareup.workflow1.ui.Compatible
 import com.squareup.workflow1.ui.Screen
-import com.squareup.workflow1.ui.ScreenViewFactoryFinder
 import com.squareup.workflow1.ui.ScreenViewHolder
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
@@ -24,8 +23,9 @@ import com.squareup.workflow1.ui.WorkflowViewStub
 import com.squareup.workflow1.ui.androidx.WorkflowLifecycleOwner
 
 /**
- * Renders [rendering] into the composition using this [ViewEnvironment]'s
- * [ScreenViewFactoryFinder] to generate the view.
+ * Renders [rendering] into the composition using the [ViewEnvironment] found in
+ * [LocalWorkflowEnvironment] to source a [ScreenComposableFactoryFinder] to generate
+ * the view.
  *
  * This function fulfills a similar role as [ScreenViewHolder] and [WorkflowViewStub],
  * but is much more convenient to use from Composable functions. Note that,
@@ -34,19 +34,17 @@ import com.squareup.workflow1.ui.androidx.WorkflowLifecycleOwner
  *
  * ## Example
  *
- * ```
- * data class FramedRendering<R : Any>(
- *   val borderColor: Color,
- *   val child: R
- * ) : ComposeRendering {
+ *     data class FramedRendering<R : Any>(
+ *       val borderColor: Color,
+ *       val child: R
+ *     ) : ComposeRendering {
  *
- *   @Composable override fun Content(viewEnvironment: ViewEnvironment) {
- *     Surface(border = Border(borderColor, 8.dp)) {
- *       WorkflowRendering(child, viewEnvironment)
+ *       @Composable override fun Content() {
+ *         Surface(border = Border(borderColor, 8.dp)) {
+ *           WorkflowRendering(child)
+ *         }
+ *       }
  *     }
- *   }
- * }
- * ```
  *
  * @param rendering The workflow rendering to display.
  * @param modifier A [Modifier] that will be applied to composable used to show [rendering].
@@ -57,13 +55,13 @@ import com.squareup.workflow1.ui.androidx.WorkflowLifecycleOwner
 @Composable
 public fun WorkflowRendering(
   rendering: Screen,
-  viewEnvironment: ViewEnvironment,
   modifier: Modifier = Modifier
 ) {
   // This will fetch a new view factory any time the new rendering is incompatible with the previous
   // one, as determined by Compatible. This corresponds to WorkflowViewStub's canShowRendering
   // check.
   val renderingCompatibilityKey = Compatible.keyFor(rendering)
+  val viewEnvironment = LocalWorkflowEnvironment.current
 
   // By surrounding the below code with this key function, any time the new rendering is not
   // compatible with the previous rendering we'll tear down the previous subtree of the composition,
@@ -91,7 +89,7 @@ public fun WorkflowRendering(
       // into this function is to directly control the layout of the child view – which means
       // minimum constraints are likely to be significant.
       Box(modifier, propagateMinConstraints = true) {
-        composableFactory.Content(rendering, viewEnvironment)
+        composableFactory.Content(rendering)
       }
     }
   }


### PR DESCRIPTION
* Introduces `LocalWorkflowEnvironment` and eliminates explicit `ViewEnvironment` parameters from `ScreenComposableFactory.Content`, `ComposeScreen.Content`, etc. It is put in place automatically by the default implementation of `ScreenComposableFactoryFinder`.

* Adds optional `CompositionRoot` argument to `ViewEnvironment.withComposeInteropSupport()`. `CompositionRoot` is our existing hook to ensure `CompositionLocal`s (e.g. for UI themes) are put in play above the `@Composable Content()` function invoked for any `Screen`.

* Replaces `ViewEnvironment.withCompositionRoot` with `@Composable fun ViewEnvironment.RootScreen`, as our preferred Compose-friendly alternative to `WorkflowLayout`

An `Activity` that uses `setContent {}` instead of `setContentView()` can now kick things off like so:

```kotlin
  override fun onCreate(savedInstanceState: Bundle?) {
    super.onCreate(savedInstanceState)

    val environment : ViewEnvironment = ViewEnvironment.EMPTY +
      // ...
      .withComposeInteropSupport()

    val rootScreen by RootWorkflow.renderAsState(
      props = Unit,
      onOutput = {},
    )

    setContent {
      environment.RootScreen(rootScreen)
    }
  }
```
