### PR TITLE
DialogCollator destroys/rebuild instead of dismiss/show

### DIFF
--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/navigation/DialogSession.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/navigation/DialogSession.kt
@@ -5,9 +5,6 @@ import android.os.Parcel
 import android.os.Parcelable
 import android.os.Parcelable.Creator
 import android.view.KeyEvent
-import android.view.KeyEvent.ACTION_UP
-import android.view.KeyEvent.KEYCODE_BACK
-import android.view.KeyEvent.KEYCODE_ESCAPE
 import android.view.MotionEvent
 import android.view.Window.Callback
 import androidx.activity.OnBackPressedDispatcher
@@ -93,9 +90,6 @@ internal class DialogSession(
    * newfangled ([stateRegistryAggregator]).
    */
   val savedStateKey = Compatible.keyFor(initialOverlay)
-
-  private val KeyEvent.isBackPress: Boolean
-    get() = (keyCode == KEYCODE_BACK || keyCode == KEYCODE_ESCAPE) && action == ACTION_UP
 
   /**
    * One time call to set up our brand new [OverlayDialogHolder] instance.
@@ -242,10 +236,13 @@ internal class DialogSession(
    * We are never going to use this `Dialog` again. Tear down our lifecycle hooks
    * and dismiss it.
    */
-  fun destroyDialog() {
+  fun destroyDialog(saveViewState: Boolean = false) {
     if (!destroyed) {
       destroyed = true
       with(holder.dialog) {
+        if (isShowing && saveViewState) {
+          stateRegistryAggregator.saveAndPruneChildRegistryOwner(savedStateKey)
+        }
         // The dialog's views are about to be detached, and when that happens we want to transition
         // the dialog view's lifecycle to a terminal state even though the parent is probably still
         // alive.


### PR DESCRIPTION
When `DialogCollator` has to reorder, it did so by calling `Dialog.dismiss()` and `Dialog.show()`. #1213 fixed a problem that caused for `ComposeView`, but that fix is undone by Compose 1.6.8. @vumngoc dug in to see why and discovered:

> The `onClick` in `Modifier.clickable` is passed all the way down to `pointerInputHandler` in `SuspendingPointerInputModifierNodeImpl` (when the screen is responsive, you should see `pointerInputHandler()` being called in `SuspendingPointerInputModifierNodeImpl#onPointerEvent`).
>
> After shuffling the overlays, even though the `ClickableNode` is found and `SuspendingPointerInputModifierNodeImpl#onPointerEvent` is called, `pointerInputHandler()` is never called  because the `pointerInputJob` in `SuspendingPointerInputModifierNodeImpl` was launched from a canceled coroutineScope. Tracking down that coroutineScope shows that it was canceled when `DialogCollator` calls `Dialog.dismiss` -> `onViewDetachedFromWindow`  -> `Recomposer.cancel()`. So it makes sense why destroying/rebuilding instead of dismissing and reusing the dialog fixes this issue.

Still need to put together a non-workflow repro sample and submit a bug to the Compose team, but this unblocks our move to Compose 1.6.8 in the meantime.