### PR TITLE
Reverts ComposeView `ViewCompositionStrategy` to default.

### DIFF
--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ScreenComposableFactory.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ScreenComposableFactory.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import com.squareup.workflow1.ui.Screen
@@ -126,7 +125,6 @@ public fun <ScreenT : Screen> ScreenComposableFactory<ScreenT>.asViewFactory():
       container: ViewGroup?
     ): ScreenViewHolder<ScreenT> {
       val view = ComposeView(context)
-      view.setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)
       return ScreenViewHolder(initialEnvironment, view) { newRendering, environment ->
 
         // Update the state whenever a new rendering is emitted.


### PR DESCRIPTION
This was the first attempt to fix dead `ComposeView` instances in shuffled `Dialog` windows, but it breaks other things. Still seems like the right thing to do, but maybe that ship has sailed. If the need comes up again, consider adding a `ViewEnvironment` property to allow customizing it (yuck).

Undoes #1213