### PR TITLE
Deprecates the name-optional flavor of `StatelessWorkflow.action`

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -411,10 +411,10 @@ public final class com/squareup/workflow1/Workflows {
 	public static final fun action (Lcom/squareup/workflow1/StatefulWorkflow;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lcom/squareup/workflow1/StatelessWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lcom/squareup/workflow1/StatelessWorkflow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
+	public static final fun action (Lcom/squareup/workflow1/StatelessWorkflow;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
-	public static synthetic fun action$default (Lcom/squareup/workflow1/StatelessWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun applyTo (Lcom/squareup/workflow1/WorkflowAction;Ljava/lang/Object;Ljava/lang/Object;)Lkotlin/Pair;
 	public static final fun contraMap (Lcom/squareup/workflow1/Sink;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/Sink;
 	public static final fun getComputedIdentifier (Lcom/squareup/workflow1/Workflow;)Lcom/squareup/workflow1/WorkflowIdentifier;

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
@@ -113,15 +113,14 @@ public fun <RenderingT> Workflow.Companion.rendering(
   rendering: RenderingT
 ): Workflow<Unit, Nothing, RenderingT> = stateless { rendering }
 
-
 @Deprecated(
   "Always provide a debugging name",
   ReplaceWith("action(\"TODO: debugging name\", update)")
 )
 public fun <PropsT, OutputT, RenderingT>
   StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
-  update: WorkflowAction<PropsT, *, OutputT>.Updater.() -> Unit
-): WorkflowAction<PropsT, Nothing, OutputT> = action("", update)
+    update: WorkflowAction<PropsT, *, OutputT>.Updater.() -> Unit
+  ): WorkflowAction<PropsT, Nothing, OutputT> = action("", update)
 
 /**
  * Convenience to create a [WorkflowAction] with parameter types matching those

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
@@ -113,6 +113,16 @@ public fun <RenderingT> Workflow.Companion.rendering(
   rendering: RenderingT
 ): Workflow<Unit, Nothing, RenderingT> = stateless { rendering }
 
+
+@Deprecated(
+  "Always provide a debugging name",
+  ReplaceWith("action(\"TODO: debugging name\", update)")
+)
+public fun <PropsT, OutputT, RenderingT>
+  StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
+  update: WorkflowAction<PropsT, *, OutputT>.Updater.() -> Unit
+): WorkflowAction<PropsT, Nothing, OutputT> = action("", update)
+
 /**
  * Convenience to create a [WorkflowAction] with parameter types matching those
  * of the receiving [StatefulWorkflow]. The action will invoke the given [lambda][update]
@@ -123,7 +133,7 @@ public fun <RenderingT> Workflow.Companion.rendering(
  */
 public fun <PropsT, OutputT, RenderingT>
   StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
-    name: String = "",
+    name: String,
     update: WorkflowAction<PropsT, *, OutputT>.Updater.() -> Unit
   ): WorkflowAction<PropsT, Nothing, OutputT> = action({ name }, update)
 


### PR DESCRIPTION
Missed a spot in #1226.