### PR TITLE
Bumps minSdk to 24

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 androidTools = "8.1.2"
 
 compileSdk = "34"
-minSdk = "21"
+minSdk = "24"
 targetSdk = "33"
 
 jdk-target = "1.8"


### PR DESCRIPTION
Fixes https://issuetracker.google.com/issues/194289155, and really we should have moved this years ago. Even 24 is too old but Square is stuck on it for a bit longer.