### PR TITLE
Makes `TextController` support equals

### DIFF
--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/TextController.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/TextController.kt
@@ -87,4 +87,17 @@ private class TextControllerImpl(initialValue: String) : TextController {
     set(value) {
       _textValue.value = value
     }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as TextController
+
+    return textValue == other.textValue
+  }
+
+  override fun hashCode(): Int {
+    return textValue.hashCode()
+  }
 }

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/TextControllerTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/TextControllerTest.kt
@@ -1,0 +1,21 @@
+package com.squareup.workflow1.ui
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+@OptIn(WorkflowUiExperimentalApi::class)
+internal class TextControllerTest {
+
+  @Test fun `equals works with the same value`() {
+    val controller1 = TextController(initialValue = "apple")
+    val controller2 = TextController(initialValue = "apple")
+    assertEquals(controller1, controller2)
+  }
+
+  @Test fun `equals works with different values`() {
+    val controller1 = TextController(initialValue = "apple")
+    val controller2 = TextController(initialValue = "orange")
+    assertNotEquals(controller1, controller2)
+  }
+}


### PR DESCRIPTION
Allows comparing `TextController` by the current `textValue`.