### PR TITLE
Updates `ComposeViewTreeIntegrationTest` to cover `ComposeScreen`

### DIFF
--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.platform.ViewCompositionStrategy.Companion
 import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnDetachedFromWindow
 import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
 import androidx.compose.ui.platform.testTag


### PR DESCRIPTION
`ComposeViewTreeIntegrationTest` was built around its own `ScreenViewFactory`, and so did not cover the production code that normally builds `ComposeView`. Now we use that thing only for a few spots where we cover the effects of specific `ViewCompositionStrategy` implementations.