### PR TITLE
Make Flow.collectToSink public.

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -329,6 +329,7 @@ public final class com/squareup/workflow1/Workflows {
 	public static final fun action (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun applyTo (Lcom/squareup/workflow1/WorkflowAction;Ljava/lang/Object;Ljava/lang/Object;)Lkotlin/Pair;
+	public static final fun collectToSink (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/Sink;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun contraMap (Lcom/squareup/workflow1/Sink;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/Sink;
 	public static final fun getComputedIdentifier (Lcom/squareup/workflow1/Workflow;)Lcom/squareup/workflow1/WorkflowIdentifier;
 	public static final fun getIdentifier (Lcom/squareup/workflow1/Workflow;)Lcom/squareup/workflow1/WorkflowIdentifier;

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/Sink.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/Sink.kt
@@ -44,8 +44,6 @@ public fun <T1, T2> Sink<T1>.contraMap(transform: (T2) -> T1): Sink<T2> = Sink {
  * is a lot of contention on the workflow runtime the flow will be suspended while the action is
  * queued.
  *
- * This method is intended to be used from [BaseRenderContext.runningSideEffect].
- *
  * Example:
  * ```
  * context.runningSideEffect("collector") {
@@ -55,7 +53,7 @@ public fun <T1, T2> Sink<T1>.contraMap(transform: (T2) -> T1): Sink<T2> = Sink {
  * }
  * ```
  */
-internal suspend fun <T, PropsT, StateT, OutputT> Flow<T>.collectToSink(
+public suspend fun <T, PropsT, StateT, OutputT> Flow<T>.collectToSink(
   actionSink: Sink<WorkflowAction<PropsT, StateT, OutputT>>,
   handler: (T) -> WorkflowAction<PropsT, StateT, OutputT>
 ) {


### PR DESCRIPTION
This allows us to use `runningSideEffect` for many of the things that we previously used workers for. Just running a side effect with a few coroutines should be way cheaper than running a `Worker` for each.