### PR TITLE
Update CI Actions Versions; tests results upload version and name for artifact

### DIFF
--- a/.github/actions/gradle-task/action.yml
+++ b/.github/actions/gradle-task/action.yml
@@ -1,53 +1,53 @@
-name : 'Set up Gradle and some task(s) with caching'
-description : 'This action performs common steps for a Gradle task.'
+name: 'Set up Gradle and some task(s) with caching'
+description: 'This action performs common steps for a Gradle task.'
 
-inputs :
-  task :
-    description : 'Gradle command line arguments (supports multi-line input)'
-    required : true
-  build-root-directory :
-    description : 'Path to the root directory of the build'
-    required : false
-  java-version :
-    description : 'The Java version to set up.'
-    default : '17'
-  distribution :
-    description : 'The JDK distribution to use.'
-    default : 'zulu'
-  restore-cache-key :
-    description : 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
-    default : 'null'
-  write-cache-key :
-    description : 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
-    default : 'null'
+inputs:
+  task:
+    description: 'Gradle command line arguments (supports multi-line input)'
+    required: true
+  build-root-directory:
+    description: 'Path to the root directory of the build'
+    required: false
+  java-version:
+    description: 'The Java version to set up.'
+    default: '17'
+  distribution:
+    description: 'The JDK distribution to use.'
+    default: 'zulu'
+  restore-cache-key:
+    description: 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
+    default: 'null'
+  write-cache-key:
+    description: 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
+    default: 'null'
 
-runs :
-  using : 'composite'
-  steps :
+runs:
+  using: 'composite'
+  steps:
 
-    - name : Set up JDK
-      uses : actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
-      with :
-        distribution : ${{inputs.distribution}}
-        java-version : ${{inputs.java-version}}
+    - name: Set up JDK
+      uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
+      with:
+        distribution: ${{inputs.distribution}}
+        java-version: ${{inputs.java-version}}
 
-    - name : Set Gradle Args for runner OS
-      id : gradle-args
-      uses : ./.github/actions/gradle-args
+    - name: Set Gradle Args for runner OS
+      id: gradle-args
+      uses: ./.github/actions/gradle-args
 
-    - name : Gradle build action
-      uses : gradle/gradle-build-action@29c0906b64b8fc82467890bfb7a0a7ef34bda89e # v3
-      with :
-        cache-read-only : false
-        gradle-home-cache-cleanup : true
+    - name: Gradle build action
+      uses: gradle/gradle-build-action@29c0906b64b8fc82467890bfb7a0a7ef34bda89e # v3
+      with:
+        cache-read-only: false
+        gradle-home-cache-cleanup: true
 
     # Calculate all the hashes for keys just one time.
     # These should only be referenced before the actual task action, since that action
     # may generate changes and we want the final cache key to reflect its current state.
-    - name : Calculate hashes
-      id : hashes
+    - name: Calculate hashes
+      id: hashes
       shell: bash
-      run : |
+      run: |
         echo "lib_versions=${{ hashFiles('**/libs.versions.toml') }}" >> $GITHUB_OUTPUT
         echo "gradle_props=${{ hashFiles('**/gradle.properties') }}" >> $GITHUB_OUTPUT
         echo "gradle_kts=${{ hashFiles('**/*.gradle.kts') }}" >> $GITHUB_OUTPUT
@@ -56,18 +56,18 @@ runs :
     # Attempt to restore from the write-cache-key, or fall back to a partial match for the write key.
     # Skipped if the write-cache-key wasn't set.
     # This step's "cache_hit" output will only be true if an exact match was found.
-    - name : restore cache for ${{inputs.write-cache-key}}
-      id : restore-write-cache
-      if : inputs.write-cache-key != 'null'
-      uses : actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
-      with :
-        path : |
+    - name: restore cache for ${{inputs.write-cache-key}}
+      id: restore-write-cache
+      if: inputs.write-cache-key != 'null'
+      uses: actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
+      with:
+        path: |
           ~/.gradle/caches/build-cache-1
           ~/.konan
           ./**/build/**/!(*.dex)
           ./**/.gradle
-        key : ${{runner.os}}-${{inputs.write-cache-key}}-${{steps.hashes.outputs.lib_versions}}-${{steps.hashes.outputs.gradle_props}}-${{steps.hashes.outputs.gradle_kts}}-${{steps.hashes.outputs.src_kt}}
-        restore-keys : |
+        key: ${{runner.os}}-${{inputs.write-cache-key}}-${{steps.hashes.outputs.lib_versions}}-${{steps.hashes.outputs.gradle_props}}-${{steps.hashes.outputs.gradle_kts}}-${{steps.hashes.outputs.src_kt}}
+        restore-keys: |
           ${{runner.os}}-${{inputs.write-cache-key}}-${{steps.hashes.outputs.lib_versions}}-${{steps.hashes.outputs.gradle_props}}-${{steps.hashes.outputs.gradle_kts}}
           ${{runner.os}}-${{inputs.write-cache-key}}-${{steps.hashes.outputs.lib_versions}}-${{steps.hashes.outputs.gradle_props}}
           ${{runner.os}}-${{inputs.write-cache-key}}-${{steps.hashes.outputs.lib_versions}}
@@ -75,55 +75,55 @@ runs :
 
     # Attempt to restore from the restore-cache-key, or fall back to a partial match for the restore key.
     # Skipped if the restore-cache-key wasn't set, or if the write-cache-key restore had an exact match.
-    - name : restore cache for ${{inputs.restore-cache-key}}
-      if : inputs.restore-cache-key != 'null' && steps.restore-write-cache.outputs.cache-hit != 'true'
-      uses : actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
-      with :
-        path : |
+    - name: restore cache for ${{inputs.restore-cache-key}}
+      if: inputs.restore-cache-key != 'null' && steps.restore-write-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
+      with:
+        path: |
           ~/.gradle/caches/build-cache-1
           ~/.konan
           ./**/build/**/!(*.dex)
           ./**/.gradle
-        key : ${{runner.os}}-${{inputs.restore-cache-key}}-${{steps.hashes.outputs.lib_versions}}-${{steps.hashes.outputs.gradle_props}}-${{steps.hashes.outputs.gradle_kts}}-${{steps.hashes.outputs.src_kt}}
-        restore-keys : |
+        key: ${{runner.os}}-${{inputs.restore-cache-key}}-${{steps.hashes.outputs.lib_versions}}-${{steps.hashes.outputs.gradle_props}}-${{steps.hashes.outputs.gradle_kts}}-${{steps.hashes.outputs.src_kt}}
+        restore-keys: |
           ${{runner.os}}-${{inputs.restore-cache-key}}-${{steps.hashes.outputs.lib_versions}}-${{steps.hashes.outputs.gradle_props}}-${{steps.hashes.outputs.gradle_kts}}
           ${{runner.os}}-${{inputs.restore-cache-key}}-${{steps.hashes.outputs.lib_versions}}-${{steps.hashes.outputs.gradle_props}}
           ${{runner.os}}-${{inputs.restore-cache-key}}-${{steps.hashes.outputs.lib_versions}}
           ${{runner.os}}-${{inputs.restore-cache-key}}
 
-    - uses : gradle/wrapper-validation-action@699bb18358f12c5b78b37bb0111d3a0e2276e0e2 # v2
+    - uses: gradle/wrapper-validation-action@699bb18358f12c5b78b37bb0111d3a0e2276e0e2 # v2
 
     # Run the actual task.  Note that this still uses gradle-build-action for more fine-grained caching.
-    - name : Run ${{inputs.task}}
-      uses : gradle/gradle-build-action@29c0906b64b8fc82467890bfb7a0a7ef34bda89e # v3
-      with :
+    - name: Run ${{inputs.task}}
+      uses: gradle/gradle-build-action@29c0906b64b8fc82467890bfb7a0a7ef34bda89e # v3
+      with:
         # These arguments need to be on a single line. If they're defined with wrapping (using `|`),
         # something along the way to the actual CLI invocation gets confused and the jvmargs list
         # winds up getting parsed as a single argument.
-        arguments : ${{steps.gradle-args.outputs.gradle-property-args}} ${{inputs.task}} '-Dorg.gradle.jvmargs=${{steps.gradle-args.outputs.gradle-jvm-args}}'
-        cache-read-only : false
-        build-root-directory : ${{inputs.build-root-directory}}
-        gradle-home-cache-cleanup : true
+        arguments: ${{steps.gradle-args.outputs.gradle-property-args}} ${{inputs.task}} '-Dorg.gradle.jvmargs=${{steps.gradle-args.outputs.gradle-jvm-args}}'
+        cache-read-only: false
+        build-root-directory: ${{inputs.build-root-directory}}
+        gradle-home-cache-cleanup: true
 
     # Save the build cache to `write-cache-key`.
     # Skip if we already had an exact match, or if the key is not set, or if this is a Windows runner.
     # Windows runners are welcome to *read* the cross-OS cache, but the directories get weird if
     # they try to write to it.
-    - name : save the '${{inputs.write-cache-key}}' cache
-      uses : actions/cache/save@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
-      id : save-write-cache-key
-      if : inputs.write-cache-key != 'null' && steps.restore-write-cache.outputs.cache-hit != 'true'
-      with :
-        path : |
+    - name: save the '${{inputs.write-cache-key}}' cache
+      uses: actions/cache/save@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
+      id: save-write-cache-key
+      if: inputs.write-cache-key != 'null' && steps.restore-write-cache.outputs.cache-hit != 'true'
+      with:
+        path: |
           ~/.gradle/caches/build-cache-1
           ~/.konan
           ./**/build/**/!(*.dex)
           ./**/.gradle
-        key : ${{runner.os}}-${{inputs.write-cache-key}}-${{hashFiles('**/libs.versions.toml')}}-${{hashFiles('**/gradle.properties')}}-${{hashFiles('**/*.gradle.kts')}}-${{hashFiles('**/src/**/*.kt')}}
+        key: ${{runner.os}}-${{inputs.write-cache-key}}-${{hashFiles('**/libs.versions.toml')}}-${{hashFiles('**/gradle.properties')}}-${{hashFiles('**/*.gradle.kts')}}-${{hashFiles('**/src/**/*.kt')}}
 
-    - name : Upload heap dump
-      if : failure()
-      uses : actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
-      with :
-        name : heap-dump
-        path : ${{github.workspace}}/**/*{.hprof,.log}
+    - name: Upload heap dump
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: heap-dump
+        path: ${{github.workspace}}/**/*{.hprof,.log}

--- a/.github/actions/gradle-tasks-with-emulator/action.yml
+++ b/.github/actions/gradle-tasks-with-emulator/action.yml
@@ -1,108 +1,111 @@
-name : Run Android Instrumentation Tests with Artifact and AVD Caching
-description : This action sets up Gradle, runs a preparatory task, runs Android tests on an emulator, and uploads test results.
+name: Run Android Instrumentation Tests with Artifact and AVD Caching
+description: This action sets up Gradle, runs a preparatory task, runs Android tests on an emulator, and uploads test results.
 
-inputs :
-  prepare-task :
-    description : 'Gradle task for preparing necessary artifacts. Supports multi-line input.'
-    required : true
-  test-task :
-    description : 'Gradle task for running instrumentation tests. Supports multi-line input.'
-    required : true
-  api-level :
-    description : 'The Android SDK api level, like `29`'
-    required : true
-  build-root-directory :
-    description : 'Path to the root directory of the build'
-    required : false
-  java-version :
-    description : 'The Java version to set up.'
-    default : '17'
-  distribution :
-    description : 'The JDK distribution to use.'
-    default : 'zulu'
-  restore-cache-key :
-    description : 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
-    default : 'null'
-  write-cache-key :
-    description : 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
-    default : 'null'
+inputs:
+  prepare-task:
+    description: 'Gradle task for preparing necessary artifacts. Supports multi-line input.'
+    required: true
+  test-task:
+    description: 'Gradle task for running instrumentation tests. Supports multi-line input.'
+    required: true
+  api-level:
+    description: 'The Android SDK api level, like `29`'
+    required: true
+  build-root-directory:
+    description: 'Path to the root directory of the build'
+    required: false
+  tests-name:
+    description: 'Name of the tests run, used to name artifact for upload.'
+    required: false
+  java-version:
+    description: 'The Java version to set up.'
+    default: '17'
+  distribution:
+    description: 'The JDK distribution to use.'
+    default: 'zulu'
+  restore-cache-key:
+    description: 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
+    default: 'null'
+  write-cache-key:
+    description: 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
+    default: 'null'
 
-runs :
-  using : 'composite'
-  steps :
+runs:
+  using: 'composite'
+  steps:
 
     # Setup the runner in the KVM group to enable HW Accleration for the emulator.
     # see https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
     - name: Enable KVM group perms
       shell: bash
       run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
 
     # Create or fetch the artifacts used for these tests.
-    - name : Run ${{ inputs.prepare-task }}
-      uses : ./.github/actions/gradle-task
-      with :
-        build-root-directory : ${{ inputs.build-root-directory }}
-        distribution : ${{ inputs.distribution }}
-        java-version : ${{ inputs.java-version }}
-        restore-cache-key : ${{ inputs.restore-cache-key }}
-        task : ${{ inputs.prepare-task }}
-        write-cache-key : ${{ inputs.write-cache-key }}
+    - name: Run ${{ inputs.prepare-task }}
+      uses: ./.github/actions/gradle-task
+      with:
+        build-root-directory: ${{ inputs.build-root-directory }}
+        distribution: ${{ inputs.distribution }}
+        java-version: ${{ inputs.java-version }}
+        restore-cache-key: ${{ inputs.restore-cache-key }}
+        task: ${{ inputs.prepare-task }}
+        write-cache-key: ${{ inputs.write-cache-key }}
 
     # Get the AVD if it's already cached.
-    - name : AVD cache
-      uses : actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
-      id : restore-avd-cache
-      with :
-        path : |
+    - name: AVD cache
+      uses: actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
+      id: restore-avd-cache
+      with:
+        path: |
           ~/.android/avd/*
           ~/.android/adb*
-        key : avd-${{ matrix.api-level }}
+        key: avd-${{ matrix.api-level }}
 
     # If the AVD cache didn't exist, create an AVD
-    - name : create AVD and generate snapshot for caching
-      if : steps.restore-avd-cache.outputs.cache-hit != 'true'
-      uses : reactivecircus/android-emulator-runner@6b0df4b0efb23bb0ec63d881db79aefbc976e4b2 # v2
-      with :
-        api-level : ${{ inputs.api-level }}
-        arch : x86_64
-        disable-animations : false
-        emulator-boot-timeout : 12000
-        emulator-options : -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        force-avd-creation : false
-        profile : Galaxy Nexus
-        ram-size : 4096M
-        script : echo "Generated AVD snapshot."
+    - name: create AVD and generate snapshot for caching
+      if: steps.restore-avd-cache.outputs.cache-hit != 'true'
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ inputs.api-level }}
+        arch: x86_64
+        disable-animations: false
+        emulator-boot-timeout: 12000
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        force-avd-creation: false
+        profile: Galaxy Nexus
+        ram-size: 4096M
+        script: echo "Generated AVD snapshot."
 
     # If we just created an AVD because there wasn't one in the cache, then cache that AVD.
-    - name : cache new AVD before tests
-      if : steps.restore-avd-cache.outputs.cache-hit != 'true'
-      id : save-avd-cache
-      uses : actions/cache/save@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
-      with :
-        path : |
+    - name: cache new AVD before tests
+      if: steps.restore-avd-cache.outputs.cache-hit != 'true'
+      id: save-avd-cache
+      uses: actions/cache/save@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
+      with:
+        path: |
           ~/.android/avd/*
           ~/.android/adb*
-        key : avd-${{ matrix.api-level }}
+        key: avd-${{ matrix.api-level }}
 
     # Run the actual emulator tests.
     # At this point every task should be up-to-date and the AVD should be ready to go.
-    - name : run tests
-      uses : reactivecircus/android-emulator-runner@6b0df4b0efb23bb0ec63d881db79aefbc976e4b2 # v2
-      with :
-        api-level : ${{ inputs.api-level }}
-        arch : x86_64
-        disable-animations : true
-        emulator-options : -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        force-avd-creation : false
-        profile : Galaxy Nexus
-        script : ./gradlew ${{ inputs.test-task }}
+    - name: run tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ inputs.api-level }}
+        arch: x86_64
+        disable-animations: true
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        force-avd-creation: false
+        profile: Galaxy Nexus
+        script: ./gradlew ${{ inputs.test-task }}
 
-   - name : Upload results
-     if : ${{ always() }}
-     uses : actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
-     with :
-       name : instrumentation-test-results
-       path : ./**/**/build/reports/androidTests/connected/**
+    - name: Upload results
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.tests-name }}
+        path: ${{github.workspace}}/**/build/reports/androidTests/connected/**

--- a/.github/actions/gradle-tasks-with-emulator/action.yml
+++ b/.github/actions/gradle-tasks-with-emulator/action.yml
@@ -100,9 +100,9 @@ runs :
         profile : Galaxy Nexus
         script : ./gradlew ${{ inputs.test-task }}
 
-    - name : Upload results
-      if : ${{ always() }}
-      uses : actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
-      with :
-        name : instrumentation-test-results
-        path : ./**/build/reports/androidTests/connected/**
+   - name : Upload results
+     if : ${{ always() }}
+     uses : actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+     with :
+       name : instrumentation-test-results
+       path : ./**/**/build/reports/androidTests/connected/**

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -303,6 +303,7 @@ jobs :
       - name : Instrumented tests
         uses : ./.github/actions/gradle-tasks-with-emulator
         with :
+          tests-name : perf-tests-results
           api-level : ${{ matrix.api-level }}
           prepare-task : :benchmarks:performance-poetry:complex-poetry:prepareDebugAndroidTestArtifacts
           test-task : :benchmarks:performance-poetry:complex-poetry:connectedCheck --continue
@@ -328,6 +329,7 @@ jobs :
       - name : Instrumented tests
         uses : ./.github/actions/gradle-tasks-with-emulator
         with :
+          tests-name : core-tests-results-${{matrix.shardNum}}
           api-level : ${{ matrix.api-level }}
           prepare-task : prepareConnectedCheckShard${{matrix.shardNum}}
           test-task : connectedCheckShard${{matrix.shardNum}} -x :benchmarks:dungeon-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-poetry:connectedCheck
@@ -355,6 +357,7 @@ jobs :
       - name : Instrumented tests
         uses : ./.github/actions/gradle-tasks-with-emulator
         with :
+          tests-name : alt-runtime-tests-results-${{matrix.runtime}}-${{matrix.shardNum}}
           api-level : ${{ matrix.api-level }}
           prepare-task : prepareConnectedCheckShard${{matrix.shardNum}} -Pworkflow.runtime=${{matrix.runtime}}
           test-task : connectedCheckShard${{matrix.shardNum}} -Pworkflow.runtime=${{matrix.runtime}} -x :benchmarks:dungeon-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-poetry:connectedCheck


### PR DESCRIPTION
The emulator termination just started failing so trying to update the github actions versions.
![image](https://github.com/user-attachments/assets/e8f12781-2bd6-4c4f-a3fa-b1e901317a14)


Also, results upload wasn't working, so change the path to use `{{ github.workspace }}`. Also when updating the version of this I need to give each a unique name. (I thought this was the problem at first, not a warning - so I looked into what was wrong)
![image](https://github.com/user-attachments/assets/bcb483b7-fcac-4b3d-8362-5baacab3d732)

Please `Hide whitespace` when reviewing as I formatted some .yaml files.
