### PR TITLE
Fix Conflate Stale Rendering Logic for Short Circuit

### DIFF
--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderWorkflowInTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderWorkflowInTest.kt
@@ -1251,6 +1251,7 @@ class RenderWorkflowInTest {
         }
         advanceUntilIdle()
 
+        // 2 renderings (initial and then the update.) Not *3* renderings.
         assertEquals(2, renderCount)
         assertEquals(1, childHandlerActionExecuted)
         assertEquals(1, workerActionExecuted)


### PR DESCRIPTION
When we kept rendering for `CONFLATE_STALE_RENDERINGS` we were not also checking if we should short circuit. We need to do both.

If any of the actions applied produces output from the _root_ runtime though, then we will stop applying actions, update the rendering, and then send the output.