### PR TITLE
Ensure Correct SavedStateRegistryOwner Propagation in asComposableFactory

### DIFF
--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ScreenComposableFactory.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ScreenComposableFactory.kt
@@ -10,8 +10,10 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.LocalSavedStateRegistryOwner
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ScreenViewFactory
 import com.squareup.workflow1.ui.ScreenViewHolder
@@ -190,6 +192,7 @@ public fun <ScreenT : Screen> ScreenViewFactory<ScreenT>.asComposableFactory():
       rendering: ScreenT
     ) {
       val lifecycleOwner = LocalLifecycleOwner.current
+      val savedStateRegistryOwner = LocalSavedStateRegistryOwner.current
       val environment = LocalWorkflowEnvironment.current
 
       // Make sure any nested WorkflowViewStub will be able to propagate the
@@ -217,6 +220,7 @@ public fun <ScreenT : Screen> ScreenViewFactory<ScreenT>.asComposableFactory():
 
               // Unfortunately AndroidView doesn't propagate these itself.
               viewHolder.view.setViewTreeLifecycleOwner(lifecycleOwner)
+              viewHolder.view.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
               onBackOrNull?.let {
                 viewHolder.view.setViewTreeOnBackPressedDispatcherOwner(it)
               }


### PR DESCRIPTION
This PR enhances state management within `asComposableFactory` by ensuring that each view level correctly accesses its own `SavedStateRegistryOwner`, preventing premature or incorrect state restoration assumptions.

### Problem
Previously, nested views in a hierarchy (e.g., grandparent, parent, and child views) could potentially retrieve a `SavedStateRegistryOwner` from a higher-level view (e.g., the grandparent) before intermediate levels (e.g., the parent) fully restored their state. This caused a state inconsistency where the child view could assume that all parent states were restored when, in fact, it wasn't. This caused a crash `java.lang.IllegalStateException: You can consumeRestoredStateForKey only after super.onCreate of corresponding component.`


### Solution
To resolve this, this PR updates `asComposableFactory` by explicitly setting the `SavedStateRegistryOwner` for each view level through `setViewTreeSavedStateRegistryOwner`. This change ensures that each view accesses its appropriate state registry owner, maintaining accurate restoration tracking at each hierarchy level.