### PR TITLE
Remove Deprecated Worker, eventHandler, and action APIs

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -34,28 +34,6 @@ public abstract interface class com/squareup/workflow1/BaseRenderContext {
 	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
 	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
 	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
-	public abstract fun eventHandler (Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public abstract fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public abstract fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
@@ -73,38 +51,6 @@ public final class com/squareup/workflow1/BaseRenderContext$DefaultImpls {
 	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
 	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
 	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
-	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;ILjava/lang/Object;)Lkotlin/jvm/functions/Function9;
-	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;ILjava/lang/Object;)Lkotlin/jvm/functions/Function10;
-	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/jvm/functions/Function0;
-	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lkotlin/jvm/functions/Function2;
-	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;ILjava/lang/Object;)Lkotlin/jvm/functions/Function3;
-	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function5;ILjava/lang/Object;)Lkotlin/jvm/functions/Function4;
-	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function6;ILjava/lang/Object;)Lkotlin/jvm/functions/Function5;
-	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;ILjava/lang/Object;)Lkotlin/jvm/functions/Function6;
-	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;ILjava/lang/Object;)Lkotlin/jvm/functions/Function7;
-	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;ILjava/lang/Object;)Lkotlin/jvm/functions/Function8;
 	public static synthetic fun renderChild$default (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -220,28 +166,6 @@ public final class com/squareup/workflow1/StatefulWorkflow$RenderContext : com/s
 	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
 	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
 	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
-	public fun eventHandler (Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
-	public fun eventHandler (Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
-	public fun eventHandler (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public fun eventHandler (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public fun eventHandler (Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public fun eventHandler (Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
-	public fun eventHandler (Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
-	public fun eventHandler (Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
-	public fun eventHandler (Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
-	public fun eventHandler (Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
-	public fun eventHandler (Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
@@ -267,28 +191,6 @@ public final class com/squareup/workflow1/StatelessWorkflow$RenderContext : com/
 	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
 	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
 	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
-	public fun eventHandler (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
-	public fun eventHandler (Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
-	public fun eventHandler (Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
-	public fun eventHandler (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public fun eventHandler (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public fun eventHandler (Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public fun eventHandler (Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
-	public fun eventHandler (Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
-	public fun eventHandler (Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
-	public fun eventHandler (Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
-	public fun eventHandler (Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
-	public fun eventHandler (Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
@@ -308,7 +210,6 @@ public abstract interface class com/squareup/workflow1/Worker {
 }
 
 public final class com/squareup/workflow1/Worker$Companion {
-	public final fun createSideEffect (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/Worker;
 	public final fun finished ()Lcom/squareup/workflow1/Worker;
 	public final fun timer (JLjava/lang/String;)Lcom/squareup/workflow1/Worker;
 	public static synthetic fun timer$default (Lcom/squareup/workflow1/Worker$Companion;JLjava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow1/Worker;
@@ -410,13 +311,10 @@ public final class com/squareup/workflow1/Workflows {
 	public static final fun RenderContext (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/StatelessWorkflow;)Lcom/squareup/workflow1/StatelessWorkflow$RenderContext;
 	public static final fun action (Lcom/squareup/workflow1/StatefulWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lcom/squareup/workflow1/StatefulWorkflow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
-	public static final fun action (Lcom/squareup/workflow1/StatefulWorkflow;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lcom/squareup/workflow1/StatelessWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lcom/squareup/workflow1/StatelessWorkflow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
-	public static final fun action (Lcom/squareup/workflow1/StatelessWorkflow;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
-	public static final fun action (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun applyTo (Lcom/squareup/workflow1/WorkflowAction;Ljava/lang/Object;Ljava/lang/Object;)Lkotlin/Pair;
 	public static final fun contraMap (Lcom/squareup/workflow1/Sink;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/Sink;
 	public static final fun getComputedIdentifier (Lcom/squareup/workflow1/Workflow;)Lcom/squareup/workflow1/WorkflowIdentifier;

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/BaseRenderContext.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/BaseRenderContext.kt
@@ -173,7 +173,6 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
    * as a debugging aid
    * @param update Function that defines the workflow update.
    */
-  @Suppress("DEPRECATION")
   public fun eventHandler(
     name: String,
     // Type variance issue: https://github.com/square/workflow-kotlin/issues/891
@@ -182,130 +181,37 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
       StateT,
       @UnsafeVariance OutputT
       >.Updater.() -> Unit
-  ): () -> Unit = eventHandler({ name }, update)
-
-  @Deprecated(
-    "Always provide a debugging name",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun eventHandler(
-    // Type variance issue: https://github.com/square/workflow-kotlin/issues/891
-    update:
-    WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.() -> Unit
-  ): () -> Unit = eventHandler("eventHandler", update)
-
-  @Deprecated(
-    "Use a static string.",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun eventHandler(
-    name: () -> String = { "eventHandler" },
-    // Type variance issue: https://github.com/square/workflow-kotlin/issues/891
-    update:
-    WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.() -> Unit
   ): () -> Unit {
     return {
-      actionSink.send(action(name, update))
+      actionSink.send(action("eH:$name", update))
     }
   }
 
-  @Deprecated(
-    "Always provide a debugging name",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <EventT> eventHandler(
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      EventT
-    ) -> Unit
-  ): (EventT) -> Unit = eventHandler("eventHandler", update)
-
-  @Suppress("DEPRECATION")
   public fun <EventT> eventHandler(
     name: String,
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      EventT
-    ) -> Unit
-  ): (EventT) -> Unit = eventHandler({ name }, update)
-
-  @Deprecated(
-    "Use a static string.",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <EventT> eventHandler(
-    name: () -> String,
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
       EventT
     ) -> Unit
   ): (EventT) -> Unit {
     return { event ->
-      actionSink.send(action(name) { update(event) })
+      actionSink.send(action("eH:$name") { update(event) })
     }
   }
 
-  @Deprecated(
-    "Always provide a debugging name",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2> eventHandler(
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2
-    ) -> Unit
-  ): (E1, E2) -> Unit = eventHandler("eventHandler", update)
-
-  @Suppress("DEPRECATION")
   public fun <E1, E2> eventHandler(
     name: String,
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2
-    ) -> Unit
-  ): (E1, E2) -> Unit = eventHandler({ name }, update)
-
-  @Deprecated(
-    "Use a static string.",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2> eventHandler(
-    name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
       E1,
       E2
     ) -> Unit
   ): (E1, E2) -> Unit {
     return { e1, e2 ->
-      actionSink.send(action(name) { update(e1, e2) })
+      actionSink.send(action("eH:$name") { update(e1, e2) })
     }
   }
 
-  @Deprecated(
-    "Always provide a debugging name",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3> eventHandler(
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3
-    ) -> Unit
-  ): (E1, E2, E3) -> Unit = eventHandler("eventHandler", update)
-
-  @Suppress("DEPRECATION")
   public fun <E1, E2, E3> eventHandler(
     name: String,
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3
-    ) -> Unit
-  ): (E1, E2, E3) -> Unit = eventHandler({ name }, update)
-
-  @Deprecated(
-    "Use a static string.",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3> eventHandler(
-    name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
       E1,
       E2,
@@ -313,40 +219,12 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     ) -> Unit
   ): (E1, E2, E3) -> Unit {
     return { e1, e2, e3 ->
-      actionSink.send(action(name) { update(e1, e2, e3) })
+      actionSink.send(action("eH:$name") { update(e1, e2, e3) })
     }
   }
 
-  @Deprecated(
-    "Always provide a debugging name",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4> eventHandler(
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3,
-      E4
-    ) -> Unit
-  ): (E1, E2, E3, E4) -> Unit = eventHandler("eventHandler", update)
-
-  @Suppress("DEPRECATION")
   public fun <E1, E2, E3, E4> eventHandler(
     name: String,
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3,
-      E4
-    ) -> Unit
-  ): (E1, E2, E3, E4) -> Unit = eventHandler({ name }, update)
-
-  @Deprecated(
-    "Use a static string.",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4> eventHandler(
-    name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
       E1,
       E2,
@@ -355,42 +233,12 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     ) -> Unit
   ): (E1, E2, E3, E4) -> Unit {
     return { e1, e2, e3, e4 ->
-      actionSink.send(action(name) { update(e1, e2, e3, e4) })
+      actionSink.send(action("eH:$name") { update(e1, e2, e3, e4) })
     }
   }
 
-  @Deprecated(
-    "Always provide a debugging name",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4, E5> eventHandler(
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3,
-      E4,
-      E5
-    ) -> Unit
-  ): (E1, E2, E3, E4, E5) -> Unit = eventHandler("eventHandler", update)
-
-  @Suppress("DEPRECATION")
   public fun <E1, E2, E3, E4, E5> eventHandler(
     name: String,
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3,
-      E4,
-      E5
-    ) -> Unit
-  ): (E1, E2, E3, E4, E5) -> Unit = eventHandler({ name }, update)
-
-  @Deprecated(
-    "Use a static string.",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4, E5> eventHandler(
-    name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
       E1,
       E2,
@@ -400,44 +248,12 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     ) -> Unit
   ): (E1, E2, E3, E4, E5) -> Unit {
     return { e1, e2, e3, e4, e5 ->
-      actionSink.send(action(name) { update(e1, e2, e3, e4, e5) })
+      actionSink.send(action("eH:$name") { update(e1, e2, e3, e4, e5) })
     }
   }
 
-  @Deprecated(
-    "Always provide a debugging name",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4, E5, E6> eventHandler(
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3,
-      E4,
-      E5,
-      E6
-    ) -> Unit
-  ): (E1, E2, E3, E4, E5, E6) -> Unit = eventHandler("eventHandler", update)
-
-  @Suppress("DEPRECATION")
   public fun <E1, E2, E3, E4, E5, E6> eventHandler(
     name: String,
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3,
-      E4,
-      E5,
-      E6
-    ) -> Unit
-  ): (E1, E2, E3, E4, E5, E6) -> Unit = eventHandler({ name }, update)
-
-  @Deprecated(
-    "Use a static string.",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4, E5, E6> eventHandler(
-    name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
       E1,
       E2,
@@ -448,46 +264,12 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     ) -> Unit
   ): (E1, E2, E3, E4, E5, E6) -> Unit {
     return { e1, e2, e3, e4, e5, e6 ->
-      actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6) })
+      actionSink.send(action("eH:$name") { update(e1, e2, e3, e4, e5, e6) })
     }
   }
 
-  @Deprecated(
-    "Always provide a debugging name",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4, E5, E6, E7> eventHandler(
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3,
-      E4,
-      E5,
-      E6,
-      E7
-    ) -> Unit
-  ): (E1, E2, E3, E4, E5, E6, E7) -> Unit = eventHandler("eventHandler", update)
-
-  @Suppress("DEPRECATION")
   public fun <E1, E2, E3, E4, E5, E6, E7> eventHandler(
     name: String,
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3,
-      E4,
-      E5,
-      E6,
-      E7
-    ) -> Unit
-  ): (E1, E2, E3, E4, E5, E6, E7) -> Unit = eventHandler({ name }, update)
-
-  @Deprecated(
-    "Use a static string.",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4, E5, E6, E7> eventHandler(
-    name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
       E1,
       E2,
@@ -499,48 +281,12 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     ) -> Unit
   ): (E1, E2, E3, E4, E5, E6, E7) -> Unit {
     return { e1, e2, e3, e4, e5, e6, e7 ->
-      actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6, e7) })
+      actionSink.send(action("eH:$name") { update(e1, e2, e3, e4, e5, e6, e7) })
     }
   }
 
-  @Deprecated(
-    "Always provide a debugging name",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4, E5, E6, E7, E8> eventHandler(
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3,
-      E4,
-      E5,
-      E6,
-      E7,
-      E8
-    ) -> Unit
-  ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit = eventHandler("eventHandler", update)
-
-  @Suppress("DEPRECATION")
   public fun <E1, E2, E3, E4, E5, E6, E7, E8> eventHandler(
     name: String,
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3,
-      E4,
-      E5,
-      E6,
-      E7,
-      E8
-    ) -> Unit
-  ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit = eventHandler({ name }, update)
-
-  @Deprecated(
-    "Use a static string.",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4, E5, E6, E7, E8> eventHandler(
-    name: () -> String = { "eventHandler" },
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
       E1,
       E2,
@@ -553,29 +299,10 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
     ) -> Unit
   ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit {
     return { e1, e2, e3, e4, e5, e6, e7, e8 ->
-      actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6, e7, e8) })
+      actionSink.send(action("eH:$name") { update(e1, e2, e3, e4, e5, e6, e7, e8) })
     }
   }
 
-  @Deprecated(
-    "Always provide a debugging name",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4, E5, E6, E7, E8, E9> eventHandler(
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3,
-      E4,
-      E5,
-      E6,
-      E7,
-      E8,
-      E9
-    ) -> Unit
-  ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit = eventHandler("eventHandler", update)
-
-  @Suppress("DEPRECATION")
   public fun <E1, E2, E3, E4, E5, E6, E7, E8, E9> eventHandler(
     name: String,
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
@@ -589,42 +316,12 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
       E8,
       E9
     ) -> Unit
-  ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit = eventHandler({ name }, update)
-
-  @Deprecated(
-    "Use a static string.",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4, E5, E6, E7, E8, E9> eventHandler(
-    name: () -> String = { "eventHandler" },
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>
-      .Updater.(E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit
   ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit {
     return { e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
-      actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6, e7, e8, e9) })
+      actionSink.send(action("eH:$name") { update(e1, e2, e3, e4, e5, e6, e7, e8, e9) })
     }
   }
 
-  @Deprecated(
-    "Always provide a debugging name",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4, E5, E6, E7, E8, E9, E10> eventHandler(
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
-      E1,
-      E2,
-      E3,
-      E4,
-      E5,
-      E6,
-      E7,
-      E8,
-      E9,
-      E10
-    ) -> Unit
-  ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit = eventHandler("eventHandler", update)
-
-  @Suppress("DEPRECATION")
   public fun <E1, E2, E3, E4, E5, E6, E7, E8, E9, E10> eventHandler(
     name: String,
     update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>.Updater.(
@@ -639,19 +336,9 @@ public interface BaseRenderContext<out PropsT, StateT, in OutputT> {
       E9,
       E10
     ) -> Unit
-  ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit = eventHandler({ name }, update)
-
-  @Deprecated(
-    "Use a static string.",
-    ReplaceWith("eventHandler(\"TODO: debugging name\", onFailedCast, update)")
-  )
-  public fun <E1, E2, E3, E4, E5, E6, E7, E8, E9, E10> eventHandler(
-    name: () -> String = { "eventHandler" },
-    update: WorkflowAction<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT>
-      .Updater.(E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit
   ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit {
     return { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
-      actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10) })
+      actionSink.send(action("eH:$name") { update(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10) })
     }
   }
 }
@@ -696,31 +383,6 @@ public fun <PropsT, StateT, OutputT, ChildRenderingT>
  * @param key An optional string key that is used to distinguish between identical [Worker]s.
  */
 public inline fun <reified W : LifecycleWorker, PropsT, StateT, OutputT>
-  BaseRenderContext<PropsT, StateT, OutputT>.runningWorker(
-    worker: W,
-    key: String = ""
-  ) {
-  runningWorker(worker, key) {
-    // The compiler thinks this code is unreachable, and it is correct. But we have to pass a lambda
-    // here so we might as well check at runtime as well.
-    @Suppress("UNREACHABLE_CODE")
-    throw AssertionError("Worker<Nothing> emitted $it")
-  }
-}
-
-/**
- * Ensures a [Worker] that never emits anything is running. Since [worker] can't emit anything,
- * it can't trigger any [WorkflowAction]s.
- *
- * If your [Worker] does not output anything, then simply use [BaseRenderContext.runningSideEffect].
- *
- * @param key An optional string key that is used to distinguish between identical [Worker]s.
- */
-@Deprecated(
-  message = "Use [BaseRenderContext.runningSideEffect] instead.",
-  replaceWith = ReplaceWith(expression = "runningSideEffect(key) { ... }", "")
-)
-public inline fun <reified W : Worker<Nothing>, PropsT, StateT, OutputT>
   BaseRenderContext<PropsT, StateT, OutputT>.runningWorker(
     worker: W,
     key: String = ""

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
@@ -76,21 +76,6 @@ public abstract class StatefulWorkflow<
   public inner class RenderContext internal constructor(
     baseContext: BaseRenderContext<PropsT, StateT, OutputT>
   ) : BaseRenderContext<@UnsafeVariance PropsT, StateT, @UnsafeVariance OutputT> by baseContext {
-    @Deprecated(
-      "Always provide a debugging name",
-      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
-    )
-    public inline fun <reified CurrentStateT : StateT & Any> safeEventHandler(
-      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
-        ::defaultOnFailedCast,
-      // Type variance issue: https://github.com/square/workflow-kotlin/issues/891
-      crossinline update: WorkflowAction<
-        @UnsafeVariance PropsT,
-        StateT,
-        @UnsafeVariance OutputT
-        >.Updater.(currentState: CurrentStateT) -> Unit
-    ): () -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
-
     /**
      * Like [eventHandler], but no-ops if [state][WorkflowAction.Updater.state] has
      * changed to a different type than [CurrentStateT] by the time [update] fires.
@@ -144,23 +129,6 @@ public abstract class StatefulWorkflow<
       }
     }
 
-    @Deprecated(
-      "Always provide a debugging name",
-      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
-    )
-    public inline fun <reified CurrentStateT : StateT & Any, EventT> safeEventHandler(
-      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
-        ::defaultOnFailedCast,
-      crossinline update: WorkflowAction<
-        @UnsafeVariance PropsT,
-        StateT,
-        @UnsafeVariance OutputT
-        >.Updater.(
-        currentState: CurrentStateT,
-        event: EventT
-      ) -> Unit
-    ): (EventT) -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
-
     public inline fun <reified CurrentStateT : StateT & Any, EventT> safeEventHandler(
       name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
@@ -180,24 +148,6 @@ public abstract class StatefulWorkflow<
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
-
-    @Deprecated(
-      "Always provide a debugging name",
-      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
-    )
-    public inline fun <reified CurrentStateT : StateT & Any, E1, E2> safeEventHandler(
-      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
-        ::defaultOnFailedCast,
-      crossinline update: WorkflowAction<
-        @UnsafeVariance PropsT,
-        StateT,
-        @UnsafeVariance OutputT
-        >.Updater.(
-        currentState: CurrentStateT,
-        e1: E1,
-        e2: E2
-      ) -> Unit
-    ): (E1, E2) -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
 
     public inline fun <reified CurrentStateT : StateT & Any, E1, E2> safeEventHandler(
       name: String,
@@ -220,25 +170,6 @@ public abstract class StatefulWorkflow<
       }
     }
 
-    @Deprecated(
-      "Always provide a debugging name",
-      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
-    )
-    public inline fun <reified CurrentStateT : StateT & Any, E1, E2, E3> safeEventHandler(
-      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
-        ::defaultOnFailedCast,
-      crossinline update: WorkflowAction<
-        @UnsafeVariance PropsT,
-        StateT,
-        @UnsafeVariance OutputT
-        >.Updater.(
-        currentState: CurrentStateT,
-        e1: E1,
-        e2: E2,
-        e3: E3
-      ) -> Unit
-    ): (E1, E2, E3) -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
-
     public inline fun <reified CurrentStateT : StateT & Any, E1, E2, E3> safeEventHandler(
       name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
@@ -260,26 +191,6 @@ public abstract class StatefulWorkflow<
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
-
-    @Deprecated(
-      "Always provide a debugging name",
-      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
-    )
-    public inline fun <reified CurrentStateT : StateT & Any, E1, E2, E3, E4> safeEventHandler(
-      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
-        ::defaultOnFailedCast,
-      crossinline update: WorkflowAction<
-        @UnsafeVariance PropsT,
-        StateT,
-        @UnsafeVariance OutputT
-        >.Updater.(
-        currentState: CurrentStateT,
-        e1: E1,
-        e2: E2,
-        e3: E3,
-        e4: E4
-      ) -> Unit
-    ): (E1, E2, E3, E4) -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
 
     public inline fun <reified CurrentStateT : StateT & Any, E1, E2, E3, E4> safeEventHandler(
       name: String,
@@ -304,27 +215,6 @@ public abstract class StatefulWorkflow<
       }
     }
 
-    @Deprecated(
-      "Always provide a debugging name",
-      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
-    )
-    public inline fun <reified CurrentStateT : StateT & Any, E1, E2, E3, E4, E5> safeEventHandler(
-      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
-        ::defaultOnFailedCast,
-      crossinline update: WorkflowAction<
-        @UnsafeVariance PropsT,
-        StateT,
-        @UnsafeVariance OutputT
-        >.Updater.(
-        currentState: CurrentStateT,
-        e1: E1,
-        e2: E2,
-        e3: E3,
-        e4: E4,
-        e5: E5
-      ) -> Unit
-    ): (E1, E2, E3, E4, E5) -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
-
     public inline fun <reified CurrentStateT : StateT & Any, E1, E2, E3, E4, E5> safeEventHandler(
       name: String,
       crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
@@ -348,36 +238,6 @@ public abstract class StatefulWorkflow<
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
-
-    @Deprecated(
-      "Always provide a debugging name",
-      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
-    )
-    public inline fun <
-      reified CurrentStateT : StateT & Any,
-      E1,
-      E2,
-      E3,
-      E4,
-      E5,
-      E6
-      > safeEventHandler(
-      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
-        ::defaultOnFailedCast,
-      crossinline update: WorkflowAction<
-        @UnsafeVariance PropsT,
-        StateT,
-        @UnsafeVariance OutputT
-        >.Updater.(
-        currentState: CurrentStateT,
-        e1: E1,
-        e2: E2,
-        e3: E3,
-        e4: E4,
-        e5: E5,
-        e6: E6
-      ) -> Unit
-    ): (E1, E2, E3, E4, E5, E6) -> Unit = safeEventHandler("safeEventHandler", onFailedCast, update)
 
     public inline fun <
       reified CurrentStateT : StateT & Any,
@@ -411,39 +271,6 @@ public abstract class StatefulWorkflow<
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
-
-    @Deprecated(
-      "Always provide a debugging name",
-      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
-    )
-    public inline fun <
-      reified CurrentStateT : StateT & Any,
-      E1,
-      E2,
-      E3,
-      E4,
-      E5,
-      E6,
-      E7
-      > safeEventHandler(
-      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
-        ::defaultOnFailedCast,
-      crossinline update: WorkflowAction<
-        @UnsafeVariance PropsT,
-        StateT,
-        @UnsafeVariance OutputT
-        >.Updater.(
-        currentState: CurrentStateT,
-        e1: E1,
-        e2: E2,
-        e3: E3,
-        e4: E4,
-        e5: E5,
-        e6: E6,
-        e7: E7
-      ) -> Unit
-    ): (E1, E2, E3, E4, E5, E6, E7) -> Unit =
-      safeEventHandler("safeEventHandler", onFailedCast, update)
 
     public inline fun <
       reified CurrentStateT : StateT & Any,
@@ -479,41 +306,6 @@ public abstract class StatefulWorkflow<
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
-
-    @Deprecated(
-      "Always provide a debugging name",
-      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
-    )
-    public inline fun <
-      reified CurrentStateT : StateT & Any,
-      E1,
-      E2,
-      E3,
-      E4,
-      E5,
-      E6,
-      E7,
-      E8
-      > safeEventHandler(
-      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
-        ::defaultOnFailedCast,
-      crossinline update: WorkflowAction<
-        @UnsafeVariance PropsT,
-        StateT,
-        @UnsafeVariance OutputT
-        >.Updater.(
-        currentState: CurrentStateT,
-        e1: E1,
-        e2: E2,
-        e3: E3,
-        e4: E4,
-        e5: E5,
-        e6: E6,
-        e7: E7,
-        e8: E8
-      ) -> Unit
-    ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit =
-      safeEventHandler("safeEventHandler", onFailedCast, update)
 
     public inline fun <
       reified CurrentStateT : StateT & Any,
@@ -551,43 +343,6 @@ public abstract class StatefulWorkflow<
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
-
-    @Deprecated(
-      "Always provide a debugging name",
-      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
-    )
-    public inline fun <
-      reified CurrentStateT : StateT & Any,
-      E1,
-      E2,
-      E3,
-      E4,
-      E5,
-      E6,
-      E7,
-      E8,
-      E9
-      > safeEventHandler(
-      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
-        ::defaultOnFailedCast,
-      crossinline update: WorkflowAction<
-        @UnsafeVariance PropsT,
-        StateT,
-        @UnsafeVariance OutputT
-        >.Updater.(
-        currentState: CurrentStateT,
-        e1: E1,
-        e2: E2,
-        e3: E3,
-        e4: E4,
-        e5: E5,
-        e6: E6,
-        e7: E7,
-        e8: E8,
-        e9: E9
-      ) -> Unit
-    ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit =
-      safeEventHandler("safeEventHandler", onFailedCast, update)
 
     public inline fun <
       reified CurrentStateT : StateT & Any,
@@ -629,45 +384,6 @@ public abstract class StatefulWorkflow<
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
     }
-
-    @Deprecated(
-      "Always provide a debugging name",
-      ReplaceWith("safeEventHandler(\"TODO: debugging name\", onFailedCast, update)")
-    )
-    public inline fun <
-      reified CurrentStateT : StateT & Any,
-      E1,
-      E2,
-      E3,
-      E4,
-      E5,
-      E6,
-      E7,
-      E8,
-      E9,
-      E10
-      > safeEventHandler(
-      crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
-        ::defaultOnFailedCast,
-      crossinline update: WorkflowAction<
-        @UnsafeVariance PropsT,
-        StateT,
-        @UnsafeVariance OutputT
-        >.Updater.(
-        currentState: CurrentStateT,
-        e1: E1,
-        e2: E2,
-        e3: E3,
-        e4: E4,
-        e5: E5,
-        e6: E6,
-        e7: E7,
-        e8: E8,
-        e9: E9,
-        e10: E10
-      ) -> Unit
-    ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit =
-      safeEventHandler("safeEventHandler", onFailedCast, update)
 
     public inline fun <
       reified CurrentStateT : StateT & Any,
@@ -714,18 +430,6 @@ public abstract class StatefulWorkflow<
       }
     }
   }
-
-  @Deprecated(
-    "Always provide a debugging name.",
-    ReplaceWith("safeAction(\"TODO: name\", onFailedCast, update)")
-  )
-  public inline fun <reified CurrentStateT : StateT & Any> safeAction(
-    crossinline onFailedCast: (name: String, type: KClass<*>, state: StateT) -> Unit =
-      ::defaultOnFailedCast,
-    noinline update: WorkflowAction<PropsT, StateT, OutputT>.Updater.(
-      currentState: CurrentStateT
-    ) -> Unit
-  ): WorkflowAction<PropsT, StateT, OutputT> = safeAction("safeAction", onFailedCast, update)
 
   /**
    * Like [action], but no-ops if [state][WorkflowAction.Updater.state] has
@@ -969,15 +673,6 @@ public inline fun <StateT, OutputT, RenderingT> Workflow.Companion.stateful(
   { initialState },
   { _, state -> render(state) }
 )
-
-@Deprecated(
-  "Always provide a debugging name",
-  ReplaceWith("action(\"TODO: debugging name\", update)")
-)
-public fun <PropsT, StateT, OutputT, RenderingT>
-  StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.action(
-    update: WorkflowAction<PropsT, StateT, OutputT>.Updater.() -> Unit
-  ): WorkflowAction<PropsT, StateT, OutputT> = action("", update)
 
 /**
  * Convenience to create a [WorkflowAction] with parameter types matching those

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
@@ -113,15 +113,6 @@ public fun <RenderingT> Workflow.Companion.rendering(
   rendering: RenderingT
 ): Workflow<Unit, Nothing, RenderingT> = stateless { rendering }
 
-@Deprecated(
-  "Always provide a debugging name",
-  ReplaceWith("action(\"TODO: debugging name\", update)")
-)
-public fun <PropsT, OutputT, RenderingT>
-  StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
-    update: WorkflowAction<PropsT, *, OutputT>.Updater.() -> Unit
-  ): WorkflowAction<PropsT, Nothing, OutputT> = action("", update)
-
 /**
  * Convenience to create a [WorkflowAction] with parameter types matching those
  * of the receiving [StatefulWorkflow]. The action will invoke the given [lambda][update]

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowAction.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowAction.kt
@@ -89,14 +89,6 @@ public abstract class WorkflowAction<in PropsT, StateT, out OutputT> {
   }
 }
 
-@Deprecated(
-  "Always provide a debugging name.",
-  ReplaceWith("action(\"TODO: name\", apply)")
-)
-public fun <PropsT, StateT, OutputT> action(
-  apply: WorkflowAction<PropsT, StateT, OutputT>.Updater.() -> Unit
-): WorkflowAction<PropsT, StateT, OutputT> = action("", apply)
-
 /**
  * Creates a [WorkflowAction] from the [apply] lambda.
  * The returned object will include the string returned from [name] in its [toString].

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -1143,7 +1143,7 @@ internal class WorkflowNodeTest {
     assertTrue(
       error.message!!.startsWith(
         "Expected sink to not be sent to until after the render pass. " +
-          "Received action: eventHandler"
+          "Received action: eH:eventHandler"
       )
     )
   }

--- a/workflow-rx2/api/workflow-rx2.api
+++ b/workflow-rx2/api/workflow-rx2.api
@@ -5,7 +5,3 @@ public abstract class com/squareup/workflow1/rx2/PublisherWorker : com/squareup/
 	public abstract fun runPublisher ()Lorg/reactivestreams/Publisher;
 }
 
-public final class com/squareup/workflow1/rx2/RxWorkersKt {
-	public static final fun asWorker (Lio/reactivex/Completable;)Lcom/squareup/workflow1/Worker;
-}
-

--- a/workflow-rx2/src/main/java/com/squareup/workflow1/rx2/RxWorkers.kt
+++ b/workflow-rx2/src/main/java/com/squareup/workflow1/rx2/RxWorkers.kt
@@ -3,7 +3,6 @@ package com.squareup.workflow1.rx2
 import com.squareup.workflow1.Worker
 import com.squareup.workflow1.asWorker
 import io.reactivex.BackpressureStrategy.BUFFER
-import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Observable
@@ -81,17 +80,3 @@ public inline fun <reified T : Any> Single<out T?>.asWorker(): Worker<T> =
 // This !! works because RxJava types don't actually allow nulls, it's just that they can't
   // express that in their types because Java.
   Worker.from { await()!! }
-
-/**
- * Creates a [Worker] from this [Completable].
- *
- * The [Completable] will be subscribed to when the [Worker] is started, and disposed when it is
- * cancelled.
- *
- * The key is required for this operator because there is no type information available to
- * distinguish workers.
- *
- * TODO: https://github.com/square/workflow-kotlin/issues/526 once this is removed.
- */
-@Suppress("DEPRECATION")
-public fun Completable.asWorker(): Worker<Nothing> = Worker.createSideEffect { await() }

--- a/workflow-rx2/src/test/java/com/squareup/workflow1/rx2/RxWorkersTest.kt
+++ b/workflow-rx2/src/test/java/com/squareup/workflow1/rx2/RxWorkersTest.kt
@@ -6,7 +6,6 @@ import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
-import io.reactivex.subjects.CompletableSubject
 import io.reactivex.subjects.MaybeSubject
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.SingleSubject
@@ -283,58 +282,6 @@ class RxWorkersTest {
   @Test fun `single is disposed when worker cancelled`() {
     var cancels = 0
     val subject = SingleSubject.create<String>()
-    val worker = subject.doOnDispose { cancels++ }
-      .asWorker()
-
-    assertEquals(0, cancels)
-
-    worker.test {
-      assertEquals(0, cancels)
-      cancelWorker()
-      assertEquals(1, cancels)
-    }
-  }
-
-  // endregion
-
-  // region Completable
-
-  @Test fun `completable emits`() {
-    val subject = CompletableSubject.create()
-    val worker = subject.asWorker()
-
-    worker.test {
-      subject.onComplete()
-      assertFinished()
-    }
-  }
-
-  @Test fun `completable throws`() {
-    val subject = CompletableSubject.create()
-    val worker = subject.asWorker()
-
-    worker.test {
-      subject.onError(ExpectedException())
-      assertTrue(getException() is ExpectedException)
-    }
-  }
-
-  @Test fun `completable is subscribed lazily`() {
-    var subscriptions = 0
-    val subject = CompletableSubject.create()
-    val worker = subject.doOnSubscribe { subscriptions++ }
-      .asWorker()
-
-    assertEquals(0, subscriptions)
-
-    worker.test {
-      assertEquals(1, subscriptions)
-    }
-  }
-
-  @Test fun `completable is disposed when worker cancelled`() {
-    var cancels = 0
-    val subject = CompletableSubject.create()
     val worker = subject.doOnDispose { cancels++ }
       .asWorker()
 

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkerCompositionIntegrationTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkerCompositionIntegrationTest.kt
@@ -17,7 +17,6 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotSame
@@ -51,9 +50,6 @@ internal class WorkerCompositionIntegrationTest {
       }
     }
     val workflow = Workflow.stateless<Boolean, Nothing, Unit> { props ->
-      // Suppress runningWorker usage because we want to make sure this
-      // test still properly tests usage with LifecycleWorker
-      @Suppress("DEPRECATION")
       if (props) runningWorker(worker)
     }
 
@@ -77,9 +73,6 @@ internal class WorkerCompositionIntegrationTest {
       }
     }
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
-      // Suppress runningWorker usage because we want to make sure this
-      // test still properly tests usage with LifecycleWorker
-      @Suppress("DEPRECATION")
       runningWorker(worker)
     }
 
@@ -110,9 +103,6 @@ internal class WorkerCompositionIntegrationTest {
       }
     }
     val workflow = Workflow.stateless<Boolean, Nothing, Unit> { props ->
-      // Suppress runningWorker usage because we want to make sure this
-      // test still properly tests usage with LifecycleWorker
-      @Suppress("DEPRECATION")
       if (props) runningWorker(worker)
     }
 
@@ -217,24 +207,6 @@ internal class WorkerCompositionIntegrationTest {
 
       assertEquals(2, awaitNextOutput())
     }
-  }
-
-  @Test fun `runningWorker throws when output emitted`() {
-    @Suppress("UNCHECKED_CAST")
-    val worker = Worker.from { } as Worker<Nothing>
-    val workflow = Workflow.stateless<Unit, Unit, Unit> {
-      // Suppress runningWorker usage because we want to make sure the deprecated
-      // method still throws an exception as expected
-      @Suppress("DEPRECATION")
-      runningWorker(worker)
-    }
-
-    val error = assertFails {
-      workflow.launchForTestingFromStartWith {
-        // Nothing to do.
-      }
-    }
-    assertTrue("java.lang.Void" in error.message!!)
   }
 
   @Test fun `runningWorker doesn't throw when worker finishes`() {

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkerTest.kt
@@ -6,7 +6,6 @@ import com.squareup.workflow1.testing.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
 
 /** Worker tests that use the [Worker.test] function. Core tests are in the core module. */
@@ -38,50 +37,6 @@ internal class WorkerTest {
 
   @Test fun `create propagates exceptions`() {
     val worker = Worker.create<Unit> { throw ExpectedException() }
-
-    worker.test {
-      assertTrue(getException() is ExpectedException)
-    }
-  }
-
-  @Suppress("DEPRECATION")
-  @Test
-  fun `createSideEffect returns equivalent workers`() {
-    val worker1 = Worker.createSideEffect {}
-    val worker2 = Worker.createSideEffect {}
-
-    assertNotSame(worker1, worker2)
-    assertTrue(worker1.doesSameWorkAs(worker2))
-  }
-
-  @Suppress("DEPRECATION")
-  @Test
-  fun `createSideEffect runs`() {
-    var ran = false
-    val worker = Worker.createSideEffect {
-      ran = true
-    }
-
-    worker.test {
-      assertFinished()
-      assertTrue(ran)
-    }
-  }
-
-  @Suppress("DEPRECATION")
-  @Test
-  fun `createSideEffect finishes`() {
-    val worker = Worker.createSideEffect {}
-
-    worker.test {
-      assertFinished()
-    }
-  }
-
-  @Suppress("DEPRECATION")
-  @Test
-  fun `createSideEffect propagates exceptions`() {
-    val worker = Worker.createSideEffect { throw ExpectedException() }
 
     worker.test {
       assertTrue(getException() is ExpectedException)

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
@@ -542,17 +542,16 @@ internal class RealRenderTesterTest {
   }
 
   @Test fun `runningWorker doesn't throw when none expected`() {
-    val worker = object : Worker<Nothing> {
+    val worker = object : Worker<Unit> {
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = true
-      override fun run(): Flow<Nothing> = emptyFlow()
+      override fun run(): Flow<Unit> = emptyFlow()
       override fun toString(): String = "TestWorker"
     }
 
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
-      // Suppress runningWorker usage because we want to make sure the internal exception
-      // is not thrown when we don't expect an output
-      @Suppress("DEPRECATION")
-      runningWorker(worker)
+      runningWorker(worker) {
+        noAction()
+      }
     }
     val tester = workflow.testRender(Unit)
     tester.render()
@@ -585,19 +584,18 @@ internal class RealRenderTesterTest {
   }
 
   @Test fun `runningWorker does throw when none expected and require explicit workers is set`() {
-    class MySpecialWorker : Worker<Nothing> {
+    class MySpecialWorker : Worker<Unit> {
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = true
-      override fun run(): Flow<Nothing> = emptyFlow()
+      override fun run(): Flow<Unit> = emptyFlow()
       override fun toString(): String = "TestWorker"
     }
 
     val worker = MySpecialWorker()
 
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
-      // Suppress runningWorker usage because we are testing/validating the internal
-      // exception that is thrown
-      @Suppress("DEPRECATION")
-      runningWorker(worker)
+      runningWorker(worker) {
+        noAction()
+      }
     }
     val tester = workflow.testRender(Unit).requireExplicitWorkerExpectations()
     val error = assertFailsWith<AssertionError> {
@@ -632,17 +630,16 @@ internal class RealRenderTesterTest {
   }
 
   @Test fun `runningWorker with key does not throw when none expected`() {
-    val worker = object : Worker<Nothing> {
+    val worker = object : Worker<Unit> {
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = true
-      override fun run(): Flow<Nothing> = emptyFlow()
+      override fun run(): Flow<Unit> = emptyFlow()
       override fun toString(): String = "TestWorker"
     }
 
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
-      // Suppress runningWorker usage because we want to make sure the internal exception
-      // is not thrown when we don't expect an output, even with a unique key specified
-      @Suppress("DEPRECATION")
-      runningWorker(worker, key = "key")
+      runningWorker(worker, key = "key") {
+        noAction()
+      }
     }
     val tester = workflow.testRender(Unit)
 
@@ -650,17 +647,16 @@ internal class RealRenderTesterTest {
   }
 
   @Test fun `runningWorker with key throws when no key expected`() {
-    val worker = object : Worker<Nothing> {
+    val worker = object : Worker<Unit> {
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = true
-      override fun run(): Flow<Nothing> = emptyFlow()
+      override fun run(): Flow<Unit> = emptyFlow()
       override fun toString(): String = "TestWorker"
     }
 
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
-      // Suppress runningWorker usage because we are
-      // testing/validating the internal exception that is thrown
-      @Suppress("DEPRECATION")
-      runningWorker(worker, key = "key")
+      runningWorker(worker, key = "key") {
+        noAction()
+      }
     }
     val tester = workflow.testRender(Unit)
       .expectWorker(typeOf<Worker<Unit>>())
@@ -674,17 +670,16 @@ internal class RealRenderTesterTest {
   }
 
   @Test fun `runningWorker with key throws when wrong key expected`() {
-    val worker = object : Worker<Nothing> {
+    val worker = object : Worker<Unit> {
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = true
-      override fun run(): Flow<Nothing> = emptyFlow()
+      override fun run(): Flow<Unit> = emptyFlow()
       override fun toString(): String = "TestWorker"
     }
 
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
-      // Suppress runningWorker usage because we are
-      // expecting an exception to be thrown with mismatched keys
-      @Suppress("DEPRECATION")
-      runningWorker(worker, key = "key")
+      runningWorker(worker, key = "key") {
+        noAction()
+      }
     }
     val tester = workflow.testRender(Unit)
       .expectWorker(
@@ -701,16 +696,17 @@ internal class RealRenderTesterTest {
   }
 
   @Test fun `runningWorker throws when multiple expectations match`() {
-    class EmptyWorker : Worker<Nothing> {
+    class EmptyWorker : Worker<Unit> {
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = true
-      override fun run(): Flow<Nothing> = emptyFlow()
+      override fun run(): Flow<Unit> = emptyFlow()
       override fun toString(): String = "TestWorker"
     }
 
     val worker = EmptyWorker()
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
-      @Suppress("DEPRECATION")
-      runningWorker(worker)
+      runningWorker(worker) {
+        noAction()
+      }
     }
     val tester = workflow.testRender(Unit)
       .expectWorker(worker)
@@ -1337,6 +1333,7 @@ internal class RealRenderTesterTest {
   @Test
   fun `testRender with CoroutineScope uses the correct scope`() = runTest {
     val signalMutex = Mutex(locked = true)
+
     class TestAction : WorkflowAction<Unit, String, String>() {
       override fun Updater.apply() {
         state = "new state"


### PR DESCRIPTION
Some have been long deprecated, others more recently deprecated (the anonymous actions and eventHandlers - but we have not received any concerns regarding removing them - https://github.com/square/workflow-kotlin/discussions/1236, https://workflow-community.slack.com/archives/CHTFPR277/p1732635078961279?thread_ts=1730740915.096009&cid=CHTFPR277)

Also, prefix `eventHandler` `debuggingName`s with `eH:`