### PR TITLE
`action {}`, `eventHandler {}` with no debugging name is deprecated

### DIFF
--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/MaybeLoadingGatekeeperWorkflow.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/MaybeLoadingGatekeeperWorkflow.kt
@@ -32,7 +32,7 @@ class MaybeLoadingGatekeeperWorkflow<T : Any>(
     context: RenderContext
   ): MayBeLoadingScreen {
     context.runningWorker(isLoading.asTraceableWorker("GatekeeperLoading")) {
-      action {
+      action("GatekeeperLoading") {
         state = it
       }
     }

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemWorkflow.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemWorkflow.kt
@@ -122,7 +122,7 @@ class PerformancePoemWorkflow(
           },
           "initializing"
         ) {
-          action {
+          action("initializing") {
             isLoading.value = false
             state = Selected(NO_SELECTED_STANZA)
           }
@@ -148,7 +148,7 @@ class PerformancePoemWorkflow(
                 }
               }.asTraceableWorker("EventRepetition")
             ) {
-              action {
+              action("currentStateIsLoading delay") {
                 (state as? ComplexCall)?.let { currentState ->
                   // Still repeating the complex call
                   state = ComplexCall(
@@ -167,7 +167,7 @@ class PerformancePoemWorkflow(
                 // is already in the state.
               }
             ) {
-              action {
+              action("loaded") {
                 isLoading.value = false
                 (state as? ComplexCall)?.let { currentState ->
                   state = Selected(currentState.payload)

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemsBrowserWorkflow.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemsBrowserWorkflow.kt
@@ -55,17 +55,17 @@ class PerformancePoemsBrowserWorkflow(
   StatefulWorkflow<ConfigAndPoems, State, Unit, OverviewDetailScreen<*>>() {
 
   sealed class State {
-    object Recurse : State()
+    data object Recurse : State()
 
     // N.B. This state is a smell. We include it to be able to mimic smells
     // we encounter in real life. Best practice would be to fold it
     // into [NoSelection] at the very least.
-    object Initializing : State()
+    data object Initializing : State()
     data class ComplexCall(
       val payload: Int
     ) : State()
 
-    object NoSelection : State()
+    data object NoSelection : State()
     data class Selected(val poemIndex: Int) : State()
   }
 
@@ -122,7 +122,7 @@ class PerformancePoemsBrowserWorkflow(
           props = nextProps,
           key = "${nextProps.first},${nextProps.second}",
         ) {
-          action {
+          action("setOutput") {
             setOutput(it)
           }
         }
@@ -134,7 +134,7 @@ class PerformancePoemsBrowserWorkflow(
       is Initializing -> {
         context.runningWorker(TraceableWorker.from("BrowserInitializing") { Unit }, "init") {
           isLoading.value = true
-          action {
+          action("onInitialized") {
             isLoading.value = false
             state = NoSelection
           }
@@ -178,7 +178,7 @@ class PerformancePoemsBrowserWorkflow(
                 // is already in the state.
               }
             ) {
-              action {
+              action("onComplexCall") {
                 isLoading.value = false
                 (state as? ComplexCall)?.let { currentState ->
                   state = if (currentState.payload != NO_POEM_SELECTED) {
@@ -229,7 +229,7 @@ class PerformancePoemsBrowserWorkflow(
 
   private fun choosePoem(
     index: Int
-  ) = action {
+  ) = action("choosePoem") {
     state = if (simulatedPerfConfig.isComplex) {
       ComplexCall(payload = index)
     } else {

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/HelloComposeWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/HelloComposeWorkflow.kt
@@ -19,7 +19,7 @@ object HelloComposeWorkflow : StatefulWorkflow<Unit, State, Nothing, HelloCompos
     }
   }
 
-  private val helloAction = action {
+  private val helloAction = action("hello") {
     state = state.theOtherState()
   }
 

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloWorkflow.kt
@@ -28,7 +28,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
     val onClick: () -> Unit
   ) : Screen
 
-  private val helloAction = action {
+  private val helloAction = action("hello") {
     state = state.theOtherState()
   }
 

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/ComposeWorkflowImpl.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/ComposeWorkflowImpl.kt
@@ -76,5 +76,5 @@ internal class ComposeWorkflowImpl<PropsT, OutputT : Any>(
   // Compiler bug doesn't let us call Snapshot.EMPTY.
   override fun snapshotState(state: State<PropsT, OutputT>): Snapshot = Snapshot.of("")
 
-  private fun forwardOutput(output: OutputT) = action { setOutput(output) }
+  private fun forwardOutput(output: OutputT) = action("forwardOutput") { setOutput(output) }
 }

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/HelloWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/HelloWorkflow.kt
@@ -26,7 +26,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, ComposeScreen>() {
     }
   }
 
-  private val helloAction = action {
+  private val helloAction = action("hello") {
     state = state.theOtherState()
   }
 

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
@@ -40,7 +40,7 @@ object InlineRenderingWorkflow : StatefulWorkflow<Unit, Int, Nothing, Screen>() 
     context: RenderContext
   ) = ComposeScreen {
     Box {
-      Button(onClick = context.eventHandler { state += 1 }) {
+      Button(onClick = context.eventHandler("increment") { state += 1 }) {
         Text("Counter: ")
         AnimatedCounter(renderState) { counterValue ->
           Text(counterValue.toString())

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/RecursiveWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/RecursiveWorkflow.kt
@@ -73,11 +73,11 @@ object RecursiveWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>() {
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private fun addChild() = action {
+  private fun addChild() = action("addChild") {
     state = state.copy(children = state.children + 1)
   }
 
-  private fun reset() = action {
+  private fun reset() = action("reset") {
     state = State()
   }
 }

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/TextInputWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/TextInputWorkflow.kt
@@ -23,7 +23,7 @@ object TextInputWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
     val onSwapText: () -> Unit
   ) : Screen
 
-  private val swapText = action {
+  private val swapText = action("swapText") {
     state = state.copy(showingTextA = !state.showingTextA)
   }
 

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/AreYouSureWorkflow.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/AreYouSureWorkflow.kt
@@ -101,7 +101,7 @@ object AreYouSureWorkflow :
 
   override fun snapshotState(state: State) = state.toSnapshot()
 
-  private val maybeQuit = action { state = Quitting }
-  private val confirmQuit = action { setOutput(Finished) }
-  private val cancelQuit = action { state = Running }
+  private val maybeQuit = action("maybeQuit") { state = Quitting }
+  private val confirmQuit = action("confirmQuit") { setOutput(Finished) }
+  private val cancelQuit = action("cancelQuit") { state = Running }
 }

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
@@ -32,7 +32,7 @@ object HelloBackButtonWorkflow : StatefulWorkflow<Unit, State, Nothing, HelloBac
   ): HelloBackButtonScreen {
     return HelloBackButtonScreen(
       message = "$renderState",
-      onClick = context.eventHandler {
+      onClick = context.eventHandler("onClick") {
         state = when (state) {
           Able -> Baker
           Baker -> Charlie
@@ -42,7 +42,7 @@ object HelloBackButtonWorkflow : StatefulWorkflow<Unit, State, Nothing, HelloBac
       onBackPressed = if (renderState == Able) {
         null
       } else {
-        context.eventHandler {
+        context.eventHandler("onBackPressed") {
           state = when (state) {
             Able -> throw IllegalStateException()
             Baker -> Able

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemListWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemListWorkflow.kt
@@ -21,7 +21,7 @@ object PoemListWorkflow : StatelessWorkflow<Props, Int, PoemListScreen>() {
     return PoemListScreen(
       poems = renderProps.poems,
       onPoemSelected = context.eventHandler(
-        name = { renderProps.eventHandlerTag("E-PoemList-PoemSelected") }
+        name = renderProps.eventHandlerTag("E-PoemList-PoemSelected")
       ) { index -> setOutput(index) }
     )
   }

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
@@ -30,15 +30,13 @@ object StanzaListWorkflow : StatelessWorkflow<Props, SelectedStanza, StanzaListS
       subtitle = poem.poet.fullName,
       firstLines = poem.initialStanzas,
       onStanzaSelected = context.eventHandler(
-        name = { renderProps.eventHandlerTag("E-StanzaList-StanzaSelected") }
+        name = renderProps.eventHandlerTag("E-StanzaList-StanzaSelected")
       ) { index ->
         setOutput(
           index
         )
       },
-      onExit = context.eventHandler(
-        name = { renderProps.eventHandlerTag("E-StanzaList-Exit") }
-      ) {
+      onExit = context.eventHandler(name = renderProps.eventHandlerTag("E-StanzaList-Exit")) {
         setOutput(
           NO_SELECTED_STANZA
         )

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
@@ -30,7 +30,7 @@ object StanzaWorkflow : StatelessWorkflow<Props, Output, StanzaScreen>() {
         0 -> null
         else -> {
           context.eventHandler(
-            name = { renderProps.eventHandlerTag("E-StanzaWorkflow-${ShowPreviousStanza.name}") }
+            name = renderProps.eventHandlerTag("E-StanzaWorkflow-${ShowPreviousStanza.name}")
           ) {
             setOutput(
               ShowPreviousStanza
@@ -43,7 +43,7 @@ object StanzaWorkflow : StatelessWorkflow<Props, Output, StanzaScreen>() {
         poem.stanzas.size - 1 -> null
         else -> {
           context.eventHandler(
-            name = { renderProps.eventHandlerTag("E-StanzaWorkflow-${ShowNextStanza.name}") }
+            name = renderProps.eventHandlerTag("E-StanzaWorkflow-${ShowNextStanza.name}")
           ) {
             setOutput(
               ShowNextStanza
@@ -54,7 +54,7 @@ object StanzaWorkflow : StatelessWorkflow<Props, Output, StanzaScreen>() {
 
       return StanzaScreen(
         onGoUp = context.eventHandler(
-          name = { renderProps.eventHandlerTag("E-StanzaWorkflow-${CloseStanzas.name}") }
+          name = renderProps.eventHandlerTag("E-StanzaWorkflow-${CloseStanzas.name}")
         ) {
           setOutput(
             CloseStanzas

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
@@ -67,11 +67,11 @@ class DungeonAppWorkflow(
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private fun displayBoards(boards: Map<String, Board>) = action {
+  private fun displayBoards(boards: Map<String, Board>) = action("displayBoards") {
     state = ChoosingBoard(boards.toList())
   }
 
-  private fun selectBoard(index: Int) = action {
+  private fun selectBoard(index: Int) = action("selectBoard") {
     // No-op if we're not in the ChoosingBoard state.
     val boards = (state as? ChoosingBoard)?.boards ?: return@action
     state = PlayingGame(boards[index].first)

--- a/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineWorkflow.kt
+++ b/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineWorkflow.kt
@@ -104,7 +104,7 @@ class ShakeableTimeMachineWorkflow<in P, O : Any, out R : Screen>(
     )
   }
 
-  private val onShake = action {
+  private val onShake = action("onShake") {
     state = PlayingBack(Duration.INFINITE)
   }
 
@@ -122,5 +122,5 @@ class ShakeableTimeMachineWorkflow<in P, O : Any, out R : Screen>(
     }
   }
 
-  private fun forwardOutput(output: O) = action { setOutput(output) }
+  private fun forwardOutput(output: O) = action("forwardOutput") { setOutput(output) }
 }

--- a/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/TimeMachineWorkflow.kt
+++ b/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/TimeMachineWorkflow.kt
@@ -82,5 +82,5 @@ class TimeMachineWorkflow<P, O : Any, out R>(
     return context.renderChild(recordingWorkflow, recorderProps)
   }
 
-  private fun forwardOutput(output: O) = action { setOutput(output) }
+  private fun forwardOutput(output: O) = action("forwardOutput") { setOutput(output) }
 }

--- a/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
+++ b/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
@@ -25,7 +25,7 @@ class TimeMachineWorkflowTest {
     val delegateWorkflow = Workflow.stateful<String, Nothing, DelegateRendering>(
       initialState = "initial",
       render = { renderState ->
-        DelegateRendering(renderState, setState = eventHandler { s -> state = s })
+        DelegateRendering(renderState, setState = eventHandler("") { s -> state = s })
       }
     )
     val clock = TestTimeSource()

--- a/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
+++ b/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
@@ -43,7 +43,7 @@ class BlinkingCursorWorkflow(
 
   override fun snapshotState(state: Boolean): Snapshot? = null
 
-  private fun setCursorShowing(showing: Boolean) = action {
+  private fun setCursorShowing(showing: Boolean) = action("setCursorShowing") {
     state = showing
   }
 }

--- a/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/HelloTerminalWorkflow.kt
+++ b/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/HelloTerminalWorkflow.kt
@@ -61,7 +61,7 @@ class HelloTerminalWorkflow : TerminalWorkflow,
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private fun onKeystroke(key: KeyStroke): HelloTerminalAction = action {
+  private fun onKeystroke(key: KeyStroke): HelloTerminalAction = action("onKeystroke") {
     when {
       key.character == 'Q' -> setOutput(0)
       key.keyType == Backspace -> state = state.backspace()

--- a/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
+++ b/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
@@ -67,7 +67,7 @@ class EditTextWorkflow : StatefulWorkflow<EditTextProps, EditTextState, String, 
 
   private fun onKeystroke(
     key: KeyStroke
-  ) = action {
+  ) = action("onKeystroke") {
     when (key.keyType) {
       Character -> {
         val newText = props.text.insertCharAt(state.cursorPosition, key.character!!)

--- a/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/TodoWorkflow.kt
+++ b/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/TodoWorkflow.kt
@@ -78,7 +78,7 @@ class TodoWorkflow : TerminalWorkflow,
 
   override fun snapshotState(state: TodoList): Snapshot? = null
 
-  private fun onKeystroke(key: KeyStroke) = action {
+  private fun onKeystroke(key: KeyStroke) = action("onKeystroke") {
     when (key.keyType) {
       ArrowUp -> state = state.moveFocusUp()
       ArrowDown -> state = state.moveFocusDown()
@@ -90,14 +90,14 @@ class TodoWorkflow : TerminalWorkflow,
   }
 }
 
-private fun updateTitle(newTitle: String): TodoAction = action {
+private fun updateTitle(newTitle: String): TodoAction = action("updateTitle") {
   state = state.copy(title = newTitle)
 }
 
 private fun setLabel(
   index: Int,
   text: String
-): TodoAction = action {
+): TodoAction = action("setLabel") {
   state = state.copy(
     items = state.items.mapIndexed { i, item ->
       if (index == i) item.copy(label = text) else item

--- a/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
+++ b/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
@@ -33,7 +33,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, HelloRendering>() 
 
   override fun snapshotState(state: State): Snapshot = Snapshot.of(if (state == Hello) 1 else 0)
 
-  private val helloAction = action {
+  private val helloAction = action("hello") {
     state = when (state) {
       Hello -> Goodbye
       Goodbye -> Hello

--- a/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
+++ b/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
@@ -33,7 +33,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, HelloRendering>() 
 
   override fun snapshotState(state: State): Snapshot = Snapshot.of(if (state == Hello) 1 else 0)
 
-  private val helloAction = action {
+  private val helloAction = action("hello") {
     state = when (state) {
       Hello -> Goodbye
       Goodbye -> Hello

--- a/samples/nested-overlays/src/main/java/com/squareup/sample/nestedoverlays/NestedOverlaysWorkflow.kt
+++ b/samples/nested-overlays/src/main/java/com/squareup/sample/nestedoverlays/NestedOverlaysWorkflow.kt
@@ -32,23 +32,29 @@ object NestedOverlaysWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>()
     context: RenderContext
   ): Screen {
     if (renderState.nuked) {
-      return ButtonBar(Button(R.string.reset, context.eventHandler { state = State() }))
+      return ButtonBar(Button(R.string.reset, context.eventHandler("reset") { state = State() }))
     }
 
     val toggleTopBarButton = Button(
       name = if (renderState.showTopBar) R.string.hide_top else R.string.show_top,
-      onClick = context.eventHandler { state = state.copy(showTopBar = !state.showTopBar) }
+      onClick = context.eventHandler("show / hide top") {
+        state = state.copy(showTopBar = !state.showTopBar)
+      }
     )
 
     val toggleBottomBarButton = Button(
       name = if (renderState.showBottomBar) R.string.hide_bottom else R.string.show_bottom,
-      onClick = context.eventHandler { state = state.copy(showBottomBar = !state.showBottomBar) }
+      onClick = context.eventHandler("show / hide bottom") {
+        state = state.copy(showBottomBar = !state.showBottomBar)
+      }
     )
 
     val outerSheet = if (!renderState.showOuterSheet) {
       null
     } else {
-      val closeOuter = context.eventHandler { state = state.copy(showOuterSheet = false) }
+      val closeOuter = context.eventHandler("closeOuter") {
+        state = state.copy(showOuterSheet = false)
+      }
       FullScreenModal(
         BackButtonScreen(
           ButtonBar(
@@ -68,7 +74,9 @@ object NestedOverlaysWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>()
     val innerSheet = if (!renderState.showInnerSheet) {
       null
     } else {
-      val closeInner = context.eventHandler { state = state.copy(showInnerSheet = false) }
+      val closeInner = context.eventHandler("closeInner") {
+        state = state.copy(showInnerSheet = false)
+      }
       FullScreenModal(
         BackButtonScreen(
           ButtonBar(
@@ -80,7 +88,7 @@ object NestedOverlaysWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>()
             toggleBottomBarButton,
             Button(
               name = R.string.nuke,
-              onClick = context.eventHandler { state = State(nuked = true) }
+              onClick = context.eventHandler("nuke") { state = State(nuked = true) }
             ),
             color = android.R.color.holo_red_light,
             showEditText = true
@@ -114,14 +122,14 @@ object NestedOverlaysWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>()
     toggleInnerSheetButton(renderState),
     Button(
       name = R.string.cover_all,
-      onClick = eventHandler { state = state.copy(showOuterSheet = true) }
+      onClick = eventHandler("cover everything") { state = state.copy(showOuterSheet = true) }
     )
   )
 
   private fun RenderContext.toggleInnerSheetButton(renderState: State) =
     Button(
       name = if (renderState.showInnerSheet) R.string.reveal_body else R.string.cover_body,
-      onClick = eventHandler {
+      onClick = eventHandler("reveal / cover body") {
         state = state.copy(showInnerSheet = !state.showInnerSheet)
       }
     )

--- a/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityWorkflow.kt
+++ b/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityWorkflow.kt
@@ -30,7 +30,7 @@ object StubVisibilityWorkflow : StatefulWorkflow<Unit, State, Nothing, OuterRend
     HideBottom -> OuterRendering(
       top = ClickyTextRendering(message = "Click to show footer") {
         context.actionSink.send(
-          action {
+          action("HideBottom") {
             this@action.state = ShowBottom
           }
         )
@@ -40,7 +40,7 @@ object StubVisibilityWorkflow : StatefulWorkflow<Unit, State, Nothing, OuterRend
     ShowBottom -> OuterRendering(
       top = ClickyTextRendering(message = "Click to hide footer") {
         context.actionSink.send(
-          action {
+          action("ShowBottom") {
             this@action.state = HideBottom
           }
         )

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/TicTacToeWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/TicTacToeWorkflow.kt
@@ -106,9 +106,9 @@ class TicTacToeWorkflow(
 
   override fun snapshotState(state: MainState): Snapshot = state.toSnapshot()
 
-  private val startAuth = action { state = Authenticating }
+  private val startAuth = action("startAuth") { state = Authenticating }
 
-  private fun handleAuthResult(result: AuthResult) = action {
+  private fun handleAuthResult(result: AuthResult) = action("handleAuthResult") {
     when (result) {
       is Canceled -> setOutput(Unit)
       is Authorized -> state = RunningGame

--- a/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/TicTacToeWorkflowTest.kt
+++ b/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/TicTacToeWorkflowTest.kt
@@ -44,7 +44,7 @@ class TicTacToeWorkflowTest {
   @Test fun `starts game on auth then moves to run game`() {
     val authWorkflow: AuthWorkflow = Workflow.stateless {
       runningWorker(Worker.from { }) {
-        action { setOutput(Authorized("auth")) }
+        action("auth") { setOutput(Authorized("auth")) }
       }
       authScreen()
     }

--- a/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
+++ b/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
@@ -15,7 +15,7 @@ import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
 sealed class TodoEditorOutput {
   data class ListUpdated(val newList: TodoList) : TodoEditorOutput()
-  object Done : TodoEditorOutput()
+  data object Done : TodoEditorOutput()
 }
 
 /**
@@ -58,12 +58,12 @@ class TodoEditorWorkflow :
     )
   }
 
-  private val textChanged = action {
+  private val textChanged = action("textChanged") {
     state = state.maintainEmptyLastRow()
     setOutput(ListUpdated(state.toTodoList()))
   }
 
-  private fun checkboxClicked(index: Int) = action {
+  private fun checkboxClicked(index: Int) = action("checkboxClicked") {
     state = state.copy(
       rows = state.rows.mapIndexed { i, row ->
         if (i == index) row.copy(checked = !row.checked) else row
@@ -72,13 +72,13 @@ class TodoEditorWorkflow :
     setOutput(ListUpdated(state.toTodoList()))
   }
 
-  private fun deleteClicked(index: Int) = action {
+  private fun deleteClicked(index: Int) = action("deleteClicked") {
     state = state.copy(rows = state.rows.filterIndexed { i, _ -> i != index })
       .maintainEmptyLastRow()
     setOutput(ListUpdated(state.toTodoList()))
   }
 
-  private val goBackClicked = action {
+  private val goBackClicked = action("goBackClicked") {
     setOutput(Done)
   }
 }

--- a/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
+++ b/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
@@ -43,11 +43,11 @@ object TodoListsAppWorkflow :
   private val listsWorkflow = TodoListsWorkflow()
   private val editorWorkflow = TodoEditorWorkflow()
 
-  private fun onListSelected(index: Int) = action {
+  private fun onListSelected(index: Int) = action("onListSelected") {
     state = EditingList(state.lists, index)
   }
 
-  private fun onEditOutput(output: TodoEditorOutput) = action {
+  private fun onEditOutput(output: TodoEditorOutput) = action("onEditOutput") {
     state = when (output) {
       is ListUpdated -> {
         val oldState = state as EditingList

--- a/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
+++ b/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
@@ -17,7 +17,7 @@ class TodoListsWorkflow : StatelessWorkflow<List<TodoList>, Int, TodoListsScreen
   ): TodoListsScreen {
     return TodoListsScreen(
       lists = renderProps,
-      onRowClicked = context.eventHandler { index -> setOutput(index) }
+      onRowClicked = context.eventHandler("onRowClicked") { index -> setOutput(index) }
     )
   }
 }

--- a/samples/tutorial/tutorial-1-complete/src/main/java/workflow/tutorial/WelcomeWorkflow.kt
+++ b/samples/tutorial/tutorial-1-complete/src/main/java/workflow/tutorial/WelcomeWorkflow.kt
@@ -29,7 +29,7 @@ object WelcomeWorkflow : StatefulWorkflow<Unit, State, Output, WelcomeScreen>() 
     onLoginTapped = {}
   )
 
-  private fun onUsernameChanged(username: String) = action {
+  private fun onUsernameChanged(username: String) = action("onUsernameChanged") {
     state = state.copy(username = username)
   }
 

--- a/samples/tutorial/tutorial-2-complete/src/main/java/workflow/tutorial/RootWorkflow.kt
+++ b/samples/tutorial/tutorial-2-complete/src/main/java/workflow/tutorial/RootWorkflow.kt
@@ -65,11 +65,11 @@ object RootWorkflow : StatefulWorkflow<Unit, State, Nothing, BackStackScreen<Any
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private fun login(username: String) = action {
+  private fun login(username: String) = action("login") {
     state = Todo(username)
   }
 
-  private val logout = action {
+  private val logout = action("logout") {
     state = Welcome
   }
 }

--- a/samples/tutorial/tutorial-2-complete/src/main/java/workflow/tutorial/TodoListWorkflow.kt
+++ b/samples/tutorial/tutorial-2-complete/src/main/java/workflow/tutorial/TodoListWorkflow.kt
@@ -51,7 +51,7 @@ object TodoListWorkflow : StatefulWorkflow<ListProps, State, Back, TodoListScree
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private fun onBack() = action {
+  private fun onBack() = action("onBack") {
     setOutput(Back)
   }
 }

--- a/samples/tutorial/tutorial-2-complete/src/main/java/workflow/tutorial/WelcomeWorkflow.kt
+++ b/samples/tutorial/tutorial-2-complete/src/main/java/workflow/tutorial/WelcomeWorkflow.kt
@@ -32,11 +32,11 @@ object WelcomeWorkflow : StatefulWorkflow<Unit, State, LoggedIn, WelcomeScreen>(
       }
   )
 
-  private fun onUsernameChanged(username: String) = action {
+  private fun onUsernameChanged(username: String) = action("onUsernameChanged") {
     state = state.copy(username = username)
   }
 
-  private fun onLogin() = action {
+  private fun onLogin() = action("onLogin") {
     setOutput(LoggedIn(state.username))
   }
 

--- a/samples/tutorial/tutorial-3-complete/src/main/java/workflow/tutorial/RootWorkflow.kt
+++ b/samples/tutorial/tutorial-3-complete/src/main/java/workflow/tutorial/RootWorkflow.kt
@@ -62,11 +62,11 @@ object RootWorkflow : StatefulWorkflow<Unit, State, Nothing, BackStackScreen<Any
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private fun login(username: String) = action {
+  private fun login(username: String) = action("login") {
     state = Todo(username)
   }
 
-  private val logout = action {
+  private val logout = action("logout") {
     state = Welcome
   }
 }

--- a/samples/tutorial/tutorial-3-complete/src/main/java/workflow/tutorial/TodoEditWorkflow.kt
+++ b/samples/tutorial/tutorial-3-complete/src/main/java/workflow/tutorial/TodoEditWorkflow.kt
@@ -63,20 +63,20 @@ object TodoEditWorkflow : StatefulWorkflow<EditProps, State, Output, TodoEditScr
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private fun onTitleChanged(title: String) = action {
+  private fun onTitleChanged(title: String) = action("onTitleChanged") {
     state = state.withTitle(title)
   }
 
-  private fun onNoteChanged(note: String) = action {
+  private fun onNoteChanged(note: String) = action("onNoteChanged") {
     state = state.withNote(note)
   }
 
-  private fun onDiscard() = action {
+  private fun onDiscard() = action("onDiscard") {
     // Emit the Discard output when the discard action is received.
     setOutput(Discard)
   }
 
-  private fun onSave() = action {
+  private fun onSave() = action("onSave") {
     // Emit the Save output with the current todo state when the save action is received.
     setOutput(Save(state.todo))
   }

--- a/samples/tutorial/tutorial-3-complete/src/main/java/workflow/tutorial/TodoListWorkflow.kt
+++ b/samples/tutorial/tutorial-3-complete/src/main/java/workflow/tutorial/TodoListWorkflow.kt
@@ -85,17 +85,17 @@ object TodoListWorkflow : StatefulWorkflow<ListProps, State, Back, List<Any>>() 
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private fun onBack() = action {
+  private fun onBack() = action("onBack") {
     // When an onBack action is received, emit a Back output.
     setOutput(Back)
   }
 
-  private fun selectTodo(index: Int) = action {
+  private fun selectTodo(index: Int) = action("selectTodo") {
     // When a todo item is selected, edit it.
     state = state.copy(step = Step.Edit(index))
   }
 
-  private fun discardChanges() = action {
+  private fun discardChanges() = action("discardChanges") {
     // When a discard action is received, return to the list.
     state = state.copy(step = Step.List)
   }
@@ -103,7 +103,7 @@ object TodoListWorkflow : StatefulWorkflow<ListProps, State, Back, List<Any>>() 
   private fun saveChanges(
     todo: TodoModel,
     index: Int
-  ) = action {
+  ) = action("saveChanges") {
     // When changes are saved, update the state of that todo item and return to the list.
     state = state.copy(
         todos = state.todos.toMutableList().also { it[index] = todo },

--- a/samples/tutorial/tutorial-3-complete/src/main/java/workflow/tutorial/WelcomeWorkflow.kt
+++ b/samples/tutorial/tutorial-3-complete/src/main/java/workflow/tutorial/WelcomeWorkflow.kt
@@ -32,11 +32,11 @@ object WelcomeWorkflow : StatefulWorkflow<Unit, State, LoggedIn, WelcomeScreen>(
       }
   )
 
-  private fun onNameChanged(name: String) = action {
+  private fun onNameChanged(name: String) = action("onNameChanged") {
     state = state.copy(name = name)
   }
 
-  private fun onLogin() = action {
+  private fun onLogin() = action("onLogin") {
     setOutput(LoggedIn(state.name))
   }
 

--- a/samples/tutorial/tutorial-4-complete/src/main/java/workflow/tutorial/RootWorkflow.kt
+++ b/samples/tutorial/tutorial-4-complete/src/main/java/workflow/tutorial/RootWorkflow.kt
@@ -65,11 +65,11 @@ object RootWorkflow : StatefulWorkflow<Unit, State, Nothing, BackStackScreen<Any
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private fun login(name: String) = action {
+  private fun login(name: String) = action("login") {
     state = Todo(name)
   }
 
-  private val logout = action {
+  private val logout = action("logout") {
     state = Welcome
   }
 }

--- a/samples/tutorial/tutorial-4-complete/src/main/java/workflow/tutorial/TodoEditWorkflow.kt
+++ b/samples/tutorial/tutorial-4-complete/src/main/java/workflow/tutorial/TodoEditWorkflow.kt
@@ -63,20 +63,20 @@ object TodoEditWorkflow : StatefulWorkflow<EditProps, State, Output, TodoEditScr
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private fun onTitleChanged(title: String) = action {
+  private fun onTitleChanged(title: String) = action("onTitleChanged") {
     state = state.withTitle(title)
   }
 
-  private fun onNoteChanged(note: String) = action {
+  private fun onNoteChanged(note: String) = action("onNoteChanged") {
     state = state.withNote(note)
   }
 
-  private fun onDiscard() = action {
+  private fun onDiscard() = action("onDiscard") {
     // Emit the Discard output when the discard action is received.
     setOutput(Discard)
   }
 
-  private fun onSave() = action {
+  private fun onSave() = action("onSave") {
     // Emit the Save output with the current todo state when the save action is received.
     setOutput(Save(state.todo))
   }

--- a/samples/tutorial/tutorial-4-complete/src/main/java/workflow/tutorial/TodoListWorkflow.kt
+++ b/samples/tutorial/tutorial-4-complete/src/main/java/workflow/tutorial/TodoListWorkflow.kt
@@ -34,12 +34,12 @@ object TodoListWorkflow : StatelessWorkflow<ListProps, Output, TodoListScreen>()
     )
   }
 
-  private fun onBack() = action {
+  private fun onBack() = action("onBack") {
     // When an onBack action is received, emit a Back output.
     setOutput(Back)
   }
 
-  private fun selectTodo(index: Int) = action {
+  private fun selectTodo(index: Int) = action("selectTodo") {
     // Tell our parent that a todo item was selected.
     setOutput(SelectTodo(index))
   }

--- a/samples/tutorial/tutorial-4-complete/src/main/java/workflow/tutorial/TodoWorkflow.kt
+++ b/samples/tutorial/tutorial-4-complete/src/main/java/workflow/tutorial/TodoWorkflow.kt
@@ -93,18 +93,18 @@ object TodoWorkflow : StatefulWorkflow<TodoProps, State, Back, List<Any>>() {
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private fun onBack() = action {
+  private fun onBack() = action("onBack") {
     // When an onBack action is received, emit a Back output.
     setOutput(Back)
   }
 
-  private fun editTodo(index: Int) = action {
+  private fun editTodo(index: Int) = action("editTodo") {
     // When a todo item is selected, edit it.
     state = state.copy(step = Step.Edit(index))
   }
 
 
-  private fun discardChanges() = action {
+  private fun discardChanges() = action("discardChanges") {
     // When a discard action is received, return to the list.
     state = state.copy(step = Step.List)
   }
@@ -112,7 +112,7 @@ object TodoWorkflow : StatefulWorkflow<TodoProps, State, Back, List<Any>>() {
   private fun saveChanges(
     todo: TodoModel,
     index: Int
-  ) = action {
+  ) = action("saveChanges") {
     // When changes are saved, update the state of that todo item and return to the list.
     state = state.copy(
         todos = state.todos.toMutableList().also { it[index] = todo },

--- a/samples/tutorial/tutorial-4-complete/src/main/java/workflow/tutorial/WelcomeWorkflow.kt
+++ b/samples/tutorial/tutorial-4-complete/src/main/java/workflow/tutorial/WelcomeWorkflow.kt
@@ -32,11 +32,11 @@ object WelcomeWorkflow : StatefulWorkflow<Unit, State, LoggedIn, WelcomeScreen>(
       }
   )
 
-  private fun onNameChanged(name: String) = action {
+  private fun onNameChanged(name: String) = action("onNameChanged") {
     state = state.copy(username = name)
   }
 
-  private fun onLogin() = action {
+  private fun onLogin() = action("onLogin") {
     setOutput(LoggedIn(state.username))
   }
 

--- a/samples/tutorial/tutorial-final/src/main/java/workflow/tutorial/RootWorkflow.kt
+++ b/samples/tutorial/tutorial-final/src/main/java/workflow/tutorial/RootWorkflow.kt
@@ -65,11 +65,11 @@ object RootWorkflow : StatefulWorkflow<Unit, State, Nothing, BackStackScreen<Any
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private fun login(username: String) = action {
+  private fun login(username: String) = action("login") {
     state = Todo(username)
   }
 
-  private val logout = action {
+  private val logout = action("logout") {
     state = Welcome
   }
 }

--- a/samples/tutorial/tutorial-final/src/main/java/workflow/tutorial/TodoEditWorkflow.kt
+++ b/samples/tutorial/tutorial-final/src/main/java/workflow/tutorial/TodoEditWorkflow.kt
@@ -63,20 +63,20 @@ object TodoEditWorkflow : StatefulWorkflow<EditProps, State, Output, TodoEditScr
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  internal fun onTitleChanged(title: String) = action {
+  internal fun onTitleChanged(title: String) = action("onTitleChanged") {
     state = state.withTitle(title)
   }
 
-  internal fun onNoteChanged(note: String) = action {
+  internal fun onNoteChanged(note: String) = action("onNoteChanged") {
     state = state.withNote(note)
   }
 
-  private fun onDiscard() = action {
+  private fun onDiscard() = action("onDiscard") {
     // Emit the Discard output when the discard action is received.
     setOutput(Discard)
   }
 
-  internal fun onSave() = action {
+  internal fun onSave() = action("onSave") {
     // Emit the Save output with the current todo state when the save action is received.
     setOutput(Save(state.todo))
   }

--- a/samples/tutorial/tutorial-final/src/main/java/workflow/tutorial/TodoListWorkflow.kt
+++ b/samples/tutorial/tutorial-final/src/main/java/workflow/tutorial/TodoListWorkflow.kt
@@ -36,17 +36,17 @@ object TodoListWorkflow : StatelessWorkflow<ListProps, Output, TodoListScreen>()
     )
   }
 
-  private fun onBack() = action {
+  private fun onBack() = action("onBack") {
     // When an onBack action is received, emit a Back output.
     setOutput(Back)
   }
 
-  private fun selectTodo(index: Int) = action {
+  private fun selectTodo(index: Int) = action("selectTodo") {
     // Tell our parent that a todo item was selected.
     setOutput(SelectTodo(index))
   }
 
-  private fun new() = action {
+  private fun new() = action("new") {
     // Tell our parent a new todo item should be created.
     setOutput(NewTodo)
   }

--- a/samples/tutorial/tutorial-final/src/main/java/workflow/tutorial/TodoWorkflow.kt
+++ b/samples/tutorial/tutorial-final/src/main/java/workflow/tutorial/TodoWorkflow.kt
@@ -95,17 +95,17 @@ object TodoWorkflow : StatefulWorkflow<TodoProps, State, Back, List<Any>>() {
 
   override fun snapshotState(state: State): Snapshot? = null
 
-  private fun onBack() = action {
+  private fun onBack() = action("onBack") {
     // When an onBack action is received, emit a Back output.
     setOutput(Back)
   }
 
-  private fun editTodo(index: Int) = action {
+  private fun editTodo(index: Int) = action("editTodo") {
     // When a todo item is selected, edit it.
     state = state.copy(step = Step.Edit(index))
   }
 
-  private fun newTodo() = action {
+  private fun newTodo() = action("newTodo") {
     // Append a new todo model to the end of the list.
     state = state.copy(
         todos = state.todos + TodoModel(
@@ -115,7 +115,7 @@ object TodoWorkflow : StatefulWorkflow<TodoProps, State, Back, List<Any>>() {
     )
   }
 
-  private fun discardChanges() = action {
+  private fun discardChanges() = action("discardChanges") {
     // When a discard action is received, return to the list.
     state = state.copy(step = Step.List)
   }
@@ -123,7 +123,7 @@ object TodoWorkflow : StatefulWorkflow<TodoProps, State, Back, List<Any>>() {
   private fun saveChanges(
     todo: TodoModel,
     index: Int
-  ) = action {
+  ) = action("saveChanges") {
     // When changes are saved, update the state of that todo item and return to the list.
     state = state.copy(
         todos = state.todos.toMutableList().also { it[index] = todo },

--- a/samples/tutorial/tutorial-final/src/main/java/workflow/tutorial/WelcomeWorkflow.kt
+++ b/samples/tutorial/tutorial-final/src/main/java/workflow/tutorial/WelcomeWorkflow.kt
@@ -33,11 +33,11 @@ object WelcomeWorkflow : StatefulWorkflow<Unit, State, LoggedIn, WelcomeScreen>(
   )
 
   // Needs to be internal so we can access it from the tests.
-  internal fun onNameChanged(name: String) = action {
+  internal fun onNameChanged(name: String) = action("onNameChanged") {
     state = state.copy(name = name)
   }
 
-  internal fun onLogin() = action {
+  internal fun onLogin() = action("onLogin") {
     // Don't log in if the name isn't filled in.
     if (state.name.isNotEmpty()) {
       setOutput(LoggedIn(state.name))

--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -23,6 +23,17 @@ public final class com/squareup/workflow1/ActionsExhausted : com/squareup/workfl
 }
 
 public abstract interface class com/squareup/workflow1/BaseRenderContext {
+	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
+	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
+	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
+	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
+	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
+	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
+	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
+	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
 	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
 	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
@@ -34,12 +45,34 @@ public abstract interface class com/squareup/workflow1/BaseRenderContext {
 	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
 	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
 	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
+	public abstract fun eventHandler (Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public abstract fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public abstract fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class com/squareup/workflow1/BaseRenderContext$DefaultImpls {
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
 	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
 	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
@@ -51,10 +84,20 @@ public final class com/squareup/workflow1/BaseRenderContext$DefaultImpls {
 	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
 	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
 	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
+	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;ILjava/lang/Object;)Lkotlin/jvm/functions/Function9;
 	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;ILjava/lang/Object;)Lkotlin/jvm/functions/Function10;
 	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/jvm/functions/Function0;
-	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlin/jvm/functions/Function1;
 	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lkotlin/jvm/functions/Function2;
 	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;ILjava/lang/Object;)Lkotlin/jvm/functions/Function3;
 	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function5;ILjava/lang/Object;)Lkotlin/jvm/functions/Function4;
@@ -166,6 +209,17 @@ public abstract class com/squareup/workflow1/StatefulWorkflow : com/squareup/wor
 }
 
 public final class com/squareup/workflow1/StatefulWorkflow$RenderContext : com/squareup/workflow1/BaseRenderContext {
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
@@ -177,6 +231,17 @@ public final class com/squareup/workflow1/StatefulWorkflow$RenderContext : com/s
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
+	public fun eventHandler (Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
+	public fun eventHandler (Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
+	public fun eventHandler (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public fun eventHandler (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public fun eventHandler (Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public fun eventHandler (Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
+	public fun eventHandler (Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
+	public fun eventHandler (Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
+	public fun eventHandler (Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
+	public fun eventHandler (Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
+	public fun eventHandler (Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
@@ -191,6 +256,17 @@ public abstract class com/squareup/workflow1/StatelessWorkflow : com/squareup/wo
 }
 
 public final class com/squareup/workflow1/StatelessWorkflow$RenderContext : com/squareup/workflow1/BaseRenderContext {
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
+	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
@@ -202,6 +278,17 @@ public final class com/squareup/workflow1/StatelessWorkflow$RenderContext : com/
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
 	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
+	public fun eventHandler (Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
+	public fun eventHandler (Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
+	public fun eventHandler (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public fun eventHandler (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
+	public fun eventHandler (Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
+	public fun eventHandler (Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
+	public fun eventHandler (Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
+	public fun eventHandler (Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
+	public fun eventHandler (Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
+	public fun eventHandler (Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
+	public fun eventHandler (Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
@@ -321,13 +408,13 @@ public final class com/squareup/workflow1/Workflows {
 	public static final fun RenderContext (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/StatelessWorkflow;)Lcom/squareup/workflow1/StatelessWorkflow$RenderContext;
 	public static final fun action (Lcom/squareup/workflow1/StatefulWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lcom/squareup/workflow1/StatefulWorkflow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
+	public static final fun action (Lcom/squareup/workflow1/StatefulWorkflow;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lcom/squareup/workflow1/StatelessWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lcom/squareup/workflow1/StatelessWorkflow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
-	public static synthetic fun action$default (Lcom/squareup/workflow1/StatefulWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/WorkflowAction;
+	public static final fun action (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static synthetic fun action$default (Lcom/squareup/workflow1/StatelessWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/WorkflowAction;
-	public static synthetic fun action$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun applyTo (Lcom/squareup/workflow1/WorkflowAction;Ljava/lang/Object;Ljava/lang/Object;)Lkotlin/Pair;
 	public static final fun contraMap (Lcom/squareup/workflow1/Sink;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/Sink;
 	public static final fun getComputedIdentifier (Lcom/squareup/workflow1/Workflow;)Lcom/squareup/workflow1/WorkflowIdentifier;

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/BaseRenderContext.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/BaseRenderContext.kt
@@ -137,7 +137,7 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
    *    return SomeScreen(
    *      onClick = {
    *        context.actionSink.send(
-   *          action { state = SomeNewState }
+   *          action("onClick") { state = SomeNewState }
    *        }
    *      }
    *    )
@@ -145,7 +145,7 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
    *  with this:
    *
    *    return SomeScreen(
-   *      onClick = context.eventHandler { state = SomeNewState }
+   *      onClick = context.eventHandler("onClick") { state = SomeNewState }
    *    )
    *
    * Notice how your [update] function is passed to the [actionSink][BaseRenderContext.actionSink]
@@ -161,7 +161,7 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
    *        MyAnalytics.log("SomeScreen was clicked")
    *
    *        context.actionSink.send(
-   *          action {
+   *          action("onClick") {
    *            // This happens eventually.
    *            state = SomeNewState
    *          }
@@ -173,6 +173,31 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
    * as a debugging aid
    * @param update Function that defines the workflow update.
    */
+  @Suppress("DEPRECATION")
+  public fun eventHandler(
+    name: String,
+    // Type variance issue: https://github.com/square/workflow-kotlin/issues/891
+    update: WorkflowAction<
+      @UnsafeVariance PropsT,
+      StateT,
+      @UnsafeVariance OutputT
+      >.Updater.() -> Unit
+  ): () -> Unit = eventHandler({ name }, update)
+
+  @Deprecated(
+    "Always provide a debugging name",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
+  public fun eventHandler(
+    // Type variance issue: https://github.com/square/workflow-kotlin/issues/891
+    update:
+    WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.() -> Unit
+  ): () -> Unit = eventHandler("eventHandler", update)
+
+  @Deprecated(
+    "Use a static string.",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
   public fun eventHandler(
     name: () -> String = { "eventHandler" },
     // Type variance issue: https://github.com/square/workflow-kotlin/issues/891
@@ -184,8 +209,30 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     }
   }
 
+  @Deprecated(
+    "Always provide a debugging name",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
   public fun <EventT> eventHandler(
-    name: () -> String = { "eventHandler" },
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      EventT
+    ) -> Unit
+  ): (EventT) -> Unit = eventHandler("eventHandler", update)
+
+  @Suppress("DEPRECATION")
+  public fun <EventT> eventHandler(
+    name: String,
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      EventT
+    ) -> Unit
+  ): (EventT) -> Unit = eventHandler({ name }, update)
+
+  @Deprecated(
+    "Use a static string.",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
+  public fun <EventT> eventHandler(
+    name: () -> String,
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
       EventT
     ) -> Unit
@@ -195,6 +242,30 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     }
   }
 
+  @Deprecated(
+    "Always provide a debugging name",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
+  public fun <E1, E2> eventHandler(
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2
+    ) -> Unit
+  ): (E1, E2) -> Unit = eventHandler("eventHandler", update)
+
+  @Suppress("DEPRECATION")
+  public fun <E1, E2> eventHandler(
+    name: String,
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2
+    ) -> Unit
+  ): (E1, E2) -> Unit = eventHandler({ name }, update)
+
+  @Deprecated(
+    "Use a static string.",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
   public fun <E1, E2> eventHandler(
     name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
@@ -207,6 +278,32 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     }
   }
 
+  @Deprecated(
+    "Always provide a debugging name",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
+  public fun <E1, E2, E3> eventHandler(
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3
+    ) -> Unit
+  ): (E1, E2, E3) -> Unit = eventHandler("eventHandler", update)
+
+  @Suppress("DEPRECATION")
+  public fun <E1, E2, E3> eventHandler(
+    name: String,
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3
+    ) -> Unit
+  ): (E1, E2, E3) -> Unit = eventHandler({ name }, update)
+
+  @Deprecated(
+    "Use a static string.",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
   public fun <E1, E2, E3> eventHandler(
     name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
@@ -220,6 +317,34 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     }
   }
 
+  @Deprecated(
+    "Always provide a debugging name",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
+  public fun <E1, E2, E3, E4> eventHandler(
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4
+    ) -> Unit
+  ): (E1, E2, E3, E4) -> Unit = eventHandler("eventHandler", update)
+
+  @Suppress("DEPRECATION")
+  public fun <E1, E2, E3, E4> eventHandler(
+    name: String,
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4
+    ) -> Unit
+  ): (E1, E2, E3, E4) -> Unit = eventHandler({ name }, update)
+
+  @Deprecated(
+    "Use a static string.",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
   public fun <E1, E2, E3, E4> eventHandler(
     name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
@@ -234,6 +359,36 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     }
   }
 
+  @Deprecated(
+    "Always provide a debugging name",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
+  public fun <E1, E2, E3, E4, E5> eventHandler(
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4,
+      E5
+    ) -> Unit
+  ): (E1, E2, E3, E4, E5) -> Unit = eventHandler("eventHandler", update)
+
+  @Suppress("DEPRECATION")
+  public fun <E1, E2, E3, E4, E5> eventHandler(
+    name: String,
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4,
+      E5
+    ) -> Unit
+  ): (E1, E2, E3, E4, E5) -> Unit = eventHandler({ name }, update)
+
+  @Deprecated(
+    "Use a static string.",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
   public fun <E1, E2, E3, E4, E5> eventHandler(
     name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
@@ -249,6 +404,38 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     }
   }
 
+  @Deprecated(
+    "Always provide a debugging name",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
+  public fun <E1, E2, E3, E4, E5, E6> eventHandler(
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6
+    ) -> Unit
+  ): (E1, E2, E3, E4, E5, E6) -> Unit = eventHandler("eventHandler", update)
+
+  @Suppress("DEPRECATION")
+  public fun <E1, E2, E3, E4, E5, E6> eventHandler(
+    name: String,
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6
+    ) -> Unit
+  ): (E1, E2, E3, E4, E5, E6) -> Unit = eventHandler({ name }, update)
+
+  @Deprecated(
+    "Use a static string.",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
   public fun <E1, E2, E3, E4, E5, E6> eventHandler(
     name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
@@ -265,6 +452,40 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     }
   }
 
+  @Deprecated(
+    "Always provide a debugging name",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
+  public fun <E1, E2, E3, E4, E5, E6, E7> eventHandler(
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6,
+      E7
+    ) -> Unit
+  ): (E1, E2, E3, E4, E5, E6, E7) -> Unit = eventHandler("eventHandler", update)
+
+  @Suppress("DEPRECATION")
+  public fun <E1, E2, E3, E4, E5, E6, E7> eventHandler(
+    name: String,
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6,
+      E7
+    ) -> Unit
+  ): (E1, E2, E3, E4, E5, E6, E7) -> Unit = eventHandler({ name }, update)
+
+  @Deprecated(
+    "Use a static string.",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
   public fun <E1, E2, E3, E4, E5, E6, E7> eventHandler(
     name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
@@ -282,6 +503,42 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     }
   }
 
+  @Deprecated(
+    "Always provide a debugging name",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
+  public fun <E1, E2, E3, E4, E5, E6, E7, E8> eventHandler(
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6,
+      E7,
+      E8
+    ) -> Unit
+  ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit = eventHandler("eventHandler", update)
+
+  @Suppress("DEPRECATION")
+  public fun <E1, E2, E3, E4, E5, E6, E7, E8> eventHandler(
+    name: String,
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6,
+      E7,
+      E8
+    ) -> Unit
+  ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit = eventHandler({ name }, update)
+
+  @Deprecated(
+    "Use a static string.",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
   public fun <E1, E2, E3, E4, E5, E6, E7, E8> eventHandler(
     name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
@@ -300,6 +557,44 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     }
   }
 
+  @Deprecated(
+    "Always provide a debugging name",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
+  public fun <E1, E2, E3, E4, E5, E6, E7, E8, E9> eventHandler(
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6,
+      E7,
+      E8,
+      E9
+    ) -> Unit
+  ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit = eventHandler("eventHandler", update)
+
+  @Suppress("DEPRECATION")
+  public fun <E1, E2, E3, E4, E5, E6, E7, E8, E9> eventHandler(
+    name: String,
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6,
+      E7,
+      E8,
+      E9
+    ) -> Unit
+  ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit = eventHandler({ name }, update)
+
+  @Deprecated(
+    "Use a static string.",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
   public fun <E1, E2, E3, E4, E5, E6, E7, E8, E9> eventHandler(
     name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>
@@ -310,6 +605,46 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     }
   }
 
+  @Deprecated(
+    "Always provide a debugging name",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
+  public fun <E1, E2, E3, E4, E5, E6, E7, E8, E9, E10> eventHandler(
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6,
+      E7,
+      E8,
+      E9,
+      E10
+    ) -> Unit
+  ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit = eventHandler("eventHandler", update)
+
+  @Suppress("DEPRECATION")
+  public fun <E1, E2, E3, E4, E5, E6, E7, E8, E9, E10> eventHandler(
+    name: String,
+    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6,
+      E7,
+      E8,
+      E9,
+      E10
+    ) -> Unit
+  ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit = eventHandler({ name }, update)
+
+  @Deprecated(
+    "Use a static string.",
+    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
+  )
   public fun <E1, E2, E3, E4, E5, E6, E7, E8, E9, E10> eventHandler(
     name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/Sink.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/Sink.kt
@@ -51,7 +51,7 @@ public fun <T1, T2> Sink<T1>.contraMap(transform: (T2) -> T1): Sink<T2> = Sink {
  * ```
  * context.runningSideEffect("collector") {
  *   myFlow.collectToSink(context.actionSink) { value ->
- *     action { setOutput(value) }
+ *     action("collect") { setOutput(value) }
  *   }
  * }
  * ```

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
@@ -76,6 +76,20 @@ public abstract class StatefulWorkflow<
   public inner class RenderContext internal constructor(
     baseContext: BaseRenderContext<PropsT, StateT, OutputT>
   ) : BaseRenderContext<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT> by baseContext {
+    @Deprecated(
+      "Always provide a debugging name",
+      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
+    )
+    public inline fun <reified CurrentStateT : StateT & Any> safeEventHandler(
+      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
+        ::defaultOnFailedCast,
+      // Type variance issue: https://github.com/square/workflow-kotlin/issues/891
+      crossinline update: WorkflowAction<
+        @UnsafeVariance PropsT,
+        StateT,
+        @UnsafeVariance OutputT
+        >.Updater.(currentState: CurrentStateT) -> Unit
+    ): () -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
 
     /**
      * Like [eventHandler], but no-ops if [state][WorkflowAction.Updater.state] has
@@ -114,7 +128,7 @@ public abstract class StatefulWorkflow<
      * @param update Function that defines the workflow update.
      */
     public inline fun <reified CurrentStateT : StateT & Any> safeEventHandler(
-      name: String = "safeEventHandler",
+      name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
         ::defaultOnFailedCast,
       // Type variance issue: https://github.com/square/workflow-kotlin/issues/891
@@ -124,14 +138,31 @@ public abstract class StatefulWorkflow<
         @UnsafeVariance OutputT
         >.Updater.(currentState: CurrentStateT) -> Unit
     ): () -> Unit {
-      return eventHandler({ name }) {
+      return eventHandler(name) {
         CurrentStateT::class.safeCast(state)?.let { currentState -> this.update(currentState) }
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
 
+    @Deprecated(
+      "Always provide a debugging name",
+      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
+    )
     public inline fun <reified CurrentStateT : StateT & Any, EventT> safeEventHandler(
-      name: String = "safeEventHandler",
+      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
+        ::defaultOnFailedCast,
+      crossinline update: WorkflowAction<
+        @UnsafeVariance PropsT,
+        StateT,
+        @UnsafeVariance OutputT
+        >.Updater.(
+        currentState: CurrentStateT,
+        event: EventT
+      ) -> Unit
+    ): (EventT) -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
+
+    public inline fun <reified CurrentStateT : StateT & Any, EventT> safeEventHandler(
+      name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
         ::defaultOnFailedCast,
       crossinline update: WorkflowAction<
@@ -143,15 +174,33 @@ public abstract class StatefulWorkflow<
         event: EventT
       ) -> Unit
     ): (EventT) -> Unit {
-      return eventHandler({ name }) { event: EventT ->
+      return eventHandler(name) { event: EventT ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, event) }
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
 
+    @Deprecated(
+      "Always provide a debugging name",
+      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
+    )
     public inline fun <reified CurrentStateT : StateT & Any, E1, E2> safeEventHandler(
-      name: String = "safeEventHandler",
+      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
+        ::defaultOnFailedCast,
+      crossinline update: WorkflowAction<
+        @UnsafeVariance PropsT,
+        StateT,
+        @UnsafeVariance OutputT
+        >.Updater.(
+        currentState: CurrentStateT,
+        e1: E1,
+        e2: E2
+      ) -> Unit
+    ): (E1, E2) -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
+
+    public inline fun <reified CurrentStateT : StateT & Any, E1, E2> safeEventHandler(
+      name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
         ::defaultOnFailedCast,
       crossinline update: WorkflowAction<
@@ -164,15 +213,34 @@ public abstract class StatefulWorkflow<
         e2: E2
       ) -> Unit
     ): (E1, E2) -> Unit {
-      return eventHandler({ name }) { e1: E1, e2: E2 ->
+      return eventHandler(name) { e1: E1, e2: E2 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2) }
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
 
+    @Deprecated(
+      "Always provide a debugging name",
+      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
+    )
     public inline fun <reified CurrentStateT : StateT & Any, E1, E2, E3> safeEventHandler(
-      name: String = "safeEventHandler",
+      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
+        ::defaultOnFailedCast,
+      crossinline update: WorkflowAction<
+        @UnsafeVariance PropsT,
+        StateT,
+        @UnsafeVariance OutputT
+        >.Updater.(
+        currentState: CurrentStateT,
+        e1: E1,
+        e2: E2,
+        e3: E3
+      ) -> Unit
+    ): (E1, E2, E3) -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
+
+    public inline fun <reified CurrentStateT : StateT & Any, E1, E2, E3> safeEventHandler(
+      name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
         ::defaultOnFailedCast,
       crossinline update: WorkflowAction<
@@ -186,15 +254,35 @@ public abstract class StatefulWorkflow<
         e3: E3
       ) -> Unit
     ): (E1, E2, E3) -> Unit {
-      return eventHandler({ name }) { e1: E1, e2: E2, e3: E3 ->
+      return eventHandler(name) { e1: E1, e2: E2, e3: E3 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3) }
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
 
+    @Deprecated(
+      "Always provide a debugging name",
+      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
+    )
     public inline fun <reified CurrentStateT : StateT & Any, E1, E2, E3, E4> safeEventHandler(
-      name: String = "safeEventHandler",
+      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
+        ::defaultOnFailedCast,
+      crossinline update: WorkflowAction<
+        @UnsafeVariance PropsT,
+        StateT,
+        @UnsafeVariance OutputT
+        >.Updater.(
+        currentState: CurrentStateT,
+        e1: E1,
+        e2: E2,
+        e3: E3,
+        e4: E4
+      ) -> Unit
+    ): (E1, E2, E3, E4) -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
+
+    public inline fun <reified CurrentStateT : StateT & Any, E1, E2, E3, E4> safeEventHandler(
+      name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
         ::defaultOnFailedCast,
       crossinline update: WorkflowAction<
@@ -209,15 +297,36 @@ public abstract class StatefulWorkflow<
         e4: E4
       ) -> Unit
     ): (E1, E2, E3, E4) -> Unit {
-      return eventHandler({ name }) { e1: E1, e2: E2, e3: E3, e4: E4 ->
+      return eventHandler(name) { e1: E1, e2: E2, e3: E3, e4: E4 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4) }
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
 
+    @Deprecated(
+      "Always provide a debugging name",
+      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
+    )
     public inline fun <reified CurrentStateT : StateT & Any, E1, E2, E3, E4, E5> safeEventHandler(
-      name: String = "safeEventHandler",
+      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
+        ::defaultOnFailedCast,
+      crossinline update: WorkflowAction<
+        @UnsafeVariance PropsT,
+        StateT,
+        @UnsafeVariance OutputT
+        >.Updater.(
+        currentState: CurrentStateT,
+        e1: E1,
+        e2: E2,
+        e3: E3,
+        e4: E4,
+        e5: E5
+      ) -> Unit
+    ): (E1, E2, E3, E4, E5) -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
+
+    public inline fun <reified CurrentStateT : StateT & Any, E1, E2, E3, E4, E5> safeEventHandler(
+      name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
         ::defaultOnFailedCast,
       crossinline update: WorkflowAction<
@@ -233,12 +342,42 @@ public abstract class StatefulWorkflow<
         e5: E5
       ) -> Unit
     ): (E1, E2, E3, E4, E5) -> Unit {
-      return eventHandler({ name }) { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5 ->
+      return eventHandler(name) { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5) }
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
+
+    @Deprecated(
+      "Always provide a debugging name",
+      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
+    )
+    public inline fun <
+      reified CurrentStateT : StateT & Any,
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6
+      > safeEventHandler(
+      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
+        ::defaultOnFailedCast,
+      crossinline update: WorkflowAction<
+        @UnsafeVariance PropsT,
+        StateT,
+        @UnsafeVariance OutputT
+        >.Updater.(
+        currentState: CurrentStateT,
+        e1: E1,
+        e2: E2,
+        e3: E3,
+        e4: E4,
+        e5: E5,
+        e6: E6
+      ) -> Unit
+    ): (E1, E2, E3, E4, E5, E6) -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
 
     public inline fun <
       reified CurrentStateT : StateT & Any,
@@ -249,7 +388,7 @@ public abstract class StatefulWorkflow<
       E5,
       E6
       > safeEventHandler(
-      name: String = "safeEventHandler",
+      name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
         ::defaultOnFailedCast,
       crossinline update: WorkflowAction<
@@ -266,12 +405,45 @@ public abstract class StatefulWorkflow<
         e6: E6
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6) -> Unit {
-      return eventHandler({ name }) { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6 ->
+      return eventHandler(name) { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5, e6) }
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
+
+    @Deprecated(
+      "Always provide a debugging name",
+      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
+    )
+    public inline fun <
+      reified CurrentStateT : StateT & Any,
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6,
+      E7
+      > safeEventHandler(
+      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
+        ::defaultOnFailedCast,
+      crossinline update: WorkflowAction<
+        @UnsafeVariance PropsT,
+        StateT,
+        @UnsafeVariance OutputT
+        >.Updater.(
+        currentState: CurrentStateT,
+        e1: E1,
+        e2: E2,
+        e3: E3,
+        e4: E4,
+        e5: E5,
+        e6: E6,
+        e7: E7
+      ) -> Unit
+    ): (E1, E2, E3, E4, E5, E6, E7) -> Unit =
+      safeEventHandler("safeEventHandler", onFailedCast, update)
 
     public inline fun <
       reified CurrentStateT : StateT & Any,
@@ -283,7 +455,7 @@ public abstract class StatefulWorkflow<
       E6,
       E7
       > safeEventHandler(
-      name: String = "safeEventHandler",
+      name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
         ::defaultOnFailedCast,
       crossinline update: WorkflowAction<
@@ -301,12 +473,47 @@ public abstract class StatefulWorkflow<
         e7: E7
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7) -> Unit {
-      return eventHandler({ name }) { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7 ->
+      return eventHandler(name) { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5, e6, e7) }
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
+
+    @Deprecated(
+      "Always provide a debugging name",
+      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
+    )
+    public inline fun <
+      reified CurrentStateT : StateT & Any,
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6,
+      E7,
+      E8
+      > safeEventHandler(
+      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
+        ::defaultOnFailedCast,
+      crossinline update: WorkflowAction<
+        @UnsafeVariance PropsT,
+        StateT,
+        @UnsafeVariance OutputT
+        >.Updater.(
+        currentState: CurrentStateT,
+        e1: E1,
+        e2: E2,
+        e3: E3,
+        e4: E4,
+        e5: E5,
+        e6: E6,
+        e7: E7,
+        e8: E8
+      ) -> Unit
+    ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit =
+      safeEventHandler("safeEventHandler", onFailedCast, update)
 
     public inline fun <
       reified CurrentStateT : StateT & Any,
@@ -319,7 +526,7 @@ public abstract class StatefulWorkflow<
       E7,
       E8
       > safeEventHandler(
-      name: String = "safeEventHandler",
+      name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
         ::defaultOnFailedCast,
       crossinline update: WorkflowAction<
@@ -338,14 +545,49 @@ public abstract class StatefulWorkflow<
         e8: E8
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit {
-      return eventHandler(
-        { name }
-      ) { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7, e8: E8 ->
+      return eventHandler(name) { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7, e8: E8 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5, e6, e7, e8) }
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
+
+    @Deprecated(
+      "Always provide a debugging name",
+      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
+    )
+    public inline fun <
+      reified CurrentStateT : StateT & Any,
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6,
+      E7,
+      E8,
+      E9
+      > safeEventHandler(
+      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
+        ::defaultOnFailedCast,
+      crossinline update: WorkflowAction<
+        @UnsafeVariance PropsT,
+        StateT,
+        @UnsafeVariance OutputT
+        >.Updater.(
+        currentState: CurrentStateT,
+        e1: E1,
+        e2: E2,
+        e3: E3,
+        e4: E4,
+        e5: E5,
+        e6: E6,
+        e7: E7,
+        e8: E8,
+        e9: E9
+      ) -> Unit
+    ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit =
+      safeEventHandler("safeEventHandler", onFailedCast, update)
 
     public inline fun <
       reified CurrentStateT : StateT & Any,
@@ -359,7 +601,7 @@ public abstract class StatefulWorkflow<
       E8,
       E9
       > safeEventHandler(
-      name: String = "safeEventHandler",
+      name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
         ::defaultOnFailedCast,
       crossinline update: WorkflowAction<
@@ -380,13 +622,52 @@ public abstract class StatefulWorkflow<
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit {
       return eventHandler(
-        { name }
+        name
       ) { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7, e8: E8, e9: E9 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5, e6, e7, e8, e9) }
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
+
+    @Deprecated(
+      "Always provide a debugging name",
+      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
+    )
+    public inline fun <
+      reified CurrentStateT : StateT & Any,
+      E1,
+      E2,
+      E3,
+      E4,
+      E5,
+      E6,
+      E7,
+      E8,
+      E9,
+      E10
+      > safeEventHandler(
+      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
+        ::defaultOnFailedCast,
+      crossinline update: WorkflowAction<
+        @UnsafeVariance PropsT,
+        StateT,
+        @UnsafeVariance OutputT
+        >.Updater.(
+        currentState: CurrentStateT,
+        e1: E1,
+        e2: E2,
+        e3: E3,
+        e4: E4,
+        e5: E5,
+        e6: E6,
+        e7: E7,
+        e8: E8,
+        e9: E9,
+        e10: E10
+      ) -> Unit
+    ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit =
+      safeEventHandler("safeEventHandler", onFailedCast, update)
 
     public inline fun <
       reified CurrentStateT : StateT & Any,
@@ -401,7 +682,7 @@ public abstract class StatefulWorkflow<
       E9,
       E10
       > safeEventHandler(
-      name: String = "safeEventHandler",
+      name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
         ::defaultOnFailedCast,
       crossinline update: WorkflowAction<
@@ -423,7 +704,7 @@ public abstract class StatefulWorkflow<
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit {
       return eventHandler(
-        { name }
+        name
       ) { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7, e8: E8, e9: E9, e10: E10 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState ->
@@ -433,6 +714,18 @@ public abstract class StatefulWorkflow<
       }
     }
   }
+
+  @Deprecated(
+    "Always provide a debugging name.",
+    ReplaceWith("safeAction(\"TODO: name\", onFailedCast, update)")
+  )
+  public inline fun <reified CurrentStateT : StateT & Any> safeAction(
+    crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
+      ::defaultOnFailedCast,
+    noinline update: WorkflowAction<PropsT, StateT, OutputT>.Updater.(
+      currentState: CurrentStateT
+    ) -> Unit
+  ): WorkflowAction<PropsT, StateT, OutputT> = safeAction("safeAction", onFailedCast, update)
 
   /**
    * Like [action], but no-ops if [state][WorkflowAction.Updater.state] has
@@ -463,7 +756,7 @@ public abstract class StatefulWorkflow<
    * @param update Function that defines the workflow update.
    */
   public inline fun <reified CurrentStateT : StateT & Any> safeAction(
-    name: String = "safeAction",
+    name: String,
     crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
       ::defaultOnFailedCast,
     noinline update: WorkflowAction<PropsT, StateT, OutputT>.Updater.(
@@ -677,6 +970,15 @@ public inline fun <StateT, OutputT, RenderingT> Workflow.Companion.stateful(
   { _, state -> render(state) }
 )
 
+@Deprecated(
+  "Always provide a debugging name",
+  ReplaceWith("action(\"TODO: debugging name\", update)")
+)
+public fun <PropsT, StateT, OutputT, RenderingT>
+  StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.action(
+    update: WorkflowAction<PropsT, StateT, OutputT>.Updater.() -> Unit
+  ): WorkflowAction<PropsT, StateT, OutputT> = action("", update)
+
 /**
  * Convenience to create a [WorkflowAction] with parameter types matching those
  * of the receiving [StatefulWorkflow]. The action will invoke the given [lambda][update]
@@ -687,7 +989,7 @@ public inline fun <StateT, OutputT, RenderingT> Workflow.Companion.stateful(
  */
 public fun <PropsT, StateT, OutputT, RenderingT>
   StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.action(
-    name: String = "",
+    name: String,
     update: WorkflowAction<PropsT, StateT, OutputT>.Updater.() -> Unit
   ): WorkflowAction<PropsT, StateT, OutputT> = action({ name }, update)
 

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowAction.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowAction.kt
@@ -20,10 +20,10 @@ import kotlin.jvm.JvmOverloads
  *
  * It is possible for one [WorkflowAction] to delegate to another, although the API is a bit opaque:
  *
- *     val actionA = action {
+ *     val actionA = action("a") {
  *     }
  *
- *     val actionB = action {
+ *     val actionB = action("b") {
  *       val (newState, outputApplied) = actionA.applyTo(props, state)
  *       state = newState
  *       outputApplied.output?.value?.let { setOutput(it) }
@@ -81,6 +81,14 @@ public abstract class WorkflowAction<in PropsT, StateT, out OutputT> {
   }
 }
 
+@Deprecated(
+  "Always provide a debugging name.",
+  ReplaceWith("action(\"TODO: name\", apply)")
+)
+public fun <PropsT, StateT, OutputT> action(
+  apply: WorkflowAction<PropsT, StateT, OutputT>.Updater.() -> Unit
+): WorkflowAction<PropsT, StateT, OutputT> = action("", apply)
+
 /**
  * Creates a [WorkflowAction] from the [apply] lambda.
  * The returned object will include the string returned from [name] in its [toString].
@@ -95,7 +103,7 @@ public abstract class WorkflowAction<in PropsT, StateT, out OutputT> {
  * @see StatefulWorkflow.action
  */
 public fun <PropsT, StateT, OutputT> action(
-  name: String = "",
+  name: String,
   apply: WorkflowAction<PropsT, StateT, OutputT>.Updater.() -> Unit
 ): WorkflowAction<PropsT, StateT, OutputT> = action({ name }, apply)
 

--- a/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/SinkTest.kt
+++ b/workflow-core/src/commonTest/kotlin/com/squareup/workflow1/SinkTest.kt
@@ -28,7 +28,7 @@ internal class SinkTest {
     val flow = MutableStateFlow(1)
     val collector = launch {
       flow.collectToSink(sink) {
-        action {
+        action("") {
           state = "$props $state $it"
           setOutput("output: $it")
         }
@@ -70,7 +70,7 @@ internal class SinkTest {
 
     runTest(UnconfinedTestDispatcher()) {
       val collectJob = launch {
-        flow.collectToSink(sink) { action { setOutput(it) } }
+        flow.collectToSink(sink) { action("") { setOutput(it) } }
       }
 
       val sendJob = launch(start = UNDISPATCHED) {
@@ -111,7 +111,7 @@ internal class SinkTest {
 
   @Test fun sendAndAwaitApplication_applies_action() {
     var applications = 0
-    val action = action<String, String, String> {
+    val action = action<String, String, String>("") {
       applications++
       state = "$props $state applied"
       setOutput("output")
@@ -131,7 +131,7 @@ internal class SinkTest {
 
   @Test fun sendAndAwaitApplication_suspends_until_after_applied() = runTest {
     var resumed = false
-    val action = action<String, String, String> {
+    val action = action<String, String, String>("") {
       assertFalse(resumed)
     }
     launch {
@@ -156,7 +156,7 @@ internal class SinkTest {
   @Test fun sendAndAwaitApplication_does_not_apply_action_when_cancelled_while_suspended() =
     runTest {
       var applied = false
-      val action = action<String, String, String> {
+      val action = action<String, String, String>("") {
         applied = true
         fail()
       }

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderWorkflowInTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderWorkflowInTest.kt
@@ -230,7 +230,7 @@ class RenderWorkflowInTest {
         render = { _, renderState ->
           Pair(
             renderState,
-            { newState -> actionSink.send(action { state = newState }) }
+            { newState -> actionSink.send(action("") { state = newState }) }
           )
         }
       )
@@ -293,7 +293,7 @@ class RenderWorkflowInTest {
           }
         },
         render = { _, renderState ->
-          sink = actionSink.contraMap { action { state = it } }
+          sink = actionSink.contraMap { action("") { state = it } }
           renderState
         }
       )
@@ -353,7 +353,7 @@ class RenderWorkflowInTest {
         runningWorker(
           trigger.consumeAsFlow()
             .asWorker()
-        ) { action { setOutput(it) } }
+        ) { action("") { setOutput(it) } }
       }
       val receivedOutputs = mutableListOf<String>()
       renderWorkflowIn(
@@ -387,7 +387,7 @@ class RenderWorkflowInTest {
             trigger.consumeAsFlow()
               .asWorker()
           ) {
-            action {
+            action("") {
               state = it
               setOutput(it)
             }
@@ -582,7 +582,7 @@ class RenderWorkflowInTest {
       val workflow = Workflow.stateful<Unit, Boolean, Nothing, Unit>(
         initialState = { false },
         render = { _, throwNow ->
-          runningWorker(Worker.from { trigger.await() }) { action { state = true } }
+          runningWorker(Worker.from { trigger.await() }) { action("") { state = true } }
           if (throwNow) {
             throw ExpectedException()
           }
@@ -613,7 +613,7 @@ class RenderWorkflowInTest {
       // Throws an exception when trigger is completed.
       val workflow = Workflow.stateless<Unit, Nothing, Unit> {
         runningWorker(Worker.from { trigger.await() }) {
-          action {
+          action("") {
             throw ExpectedException()
           }
         }
@@ -672,7 +672,7 @@ class RenderWorkflowInTest {
       val workflow = Workflow.stateless<Unit, Nothing, Unit> {
         renderCount++
         runningWorker(Worker.from { trigger.await() }) {
-          action {
+          action("") {
             testScope.cancel()
           }
         }
@@ -790,7 +790,7 @@ class RenderWorkflowInTest {
       val trigger = CompletableDeferred<Unit>()
       // Emits a Unit when trigger is completed.
       val workflow = Workflow.stateless<Unit, Unit, Unit> {
-        runningWorker(Worker.from { trigger.await() }) { action { setOutput(Unit) } }
+        runningWorker(Worker.from { trigger.await() }) { action("") { setOutput(Unit) } }
       }
       renderWorkflowIn(
         workflow = workflow,
@@ -822,7 +822,7 @@ class RenderWorkflowInTest {
         initialState = { "{no output}" },
         render = { _, renderState ->
           runningWorker(Worker.from { outputTrigger.await() }) { output ->
-            action {
+            action("") {
               setOutput(output)
               state = output
             }
@@ -1007,7 +1007,7 @@ class RenderWorkflowInTest {
       val workflow = Workflow.stateful<Unit, String, Nothing, String>(
         initialState = { "unchanging state" },
         render = { _, renderState ->
-          sink = actionSink.contraMap { action { state = it } }
+          sink = actionSink.contraMap { action("") { state = it } }
           renderState
         }
       )
@@ -1048,7 +1048,7 @@ class RenderWorkflowInTest {
       val workflow = Workflow.stateful<Unit, String, Nothing, String>(
         initialState = { "unchanging state" },
         render = { _, renderState ->
-          sink = actionSink.contraMap { action { state = it } }
+          sink = actionSink.contraMap { action("") { state = it } }
           renderState
         }
       )

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
@@ -259,7 +259,7 @@ internal class WorkflowInterceptorTest {
       renderState: String,
       context: RenderContext
     ): TestRendering {
-      return TestRendering(context.eventHandler { state = "$state: fired" })
+      return TestRendering(context.eventHandler("") { state = "$state: fired" })
     }
 
     override fun snapshotState(state: String): Snapshot? = null

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/RealRenderContextTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/RealRenderContextTest.kt
@@ -26,6 +26,11 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
+/**
+ * Cheap hack to avoid lines that are too long and cause auto-format v. lint pain.
+ */
+private typealias S = String
+
 internal class RealRenderContextTest {
 
   private class TestRenderer : Renderer<String, String, String> {
@@ -153,7 +158,7 @@ internal class RealRenderContextTest {
 
   @Test fun eventHandler0_gets_event() {
     val context = createdPoisonedContext()
-    val sink: () -> Unit = context.eventHandler { setOutput("yay") }
+    val sink: () -> Unit = context.eventHandler("") { setOutput("yay") }
     // Enable sink sends.
     context.freeze()
 
@@ -168,7 +173,7 @@ internal class RealRenderContextTest {
 
   @Test fun eventHandler1_gets_event() {
     val context = createdPoisonedContext()
-    val sink = context.eventHandler { it: String -> setOutput(it) }
+    val sink = context.eventHandler("") { it: String -> setOutput(it) }
     // Enable sink sends.
     context.freeze()
 
@@ -183,7 +188,7 @@ internal class RealRenderContextTest {
 
   @Test fun eventHandler2_gets_event() {
     val context = createdPoisonedContext()
-    val sink = context.eventHandler { a: String, b: String -> setOutput(a + b) }
+    val sink = context.eventHandler("") { a: String, b: String -> setOutput(a + b) }
     // Enable sink sends.
     context.freeze()
 
@@ -198,7 +203,7 @@ internal class RealRenderContextTest {
 
   @Test fun eventHandler3_gets_event() {
     val context = createdPoisonedContext()
-    val sink = context.eventHandler { a: String, b: String, c: String, d: String ->
+    val sink = context.eventHandler("") { a: String, b: String, c: String, d: String ->
       setOutput(a + b + c + d)
     }
     // Enable sink sends.
@@ -215,7 +220,7 @@ internal class RealRenderContextTest {
 
   @Test fun eventHandler4_gets_event() {
     val context = createdPoisonedContext()
-    val sink = context.eventHandler { a: String, b: String, c: String, d: String ->
+    val sink = context.eventHandler("") { a: String, b: String, c: String, d: String ->
       setOutput(a + b + c + d)
     }
     // Enable sink sends.
@@ -232,7 +237,7 @@ internal class RealRenderContextTest {
 
   @Test fun eventHandler5_gets_event() {
     val context = createdPoisonedContext()
-    val sink = context.eventHandler { a: String, b: String, c: String, d: String, e: String ->
+    val sink = context.eventHandler("") { a: String, b: String, c: String, d: String, e: String ->
       setOutput(a + b + c + d + e)
     }
     // Enable sink sends.
@@ -250,7 +255,7 @@ internal class RealRenderContextTest {
   @Test fun eventHandler6_gets_event() {
     val context = createdPoisonedContext()
     val sink =
-      context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String ->
+      context.eventHandler("") { a: String, b: String, c: String, d: String, e: String, f: String ->
         setOutput(a + b + c + d + e + f)
       }
     // Enable sink sends.
@@ -268,8 +273,7 @@ internal class RealRenderContextTest {
   @Test fun eventHandler7_gets_event() {
     val context = createdPoisonedContext()
     val sink =
-      context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String,
-                             g: String ->
+      context.eventHandler("") { a: S, b: S, c: S, d: S, e: S, f: S, g: S ->
         setOutput(a + b + c + d + e + f + g)
       }
     // Enable sink sends.
@@ -287,8 +291,7 @@ internal class RealRenderContextTest {
   @Test fun eventHandler8_gets_event() {
     val context = createdPoisonedContext()
     val sink =
-      context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String,
-                             g: String, h: String ->
+      context.eventHandler("") { a: S, b: S, c: S, d: S, e: S, f: S, g: S, h: S ->
         setOutput(a + b + c + d + e + f + g + h)
       }
     // Enable sink sends.
@@ -306,8 +309,7 @@ internal class RealRenderContextTest {
   @Test fun eventHandler9_gets_event() {
     val context = createdPoisonedContext()
     val sink =
-      context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String,
-                             g: String, h: String, i: String ->
+      context.eventHandler("") { a: S, b: S, c: S, d: S, e: S, f: S, g: S, h: S, i: S ->
         setOutput(a + b + c + d + e + f + g + h + i)
       }
     // Enable sink sends.
@@ -325,8 +327,7 @@ internal class RealRenderContextTest {
   @Test fun eventHandler10_gets_event() {
     val context = createdPoisonedContext()
     val sink =
-      context.eventHandler { a: String, b: String, c: String, d: String, e: String, f: String,
-                             g: String, h: String, i: String, j: String ->
+      context.eventHandler("") { a: S, b: S, c: S, d: S, e: S, f: S, g: S, h: S, i: S, j: S ->
         setOutput(a + b + c + d + e + f + g + h + i + j)
       }
     // Enable sink sends.
@@ -346,7 +347,7 @@ internal class RealRenderContextTest {
     val workflow = TestWorkflow()
 
     val (child, props, key, handler) = context.renderChild(workflow, "props", "key") { output ->
-      action { setOutput("output:$output") }
+      action("") { setOutput("output:$output") }
     }
 
     assertSame(workflow, child)
@@ -365,7 +366,7 @@ internal class RealRenderContextTest {
     val workflow = TestWorkflow()
 
     val (child, props, key, handler) = context.renderChild(workflow, "props", "key") {
-      action {
+      action("") {
         state = "new"
       }
     }

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
@@ -57,7 +57,7 @@ internal class SubtreeManagerTest {
       return Rendering(
         renderProps,
         renderState,
-        eventHandler = context.eventHandler { out -> setOutput("workflow output:$out") }
+        eventHandler = context.eventHandler("") { out -> setOutput("workflow output:$out") }
       )
     }
 
@@ -163,7 +163,7 @@ internal class SubtreeManagerTest {
     val manager = subtreeManagerForTest<String, String, String>()
     val workflow = TestWorkflow()
     val handler: StringHandler = { output ->
-      action { setOutput("case output:$output") }
+      action("") { setOutput("case output:$output") }
     }
 
     // Initialize the child so applyNextAction has something to work with, and so that we can send
@@ -213,7 +213,7 @@ internal class SubtreeManagerTest {
         .also { manager.commitRenderedChildren() }
 
     // First render + apply action pass – uninteresting.
-    render { action { setOutput("initial handler: $it") } }
+    render { action("") { setOutput("initial handler: $it") } }
       .let { rendering ->
         rendering.eventHandler("initial output")
         val initialAction = manager.applyNextAction().output!!.value
@@ -227,7 +227,7 @@ internal class SubtreeManagerTest {
 
     // Do a second render + apply action, but with a different handler function.
     render {
-      action {
+      action("") {
         state = "New State"
         setOutput("second handler: $it")
       }

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -168,7 +168,7 @@ internal class WorkflowNodeTest {
         renderState: String,
         context: RenderContext
       ): (String) -> Unit {
-        return context.eventHandler { event -> setOutput(event) }
+        return context.eventHandler("") { event -> setOutput(event) }
       }
     }
     val node = WorkflowNode(
@@ -210,7 +210,7 @@ internal class WorkflowNodeTest {
         renderState: String,
         context: RenderContext
       ): (String) -> Unit {
-        return context.eventHandler { event -> setOutput(event) }
+        return context.eventHandler("") { event -> setOutput(event) }
       }
     }
     val node = WorkflowNode(
@@ -268,10 +268,10 @@ internal class WorkflowNodeTest {
     val node = WorkflowNode(workflow.id(), workflow, "", null, context)
 
     node.render(workflow, "")
-    sink.send(action { setOutput("event") })
+    sink.send(action("") { setOutput("event") })
 
     // Should not throw.
-    sink.send(action { setOutput("event2") })
+    sink.send(action("") { setOutput("event2") })
   }
 
   @Test fun sideEffect_is_not_started_until_after_render_completes() {
@@ -322,7 +322,7 @@ internal class WorkflowNodeTest {
   @Test fun sideEffect_can_send_to_actionSink() {
     val workflow = Workflow.stateless<Unit, String, Unit> {
       runningSideEffect("key") {
-        actionSink.send(action { setOutput("result") })
+        actionSink.send(action("") { setOutput("result") })
       }
     }
     val node = WorkflowNode(
@@ -1126,7 +1126,7 @@ internal class WorkflowNodeTest {
 
   @Test fun eventSink_send_fails_before_render_pass_completed() {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
-      val sink = eventHandler { _: String -> fail("Expected handler to fail.") }
+      val sink = eventHandler("eventHandler") { _: String -> fail("Expected handler to fail.") }
       sink("Foo")
     }
     val node = WorkflowNode(
@@ -1180,7 +1180,7 @@ internal class WorkflowNodeTest {
       initialState = { "initial" },
       render = { _, renderState ->
         renderState to actionSink.contraMap {
-          action { state = "$state->$it" }
+          action("") { state = "$state->$it" }
         }
       }
     )
@@ -1207,7 +1207,7 @@ internal class WorkflowNodeTest {
 
   @Test fun actionSink_action_emits_output() {
     val workflow = Workflow.stateless<Unit, String, Sink<String>> {
-      actionSink.contraMap { action { setOutput(it) } }
+      actionSink.contraMap { action("") { setOutput(it) } }
     }
     val node = WorkflowNode(
       workflow.id(),
@@ -1234,7 +1234,7 @@ internal class WorkflowNodeTest {
 
   @Test fun actionSink_action_allows_null_output() {
     val workflow = Workflow.stateless<Unit, String?, Sink<String?>> {
-      actionSink.contraMap { action { setOutput(null) } }
+      actionSink.contraMap { action("") { setOutput(null) } }
     }
     val node = WorkflowNode(
       workflow.id(),
@@ -1262,7 +1262,7 @@ internal class WorkflowNodeTest {
       initialState = { "initial" },
       render = { _, renderState ->
         runningSideEffect("test") {
-          actionSink.send(action { state = "$state->hello" })
+          actionSink.send(action("") { state = "$state->hello" })
         }
         return@stateful renderState
       }
@@ -1287,7 +1287,7 @@ internal class WorkflowNodeTest {
   @Test fun child_action_emits_output() {
     val workflow = Workflow.stateless<Unit, String, Unit> {
       runningSideEffect("test") {
-        actionSink.send(action { setOutput("child:hello") })
+        actionSink.send(action("") { setOutput("child:hello") })
       }
     }
     val node = WorkflowNode(
@@ -1313,7 +1313,7 @@ internal class WorkflowNodeTest {
   @Test fun child_action_allows_null_output() {
     val workflow = Workflow.stateless<Unit, String?, Unit> {
       runningSideEffect("test") {
-        actionSink.send(action { setOutput(null) })
+        actionSink.send(action("") { setOutput(null) })
       }
     }
     val node = WorkflowNode(

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowRunnerTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowRunnerTest.kt
@@ -154,7 +154,7 @@ internal class WorkflowRunnerTest {
         initialState = { "initial" },
         render = { _, renderState ->
           runningWorker(Worker.from { "work" }) {
-            action {
+            action("") {
               state = "state: $it"
               setOutput("output: $it")
             }
@@ -187,7 +187,7 @@ internal class WorkflowRunnerTest {
         initialState = { "initial state($it)" },
         render = { renderProps, renderState ->
           runningWorker(Worker.from { "work" }) {
-            action {
+            action("") {
               state = "state: $it"
               setOutput("output: $it")
             }

--- a/workflow-rx2/src/test/java/com/squareup/workflow1/rx2/PublisherWorkerTest.kt
+++ b/workflow-rx2/src/test/java/com/squareup/workflow1/rx2/PublisherWorkerTest.kt
@@ -22,7 +22,7 @@ internal class PublisherWorkerTest {
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = otherWorker === this
     }
 
-    fun action(value: String) = action<Unit, Nothing, String> { setOutput(value) }
+    fun action(value: String) = action<Unit, Nothing, String>("") { setOutput(value) }
     val workflow = Workflow.stateless<Unit, String, Unit> {
       runningWorker(worker) { action(it) }
     }

--- a/workflow-testing/src/test/java/com/squareup/workflow1/TreeWorkflow.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/TreeWorkflow.kt
@@ -59,7 +59,7 @@ internal class TreeWorkflow(
       it.writeUtf8WithLength(state)
     }
 
-  private fun onEvent(newState: String) = action {
+  private fun onEvent(newState: String) = action("onEvent") {
     state = newState
   }
 }

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkerCompositionIntegrationTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkerCompositionIntegrationTest.kt
@@ -137,7 +137,7 @@ internal class WorkerCompositionIntegrationTest {
   @Test fun `runningWorker gets output`() {
     val worker = WorkerSink<String>("")
     val workflow = Workflow.stateless<Unit, String, Unit> {
-      runningWorker(worker) { action { setOutput(it) } }
+      runningWorker(worker) { action("") { setOutput(it) } }
     }
 
     workflow.launchForTestingFromStartWith {
@@ -152,7 +152,7 @@ internal class WorkerCompositionIntegrationTest {
   @Test fun `runningWorker gets error`() {
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
       runningWorker(Worker.from<Unit> { throw ExpectedException() }) {
-        action { }
+        action("") { }
       }
     }
 
@@ -188,14 +188,14 @@ internal class WorkerCompositionIntegrationTest {
   @Test fun `runningWorker handler closes over latest state`() {
     val triggerOutput = WorkerSink<Unit>("")
 
-    val incrementState = action<Unit, Int, Int> {
+    val incrementState = action<Unit, Int, Int>("") {
       state += 1
     }
 
     val workflow = Workflow.stateful(
       initialState = 0,
       render = { _ ->
-        runningWorker(triggerOutput) { action { setOutput(state) } }
+        runningWorker(triggerOutput) { action("") { setOutput(state) } }
 
         return@stateful { actionSink.send(incrementState) }
       }
@@ -242,7 +242,7 @@ internal class WorkerCompositionIntegrationTest {
     val worker = Worker.from { }
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
       runningWorker(worker) {
-        action { }
+        action("") { }
       }
     }
 
@@ -256,10 +256,10 @@ internal class WorkerCompositionIntegrationTest {
   @Test fun `worker context job is ignored`() {
     val worker = Worker.from { coroutineContext }
     val leafWorkflow = Workflow.stateless<Unit, CoroutineContext, Unit> {
-      runningWorker(worker) { context -> action { setOutput(context) } }
+      runningWorker(worker) { context -> action("") { setOutput(context) } }
     }
     val workflow = Workflow.stateless<Unit, CoroutineContext, Unit> {
-      renderChild(leafWorkflow) { action { setOutput(it) } }
+      renderChild(leafWorkflow) { action("") { setOutput(it) } }
     }
     val job = Job()
 
@@ -272,10 +272,10 @@ internal class WorkerCompositionIntegrationTest {
   @Test fun `worker context is used for workers`() {
     val worker = Worker.from { coroutineContext }
     val leafWorkflow = Workflow.stateless<Unit, CoroutineContext, Unit> {
-      runningWorker(worker) { context -> action { setOutput(context) } }
+      runningWorker(worker) { context -> action("") { setOutput(context) } }
     }
     val workflow = Workflow.stateless<Unit, CoroutineContext, Unit> {
-      renderChild(leafWorkflow) { action { setOutput(it) } }
+      renderChild(leafWorkflow) { action("") { setOutput(it) } }
     }
     val dispatcher: CoroutineDispatcher = object : CoroutineDispatcher() {
       override fun isDispatchNeeded(context: CoroutineContext): Boolean =

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkerStressTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkerStressTest.kt
@@ -32,7 +32,7 @@ internal class WorkerStressTest {
         .asWorker()
         .transform { it.onCompletion { emit(Unit) } }
     }
-    val action = action<Unit, Nothing, Unit> { setOutput(Unit) }
+    val action = action<Unit, Nothing, Unit>("") { setOutput(Unit) }
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
       // Run lots of workers that will all see the same close event.
       workers.forEachIndexed { i, worker ->
@@ -72,7 +72,7 @@ internal class WorkerStressTest {
     val flow = MutableStateFlow(Unit)
 
     val workers = List(WORKER_COUNT) { flow.asWorker() }
-    val action = action<Unit, Nothing, Int> { setOutput(1) }
+    val action = action<Unit, Nothing, Int>("") { setOutput(1) }
     val workflow = Workflow.stateless<Unit, Int, Unit> {
       // Run lots of workers that will all see the same conflated channel value.
       workers.forEachIndexed { i, worker ->

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowCompositionIntegrationTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowCompositionIntegrationTest.kt
@@ -89,15 +89,15 @@ class WorkflowCompositionIntegrationTest {
   @Test fun `renderChild closes over latest state`() {
     val triggerChildOutput = WorkerSink<Unit>("")
     val child = Workflow.stateless<Unit, Unit, Unit> {
-      runningWorker(triggerChildOutput) { action { setOutput(Unit) } }
+      runningWorker(triggerChildOutput) { action("") { setOutput(Unit) } }
     }
-    val incrementState = action<Unit, Int, Int> {
+    val incrementState = action<Unit, Int, Int>("") {
       state += 1
     }
-    val workflow = Workflow.stateful<Int, Int, () -> Unit>(
+    val workflow = Workflow.stateful(
       initialState = 0,
       render = { _ ->
-        renderChild(child) { action { setOutput(state) } }
+        renderChild(child) { action("") { setOutput(state) } }
         return@stateful { actionSink.send(incrementState) }
       }
     )

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowsLifecycleTests.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowsLifecycleTests.kt
@@ -42,7 +42,7 @@ class WorkflowsLifecycleTests {
           }
         }
         // Rendering pair is current int state and a function to change it.
-        renderState to { newState -> actionSink.send(action { state = newState }) }
+        renderState to { newState -> actionSink.send(action("") { state = newState }) }
       }
     )
 
@@ -70,7 +70,7 @@ class WorkflowsLifecycleTests {
           renderChild(sessionWorkflow)
         }
         // Rendering pair is current int state and a function to change it.
-        renderState to { newState -> actionSink.send(action { state = newState }) }
+        renderState to { newState -> actionSink.send(action("") { state = newState }) }
       }
     )
 

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
@@ -768,10 +768,10 @@ internal class RealRenderTesterTest {
     val worker = Worker.from { }
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningWorker(worker) {
-        action { }
+        action("") { }
       }
       runningWorker(worker) {
-        action { }
+        action("") { }
       }
     }
 
@@ -1244,7 +1244,7 @@ internal class RealRenderTesterTest {
     var actionCount = 0
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningWorker(worker) {
-        action { actionCount++ }
+        action("") { actionCount++ }
       }
     }
 

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/RenderIdempotencyCheckerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/RenderIdempotencyCheckerTest.kt
@@ -7,13 +7,11 @@ import com.squareup.workflow1.renderWorkflowIn
 import com.squareup.workflow1.stateless
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.Unconfined
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class RenderIdempotencyCheckerTest {
 
   @Test fun `renders tree twice`() {
@@ -42,7 +40,7 @@ class RenderIdempotencyCheckerTest {
       {
           value: String ->
         actionSink.send(
-          action {
+          action("") {
             setOutput(value)
           }
         )
@@ -58,7 +56,7 @@ class RenderIdempotencyCheckerTest {
       outputs += it
     }
 
-    assertEquals(emptyList<String>(), outputs)
+    assertEquals(emptyList(), outputs)
     renderings.value.rendering.invoke("poke")
     assertEquals(listOf("poke"), outputs)
   }
@@ -68,7 +66,7 @@ class RenderIdempotencyCheckerTest {
       val sink = actionSink
       { value: String ->
         sink.send(
-          action {
+          action("") {
             setOutput(value)
           }
         )
@@ -84,7 +82,7 @@ class RenderIdempotencyCheckerTest {
       outputs += it
     }
 
-    assertEquals(emptyList<String>(), outputs)
+    assertEquals(emptyList(), outputs)
     renderings.value.rendering.invoke("poke")
     assertEquals(listOf("poke"), outputs)
   }

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/WorkerRenderExpectationsTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/WorkerRenderExpectationsTest.kt
@@ -26,8 +26,8 @@ class WorkerRenderExpectationsTest {
       override fun run(): Flow<Int> = emptyFlow()
     }
     val workflow = Workflow.stateless<Unit, String, Unit> {
-      runningWorker(stringWorker) { action { setOutput(it) } }
-      runningWorker(intWorker) { action { setOutput(it.toString()) } }
+      runningWorker(stringWorker) { action("") { setOutput(it) } }
+      runningWorker(intWorker) { action("") { setOutput(it.toString()) } }
     }
 
     // Exact string match
@@ -66,8 +66,8 @@ class WorkerRenderExpectationsTest {
       override fun run(): Flow<Int> = emptyFlow()
     }
     val workflow = Workflow.stateless<Unit, String, Unit> {
-      runningWorker(stringWorker) { action { setOutput(it) } }
-      runningWorker(intWorker) { action { setOutput(it.toString()) } }
+      runningWorker(stringWorker) { action("") { setOutput(it) } }
+      runningWorker(intWorker) { action("") { setOutput(it.toString()) } }
     }
 
     // Exact string match
@@ -100,8 +100,8 @@ class WorkerRenderExpectationsTest {
     class EmptyIntWorker : EmptyWorker<Int>()
 
     val workflow = Workflow.stateless<Unit, String, Unit> {
-      runningWorker(EmptyStringWorker()) { action { setOutput(it) } }
-      runningWorker(EmptyIntWorker()) { action { setOutput(it.toString()) } }
+      runningWorker(EmptyStringWorker()) { action("") { setOutput(it) } }
+      runningWorker(EmptyIntWorker()) { action("") { setOutput(it.toString()) } }
     }
 
     // Exact string match
@@ -152,7 +152,7 @@ class WorkerRenderExpectationsTest {
     // Match with instance of parameterized workflow
     Workflow
       .stateless<Unit, String, Unit> {
-        runningWorker(EmptyWorker<String>()) { action { setOutput(it) } }
+        runningWorker(EmptyWorker<String>()) { action("") { setOutput(it) } }
       }
       .let {
         it.testRender(Unit)
@@ -176,8 +176,8 @@ class WorkerRenderExpectationsTest {
     class EmptyIntWorker : EmptyWorker<Int>()
 
     val workflow = Workflow.stateless<Unit, String, Unit> {
-      runningWorker(EmptyStringWorker()) { action { setOutput(it) } }
-      runningWorker(EmptyIntWorker()) { action { setOutput(it.toString()) } }
+      runningWorker(EmptyStringWorker()) { action("") { setOutput(it) } }
+      runningWorker(EmptyIntWorker()) { action("") { setOutput(it.toString()) } }
     }
 
     // Exact string match
@@ -250,7 +250,7 @@ class WorkerRenderExpectationsTest {
     // Match with instance of parameterized workflow
     Workflow
       .stateless<Unit, String, Unit> {
-        runningWorker(EmptyWorker<String>()) { action { setOutput(it) } }
+        runningWorker(EmptyWorker<String>()) { action("") { setOutput(it) } }
       }
       .let {
         it.testRender(Unit)
@@ -273,7 +273,7 @@ class WorkerRenderExpectationsTest {
     }
 
     val workflow = Workflow.stateless<Unit, String, Unit> {
-      runningWorker(RequestWorker("foo")) { action { setOutput(it) } }
+      runningWorker(RequestWorker("foo")) { action("") { setOutput(it) } }
     }
 
     // Matching input
@@ -314,8 +314,8 @@ class WorkerRenderExpectationsTest {
       // TODO(https://github.com/square/workflow-kotlin/issues/120) There's a major bug here,
       //  renderTester is allowing duplicate workflows to be rendered. This test should fail because
       //  of that, not because trick doesn't match the expectation for honest.
-      runningWorker(trickWorker) { action { setOutput(it) } }
-      runningWorker(honestWorker) { action { setOutput(it) } }
+      runningWorker(trickWorker) { action("") { setOutput(it) } }
+      runningWorker(honestWorker) { action("") { setOutput(it) } }
     }
     multiWorkflow.testRender(Unit)
       .expectWorker(trickWorker, description = "trick")
@@ -333,8 +333,8 @@ class WorkerRenderExpectationsTest {
 
     // Using keys clears up the ambiguity.
     val multiKeyedWorkflow = Workflow.stateless<Unit, String, Unit> {
-      runningWorker(trickWorker, key = "trick") { action { setOutput(it) } }
-      runningWorker(honestWorker, key = "honest") { action { setOutput(it) } }
+      runningWorker(trickWorker, key = "trick") { action("") { setOutput(it) } }
+      runningWorker(honestWorker, key = "honest") { action("") { setOutput(it) } }
     }
     multiKeyedWorkflow.testRender(Unit)
       .expectWorker(trickWorker, key = "trick", description = "trick")
@@ -342,7 +342,7 @@ class WorkerRenderExpectationsTest {
       .render()
 
     val trickWorkflow = Workflow.stateless<Unit, String, Unit> {
-      runningWorker(trickWorker) { action { setOutput(it) } }
+      runningWorker(trickWorker) { action("") { setOutput(it) } }
     }
     trickWorkflow.testRender(Unit)
       .expectWorker(honestWorker)
@@ -357,7 +357,7 @@ class WorkerRenderExpectationsTest {
       }
 
     val honestWorkflow = Workflow.stateless<Unit, String, Unit> {
-      runningWorker(honestWorker) { action { setOutput(it) } }
+      runningWorker(honestWorker) { action("") { setOutput(it) } }
     }
     honestWorkflow.testRender(Unit)
       .expectWorker(trickWorker)

--- a/workflow-tracing/src/test/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptorTest.kt
+++ b/workflow-tracing/src/test/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptorTest.kt
@@ -137,7 +137,7 @@ internal class TracingWorkflowInterceptorTest {
 
     override fun snapshotState(state: String): Snapshot? = null
 
-    private fun bubbleUp(output: String) = action { setOutput(output) }
+    private fun bubbleUp(output: String) = action("bubbleUp") { setOutput(output) }
   }
 }
 

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/RenderAsStateTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/RenderAsStateTest.kt
@@ -91,7 +91,7 @@ internal class RenderAsStateTest {
     val workflow = Workflow.stateless<Unit, String, (String) -> Unit> {
       {
           string ->
-        actionSink.send(action { setOutput(string) })
+        actionSink.send(action("") { setOutput(string) })
       }
     }
     val receivedOutputs = mutableListOf<String>()
@@ -386,7 +386,7 @@ internal class RenderAsStateTest {
     override fun snapshotState(state: String): Snapshot =
       Snapshot.write { it.writeUtf8WithLength(state) }
 
-    private fun updateString(newString: String) = action {
+    private fun updateString(newString: String) = action("updateString") {
       state = newString
     }
   }


### PR DESCRIPTION
Logs of actions are nearly useless if they have no name. Let's stop making things so convenient that we go blind.