### PR TITLE
Improves `TextController` test coverage

### DIFF
--- a/workflow-ui/core-common/build.gradle.kts
+++ b/workflow-ui/core-common/build.gradle.kts
@@ -11,5 +11,7 @@ dependencies {
   testImplementation(libs.junit)
   testImplementation(libs.kotlin.test.core)
   testImplementation(libs.kotlin.test.jdk)
+  testImplementation(libs.kotlinx.coroutines.test)
   testImplementation(libs.truth)
+  testImplementation(libs.turbine)
 }

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/TextControllerTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/TextControllerTest.kt
@@ -1,11 +1,41 @@
 package com.squareup.workflow1.ui
 
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 @OptIn(WorkflowUiExperimentalApi::class)
 internal class TextControllerTest {
+
+  @Test fun `does not emit initial value`() = runTest {
+    val controller = TextController()
+    controller.onTextChanged.test {
+      expectNoEvents()
+    }
+  }
+
+  @Test fun `emits value when text changes`() = runTest {
+    val controller = TextController()
+    controller.onTextChanged.test {
+      controller.textValue = "apple"
+      assertThat(awaitItem()).isEqualTo("apple")
+      controller.textValue = "orange"
+      assertThat(awaitItem()).isEqualTo("orange")
+    }
+  }
+
+  @Test fun `does not emit twice with the same value`() = runTest {
+    val controller = TextController()
+    controller.onTextChanged.test {
+      controller.textValue = "apple"
+      assertThat(awaitItem()).isEqualTo("apple")
+      controller.textValue = "apple"
+      expectNoEvents()
+    }
+  }
 
   @Test fun `equals works with the same value`() {
     val controller1 = TextController(initialValue = "apple")


### PR DESCRIPTION
Some tests for `TextController` were added in https://github.com/square/workflow-kotlin/pull/1224 to support `equals` and `hashCode`, and this improves the coverage.