### PR TITLE
Reverts make `TextController` support equals

### DIFF
--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/TextController.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/TextController.kt
@@ -87,17 +87,4 @@ private class TextControllerImpl(initialValue: String) : TextController {
     set(value) {
       _textValue.value = value
     }
-
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-
-    other as TextController
-
-    return textValue == other.textValue
-  }
-
-  override fun hashCode(): Int {
-    return textValue.hashCode()
-  }
 }

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/TextControllerTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/TextControllerTest.kt
@@ -4,8 +4,6 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 
 @OptIn(WorkflowUiExperimentalApi::class)
 internal class TextControllerTest {
@@ -35,17 +33,5 @@ internal class TextControllerTest {
       controller.textValue = "apple"
       expectNoEvents()
     }
-  }
-
-  @Test fun `equals works with the same value`() {
-    val controller1 = TextController(initialValue = "apple")
-    val controller2 = TextController(initialValue = "apple")
-    assertEquals(controller1, controller2)
-  }
-
-  @Test fun `equals works with different values`() {
-    val controller1 = TextController(initialValue = "apple")
-    val controller2 = TextController(initialValue = "orange")
-    assertNotEquals(controller1, controller2)
   }
 }


### PR DESCRIPTION
This PR reverts https://github.com/square/workflow-kotlin/pull/1224