### PR TITLE
*BREAKING* Introduces `BaseRenderContext.remember` and stable `eventHandlers`.

### DIFF
--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/instrumentation/ActionHandlingTracingInterceptor.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/instrumentation/ActionHandlingTracingInterceptor.kt
@@ -12,12 +12,12 @@ import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
  * particular events.
  *
  * If you want to trace how long Workflow takes to process a UI event, then
- * annotate the [RenderContext.eventHandler] name argument with [keyForTrace]. That will cause
+ * annotate the `RenderContext.eventHandler` name argument with [keyForTrace]. That will cause
  * this interceptor to pick it up when the action is sent into the sink and trace that main thread
  * message.
  *
- * If you want to trace how long Workflow takes to process the result of a [Worker], then
- * annotate the [Worker] using [TraceableWorker] which will set it up with a key such that when
+ * If you want to trace how long Workflow takes to process the result of a `Worker`, then
+ * annotate the `Worker` using [TraceableWorker] which will set it up with a key such that when
  * the action for the result is sent to the sink the main thread message will be traced.
  */
 class ActionHandlingTracingInterceptor : WorkflowInterceptor, Resettable {

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
@@ -3,7 +3,6 @@
 package com.squareup.sample.compose.inlinerendering
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -38,12 +37,15 @@ object InlineRenderingWorkflow : StatefulWorkflow<Unit, Int, Nothing, Screen>() 
     renderProps: Unit,
     renderState: Int,
     context: RenderContext
-  ) = ComposeScreen {
-    Box {
-      Button(onClick = context.eventHandler("increment") { state += 1 }) {
-        Text("Counter: ")
-        AnimatedCounter(renderState) { counterValue ->
-          Text(counterValue.toString())
+  ): ComposeScreen {
+    val onClick = context.eventHandler("increment") { state += 1 }
+    return ComposeScreen {
+      Box {
+        Button(onClick = onClick) {
+          Text("Counter: ")
+          AnimatedCounter(renderState) { counterValue ->
+            Text(counterValue.toString())
+          }
         }
       }
     }
@@ -68,7 +70,6 @@ internal fun InlineRenderingWorkflowPreview() {
   InlineRenderingWorkflowRendering()
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 private fun AnimatedCounter(
   counterValue: Int,
@@ -79,6 +80,7 @@ private fun AnimatedCounter(
     transitionSpec = {
       ((slideInVertically() + fadeIn()).togetherWith(slideOutVertically() + fadeOut()))
         .using(SizeTransform(clip = false))
-    }
+    },
+    label = ""
   ) { content(it) }
 }

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
@@ -15,7 +15,7 @@ object StanzaListWorkflow : StatelessWorkflow<Props, SelectedStanza, StanzaListS
 
   data class Props(
     val poem: Poem,
-    val eventHandlerTag: (String) -> String = { "" }
+    val eventHandlerTag: (String) -> String = { it }
   )
 
   const val NO_SELECTED_STANZA = -1

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
@@ -12,7 +12,7 @@ object StanzaWorkflow : StatelessWorkflow<Props, Output, StanzaScreen>() {
   data class Props(
     val poem: Poem,
     val index: Int,
-    val eventHandlerTag: (String) -> String = { "" }
+    val eventHandlerTag: (String) -> String = { it }
   )
 
   enum class Output {

--- a/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
+++ b/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
@@ -25,7 +25,10 @@ class TimeMachineWorkflowTest {
     val delegateWorkflow = Workflow.stateful<String, Nothing, DelegateRendering>(
       initialState = "initial",
       render = { renderState ->
-        DelegateRendering(renderState, setState = eventHandler("") { s -> state = s })
+        DelegateRendering(
+          renderState,
+          setState = eventHandler("setState") { s -> state = s }
+        )
       }
     )
     val clock = TestTimeSource()

--- a/samples/nested-overlays/src/main/java/com/squareup/sample/nestedoverlays/NestedOverlaysWorkflow.kt
+++ b/samples/nested-overlays/src/main/java/com/squareup/sample/nestedoverlays/NestedOverlaysWorkflow.kt
@@ -62,7 +62,7 @@ object NestedOverlaysWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>()
               name = R.string.close,
               onClick = closeOuter
             ),
-            context.toggleInnerSheetButton(renderState),
+            context.toggleInnerSheetButton(name = "inner", renderState),
             color = android.R.color.holo_green_light,
             showEditText = true,
           ),
@@ -103,13 +103,27 @@ object NestedOverlaysWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>()
       name = "outer",
       overlays = listOfNotNull(outerSheet),
       body = TopAndBottomBarsScreen(
-        topBar = if (!renderState.showTopBar) null else context.topBottomBar(renderState),
+        topBar = if (!renderState.showTopBar) {
+          null
+        } else {
+          context.topBottomBar(
+            top = true,
+            renderState
+          )
+        },
         content = BodyAndOverlaysScreen(
           name = "inner",
           body = bodyBarButtons,
           overlays = listOfNotNull(innerSheet)
         ),
-        bottomBar = if (!renderState.showBottomBar) null else context.topBottomBar(renderState)
+        bottomBar = if (!renderState.showBottomBar) {
+          null
+        } else {
+          context.topBottomBar(
+            top = false,
+            renderState
+          )
+        }
       )
     )
   }
@@ -117,19 +131,31 @@ object NestedOverlaysWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>()
   override fun snapshotState(state: State) = null
 
   private fun RenderContext.topBottomBar(
+    top: Boolean,
     renderState: State
-  ) = ButtonBar(
-    toggleInnerSheetButton(renderState),
-    Button(
-      name = R.string.cover_all,
-      onClick = eventHandler("cover everything") { state = state.copy(showOuterSheet = true) }
+  ): ButtonBar {
+    val name = if (top) "top" else "bottom"
+    return ButtonBar(
+      toggleInnerSheetButton(
+        name = name,
+        renderState = renderState,
+      ),
+      Button(
+        name = R.string.cover_all,
+        onClick = eventHandler("$name cover everything") {
+          state = state.copy(showOuterSheet = true)
+        }
+      )
     )
-  )
+  }
 
-  private fun RenderContext.toggleInnerSheetButton(renderState: State) =
+  private fun RenderContext.toggleInnerSheetButton(
+    name: String,
+    renderState: State
+  ) =
     Button(
       name = if (renderState.showInnerSheet) R.string.reveal_body else R.string.cover_body,
-      onClick = eventHandler("reveal / cover body") {
+      onClick = eventHandler("$name: reveal / cover body") {
         state = state.copy(showInnerSheet = !state.showInnerSheet)
       }
     )

--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -23,36 +23,96 @@ public final class com/squareup/workflow1/ActionsExhausted : com/squareup/workfl
 }
 
 public abstract interface class com/squareup/workflow1/BaseRenderContext {
-	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
-	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
-	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
-	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
-	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
-	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
-	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
-	public abstract fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public abstract fun getActionSink ()Lcom/squareup/workflow1/Sink;
+	public abstract fun getRuntimeConfig ()Ljava/util/Set;
 	public abstract fun getWorkflowTracer ()Lcom/squareup/workflow1/WorkflowTracer;
+	public abstract fun remember (Ljava/lang/String;Lkotlin/reflect/KType;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public abstract fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class com/squareup/workflow1/BaseRenderContext$DefaultImpls {
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
-	public static fun eventHandler (Lcom/squareup/workflow1/BaseRenderContext;Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
 	public static synthetic fun renderChild$default (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow1/HandlerBox1 {
+	public field handler Lkotlin/jvm/functions/Function1;
+	public fun <init> ()V
+	public final fun getHandler ()Lkotlin/jvm/functions/Function1;
+	public final fun getStableHandler ()Lkotlin/jvm/functions/Function1;
+	public final fun setHandler (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class com/squareup/workflow1/HandlerBox10 {
+	public field handler Lkotlin/jvm/functions/Function10;
+	public fun <init> ()V
+	public final fun getHandler ()Lkotlin/jvm/functions/Function10;
+	public final fun getStableHandler ()Lkotlin/jvm/functions/Function10;
+	public final fun setHandler (Lkotlin/jvm/functions/Function10;)V
+}
+
+public final class com/squareup/workflow1/HandlerBox2 {
+	public field handler Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getHandler ()Lkotlin/jvm/functions/Function2;
+	public final fun getStableHandler ()Lkotlin/jvm/functions/Function2;
+	public final fun setHandler (Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class com/squareup/workflow1/HandlerBox3 {
+	public field handler Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getHandler ()Lkotlin/jvm/functions/Function3;
+	public final fun getStableHandler ()Lkotlin/jvm/functions/Function3;
+	public final fun setHandler (Lkotlin/jvm/functions/Function3;)V
+}
+
+public final class com/squareup/workflow1/HandlerBox4 {
+	public field handler Lkotlin/jvm/functions/Function4;
+	public fun <init> ()V
+	public final fun getHandler ()Lkotlin/jvm/functions/Function4;
+	public final fun getStableHandler ()Lkotlin/jvm/functions/Function4;
+	public final fun setHandler (Lkotlin/jvm/functions/Function4;)V
+}
+
+public final class com/squareup/workflow1/HandlerBox5 {
+	public field handler Lkotlin/jvm/functions/Function5;
+	public fun <init> ()V
+	public final fun getHandler ()Lkotlin/jvm/functions/Function5;
+	public final fun getStableHandler ()Lkotlin/jvm/functions/Function5;
+	public final fun setHandler (Lkotlin/jvm/functions/Function5;)V
+}
+
+public final class com/squareup/workflow1/HandlerBox6 {
+	public field handler Lkotlin/jvm/functions/Function6;
+	public fun <init> ()V
+	public final fun getHandler ()Lkotlin/jvm/functions/Function6;
+	public final fun getStableHandler ()Lkotlin/jvm/functions/Function6;
+	public final fun setHandler (Lkotlin/jvm/functions/Function6;)V
+}
+
+public final class com/squareup/workflow1/HandlerBox7 {
+	public field handler Lkotlin/jvm/functions/Function7;
+	public fun <init> ()V
+	public final fun getHandler ()Lkotlin/jvm/functions/Function7;
+	public final fun getStableHandler ()Lkotlin/jvm/functions/Function7;
+	public final fun setHandler (Lkotlin/jvm/functions/Function7;)V
+}
+
+public final class com/squareup/workflow1/HandlerBox8 {
+	public field handler Lkotlin/jvm/functions/Function8;
+	public fun <init> ()V
+	public final fun getHandler ()Lkotlin/jvm/functions/Function8;
+	public final fun getStableHandler ()Lkotlin/jvm/functions/Function8;
+	public final fun setHandler (Lkotlin/jvm/functions/Function8;)V
+}
+
+public final class com/squareup/workflow1/HandlerBox9 {
+	public field handler Lkotlin/jvm/functions/Function9;
+	public fun <init> ()V
+	public final fun getHandler ()Lkotlin/jvm/functions/Function9;
+	public final fun getStableHandler ()Lkotlin/jvm/functions/Function9;
+	public final fun setHandler (Lkotlin/jvm/functions/Function9;)V
 }
 
 public abstract interface class com/squareup/workflow1/IdCacheable {
@@ -99,6 +159,22 @@ public final class com/squareup/workflow1/NullableInitBox$Uninitialized {
 
 public final class com/squareup/workflow1/PropsUpdated : com/squareup/workflow1/ActionProcessingResult {
 	public static final field INSTANCE Lcom/squareup/workflow1/PropsUpdated;
+}
+
+public final class com/squareup/workflow1/RuntimeConfigOptions : java/lang/Enum {
+	public static final field CONFLATE_STALE_RENDERINGS Lcom/squareup/workflow1/RuntimeConfigOptions;
+	public static final field Companion Lcom/squareup/workflow1/RuntimeConfigOptions$Companion;
+	public static final field PARTIAL_TREE_RENDERING Lcom/squareup/workflow1/RuntimeConfigOptions;
+	public static final field RENDER_ONLY_WHEN_STATE_CHANGES Lcom/squareup/workflow1/RuntimeConfigOptions;
+	public static final field STABLE_EVENT_HANDLERS Lcom/squareup/workflow1/RuntimeConfigOptions;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/squareup/workflow1/RuntimeConfigOptions;
+	public static fun values ()[Lcom/squareup/workflow1/RuntimeConfigOptions;
+}
+
+public final class com/squareup/workflow1/RuntimeConfigOptions$Companion {
+	public final fun getDEFAULT_CONFIG ()Ljava/util/Set;
+	public final fun getRENDER_PER_ACTION ()Ljava/util/Set;
 }
 
 public abstract class com/squareup/workflow1/SessionWorkflow : com/squareup/workflow1/StatefulWorkflow {
@@ -176,19 +252,13 @@ public abstract class com/squareup/workflow1/StatefulWorkflow : com/squareup/wor
 }
 
 public final class com/squareup/workflow1/StatefulWorkflow$RenderContext : com/squareup/workflow1/BaseRenderContext {
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
+	public final fun eventHandler (Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/StatefulWorkflow$RenderContext;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/jvm/functions/Function0;
 	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
+	public fun getRuntimeConfig ()Ljava/util/Set;
+	public final fun getStableEventHandlers ()Z
 	public fun getWorkflowTracer ()Lcom/squareup/workflow1/WorkflowTracer;
+	public fun remember (Ljava/lang/String;Lkotlin/reflect/KType;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
@@ -202,19 +272,13 @@ public abstract class com/squareup/workflow1/StatelessWorkflow : com/squareup/wo
 }
 
 public final class com/squareup/workflow1/StatelessWorkflow$RenderContext : com/squareup/workflow1/BaseRenderContext {
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function10;)Lkotlin/jvm/functions/Function9;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function11;)Lkotlin/jvm/functions/Function10;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function1;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function3;)Lkotlin/jvm/functions/Function2;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function4;)Lkotlin/jvm/functions/Function3;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function5;)Lkotlin/jvm/functions/Function4;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function6;)Lkotlin/jvm/functions/Function5;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function7;)Lkotlin/jvm/functions/Function6;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function8;)Lkotlin/jvm/functions/Function7;
-	public fun eventHandler (Ljava/lang/String;Lkotlin/jvm/functions/Function9;)Lkotlin/jvm/functions/Function8;
+	public final fun eventHandler (Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/StatelessWorkflow$RenderContext;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/jvm/functions/Function0;
 	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
+	public fun getRuntimeConfig ()Ljava/util/Set;
+	public final fun getStableEventHandlers ()Z
 	public fun getWorkflowTracer ()Lcom/squareup/workflow1/WorkflowTracer;
+	public fun remember (Ljava/lang/String;Lkotlin/reflect/KType;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun renderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun runningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
@@ -271,6 +335,9 @@ public final class com/squareup/workflow1/WorkflowAction$Updater {
 }
 
 public abstract interface annotation class com/squareup/workflow1/WorkflowExperimentalApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class com/squareup/workflow1/WorkflowExperimentalRuntime : java/lang/annotation/Annotation {
 }
 
 public final class com/squareup/workflow1/WorkflowIdentifier {

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/HandlerBox.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/HandlerBox.kt
@@ -1,0 +1,413 @@
+package com.squareup.workflow1
+
+import kotlin.reflect.typeOf
+
+internal class HandlerBox0 {
+  lateinit var handler: () -> Unit
+  val stableHandler: () -> Unit = { handler() }
+}
+
+internal fun <P, S, O> BaseRenderContext<P, S, O>.eventHandler0(
+  name: String,
+  remember: Boolean,
+  update: Updater<P, S, O>.() -> Unit
+): () -> Unit {
+  val handler = { actionSink.send(action("eH: $name", update)) }
+  return if (remember) {
+    val box = remember(name) { HandlerBox0() }
+    box.handler = handler
+    box.stableHandler
+  } else {
+    handler
+  }
+}
+
+@PublishedApi
+internal class HandlerBox1<E> {
+  lateinit var handler: (E) -> Unit
+  val stableHandler: (E) -> Unit = { handler(it) }
+}
+
+@PublishedApi
+internal inline fun <P, S, O, reified EventT> BaseRenderContext<P, S, O>.eventHandler1(
+  name: String,
+  remember: Boolean,
+  noinline update: Updater<P, S, O>.(EventT) -> Unit
+): (EventT) -> Unit {
+  val handler = { e: EventT -> actionSink.send(action("eH: $name") { update(e) }) }
+  return if (remember) {
+    val box = remember(name, typeOf<EventT>()) { HandlerBox1<EventT>() }
+    box.handler = handler
+    box.stableHandler
+  } else {
+    handler
+  }
+}
+
+@PublishedApi
+internal class HandlerBox2<E1, E2> {
+  lateinit var handler: (E1, E2) -> Unit
+  val stableHandler: (E1, E2) -> Unit = { e1, e2 -> handler(e1, e2) }
+}
+
+@PublishedApi
+internal inline fun <P, S, O, reified E1, reified E2> BaseRenderContext<P, S, O>.eventHandler2(
+  name: String,
+  remember: Boolean,
+  noinline update: Updater<P, S, O>.(E1, E2) -> Unit
+): (E1, E2) -> Unit {
+  val handler = { e1: E1, e2: E2 -> actionSink.send(action("eH: $name") { update(e1, e2) }) }
+  return if (remember) {
+    val box = remember(name, typeOf<E1>(), typeOf<E2>()) { HandlerBox2<E1, E2>() }
+    box.handler = handler
+    box.stableHandler
+  } else {
+    handler
+  }
+}
+
+@PublishedApi
+internal class HandlerBox3<E1, E2, E3> {
+  lateinit var handler: (E1, E2, E3) -> Unit
+  val stableHandler: (E1, E2, E3) -> Unit = { e1, e2, e3 -> handler(e1, e2, e3) }
+}
+
+@PublishedApi
+internal inline fun <
+  P,
+  S,
+  O,
+  reified E1,
+  reified E2,
+  reified E3,
+  > BaseRenderContext<P, S, O>.eventHandler3(
+  name: String,
+  remember: Boolean,
+  noinline update: Updater<P, S, O>.(E1, E2, E3) -> Unit
+): (E1, E2, E3) -> Unit {
+  val handler =
+    { e1: E1, e2: E2, e3: E3 -> actionSink.send(action("eH: $name") { update(e1, e2, e3) }) }
+  return if (remember) {
+    val box =
+      remember(name, typeOf<E1>(), typeOf<E2>(), typeOf<E3>()) { HandlerBox3<E1, E2, E3>() }
+    box.handler = handler
+    box.stableHandler
+  } else {
+    handler
+  }
+}
+
+@PublishedApi
+internal class HandlerBox4<E1, E2, E3, E4> {
+  lateinit var handler: (E1, E2, E3, E4) -> Unit
+  val stableHandler: (E1, E2, E3, E4) -> Unit = { e1, e2, e3, e4 -> handler(e1, e2, e3, e4) }
+}
+
+@PublishedApi
+internal inline fun <
+  P,
+  S,
+  O,
+  reified E1,
+  reified E2,
+  reified E3,
+  reified E4,
+  > BaseRenderContext<P, S, O>.eventHandler4(
+  name: String,
+  remember: Boolean,
+  noinline update: Updater<P, S, O>.(E1, E2, E3, E4) -> Unit
+): (E1, E2, E3, E4) -> Unit {
+  val handler = { e1: E1, e2: E2, e3: E3, e4: E4 ->
+    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4) })
+  }
+  return if (remember) {
+    val box = remember(
+      name,
+      typeOf<E1>(),
+      typeOf<E2>(),
+      typeOf<E3>(),
+      typeOf<E4>()
+    ) { HandlerBox4<E1, E2, E3, E4>() }
+    box.handler = handler
+    box.stableHandler
+  } else {
+    handler
+  }
+}
+
+@PublishedApi
+internal class HandlerBox5<E1, E2, E3, E4, E5> {
+  lateinit var handler: (E1, E2, E3, E4, E5) -> Unit
+  val stableHandler: (E1, E2, E3, E4, E5) -> Unit =
+    { e1, e2, e3, e4, e5 -> handler(e1, e2, e3, e4, e5) }
+}
+
+@PublishedApi
+internal inline fun <
+  P,
+  S,
+  O,
+  reified E1,
+  reified E2,
+  reified E3,
+  reified E4,
+  reified E5,
+  > BaseRenderContext<P, S, O>.eventHandler5(
+  name: String,
+  remember: Boolean,
+  noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5) -> Unit
+): (E1, E2, E3, E4, E5) -> Unit {
+  val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5 ->
+    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5) })
+  }
+  return if (remember) {
+    val box = remember(
+      name,
+      typeOf<E1>(),
+      typeOf<E2>(),
+      typeOf<E3>(),
+      typeOf<E4>(),
+      typeOf<E5>()
+    ) { HandlerBox5<E1, E2, E3, E4, E5>() }
+    box.handler = handler
+    box.stableHandler
+  } else {
+    handler
+  }
+}
+
+@PublishedApi
+internal class HandlerBox6<E1, E2, E3, E4, E5, E6> {
+  lateinit var handler: (E1, E2, E3, E4, E5, E6) -> Unit
+  val stableHandler: (E1, E2, E3, E4, E5, E6) -> Unit =
+    { e1, e2, e3, e4, e5, e6 -> handler(e1, e2, e3, e4, e5, e6) }
+}
+
+@PublishedApi
+internal inline fun <
+  P,
+  S,
+  O,
+  reified E1,
+  reified E2,
+  reified E3,
+  reified E4,
+  reified E5,
+  reified E6,
+  > BaseRenderContext<P, S, O>.eventHandler6(
+  name: String,
+  remember: Boolean,
+  noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6) -> Unit
+): (E1, E2, E3, E4, E5, E6) -> Unit {
+  val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6 ->
+    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6) })
+  }
+  return if (remember) {
+    val box = remember(
+      name,
+      typeOf<E1>(),
+      typeOf<E2>(),
+      typeOf<E3>(),
+      typeOf<E4>(),
+      typeOf<E5>(),
+      typeOf<E6>()
+    ) { HandlerBox6<E1, E2, E3, E4, E5, E6>() }
+    box.handler = handler
+    box.stableHandler
+  } else {
+    handler
+  }
+}
+
+@PublishedApi
+internal class HandlerBox7<E1, E2, E3, E4, E5, E6, E7> {
+  lateinit var handler: (E1, E2, E3, E4, E5, E6, E7) -> Unit
+  val stableHandler: (E1, E2, E3, E4, E5, E6, E7) -> Unit =
+    { e1, e2, e3, e4, e5, e6, e7 -> handler(e1, e2, e3, e4, e5, e6, e7) }
+}
+
+@PublishedApi
+internal inline fun <
+  P,
+  S,
+  O,
+  reified E1,
+  reified E2,
+  reified E3,
+  reified E4,
+  reified E5,
+  reified E6,
+  reified E7,
+  > BaseRenderContext<P, S, O>.eventHandler7(
+  name: String,
+  remember: Boolean,
+  noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6, E7) -> Unit
+): (E1, E2, E3, E4, E5, E6, E7) -> Unit {
+  val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7 ->
+    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6, e7) })
+  }
+  return if (remember) {
+    val box = remember(
+      name,
+      typeOf<E1>(),
+      typeOf<E2>(),
+      typeOf<E3>(),
+      typeOf<E4>(),
+      typeOf<E5>(),
+      typeOf<E6>(),
+      typeOf<E7>()
+    ) { HandlerBox7<E1, E2, E3, E4, E5, E6, E7>() }
+    box.handler = handler
+    box.stableHandler
+  } else {
+    handler
+  }
+}
+
+@PublishedApi
+internal class HandlerBox8<E1, E2, E3, E4, E5, E6, E7, E8> {
+  lateinit var handler: (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit
+  val stableHandler: (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit =
+    { e1, e2, e3, e4, e5, e6, e7, e8 -> handler(e1, e2, e3, e4, e5, e6, e7, e8) }
+}
+
+@PublishedApi
+internal inline fun <
+  P,
+  S,
+  O,
+  reified E1,
+  reified E2,
+  reified E3,
+  reified E4,
+  reified E5,
+  reified E6,
+  reified E7,
+  reified E8,
+  > BaseRenderContext<P, S, O>.eventHandler8(
+  name: String,
+  remember: Boolean,
+  noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6, E7, E8) -> Unit
+): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit {
+  val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7, e8: E8 ->
+    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6, e7, e8) })
+  }
+  return if (remember) {
+    val box = remember(
+      name,
+      typeOf<E1>(),
+      typeOf<E2>(),
+      typeOf<E3>(),
+      typeOf<E4>(),
+      typeOf<E5>(),
+      typeOf<E6>(),
+      typeOf<E7>(),
+      typeOf<E8>()
+    ) { HandlerBox8<E1, E2, E3, E4, E5, E6, E7, E8>() }
+    box.handler = handler
+    box.stableHandler
+  } else {
+    handler
+  }
+}
+
+@PublishedApi
+internal class HandlerBox9<E1, E2, E3, E4, E5, E6, E7, E8, E9> {
+  lateinit var handler: (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit
+  val stableHandler: (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit =
+    { e1, e2, e3, e4, e5, e6, e7, e8, e9 -> handler(e1, e2, e3, e4, e5, e6, e7, e8, e9) }
+}
+
+@PublishedApi
+internal inline fun <
+  P,
+  S,
+  O,
+  reified E1,
+  reified E2,
+  reified E3,
+  reified E4,
+  reified E5,
+  reified E6,
+  reified E7,
+  reified E8,
+  reified E9,
+  > BaseRenderContext<P, S, O>.eventHandler9(
+  name: String,
+  remember: Boolean,
+  noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit
+): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit {
+  val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7, e8: E8, e9: E9 ->
+    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6, e7, e8, e9) })
+  }
+  return if (remember) {
+    val box = remember(
+      name,
+      typeOf<E1>(),
+      typeOf<E2>(),
+      typeOf<E3>(),
+      typeOf<E4>(),
+      typeOf<E5>(),
+      typeOf<E6>(),
+      typeOf<E7>(),
+      typeOf<E8>(),
+      typeOf<E9>()
+    ) { HandlerBox9<E1, E2, E3, E4, E5, E6, E7, E8, E9>() }
+    box.handler = handler
+    box.stableHandler
+  } else {
+    handler
+  }
+}
+
+@PublishedApi
+internal class HandlerBox10<E1, E2, E3, E4, E5, E6, E7, E8, E9, E10> {
+  lateinit var handler: (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit
+  val stableHandler: (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit =
+    { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 -> handler(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10) }
+}
+
+@PublishedApi
+internal inline fun <
+  P,
+  S,
+  O,
+  reified E1,
+  reified E2,
+  reified E3,
+  reified E4,
+  reified E5,
+  reified E6,
+  reified E7,
+  reified E8,
+  reified E9,
+  reified E10,
+  > BaseRenderContext<P, S, O>.eventHandler10(
+  name: String,
+  remember: Boolean,
+  noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit
+): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit {
+  val handler =
+    { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7, e8: E8, e9: E9, e10: E10 ->
+      actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10) })
+    }
+  return if (remember) {
+    val box = remember(
+      name,
+      typeOf<E1>(),
+      typeOf<E2>(),
+      typeOf<E3>(),
+      typeOf<E4>(),
+      typeOf<E5>(),
+      typeOf<E6>(),
+      typeOf<E7>(),
+      typeOf<E8>(),
+      typeOf<E9>(),
+      typeOf<E10>()
+    ) { HandlerBox10<E1, E2, E3, E4, E5, E6, E7, E8, E9, E10>() }
+    box.handler = handler
+    box.stableHandler
+  } else {
+    handler
+  }
+}

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/RuntimeConfig.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/RuntimeConfig.kt
@@ -58,14 +58,22 @@ public enum class RuntimeConfigOptions {
    * If we have more actions to process, do so before passing the rendering to the UI layer.
    */
   @WorkflowExperimentalRuntime
-  CONFLATE_STALE_RENDERINGS;
+  CONFLATE_STALE_RENDERINGS,
+
+  /**
+   * Changes the default value of the `remember: Boolean?` parameter of
+   * `RenderContext.eventHandler` calls from `false` to `true`.
+   */
+  @WorkflowExperimentalRuntime
+  STABLE_EVENT_HANDLERS,
+  ;
 
   public companion object {
     /**
      * Baseline configuration where we render for each action and always pass the rendering to
      * the view layer.
      */
-    public val RENDER_PER_ACTION: RuntimeConfig = emptySet<RuntimeConfigOptions>()
+    public val RENDER_PER_ACTION: RuntimeConfig = emptySet()
 
     public val DEFAULT_CONFIG: RuntimeConfig = RENDER_PER_ACTION
   }

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
@@ -1,8 +1,10 @@
 @file:JvmMultifileClass
 @file:JvmName("Workflows")
+@file:Suppress("ktlint:standard:indent")
 
 package com.squareup.workflow1
 
+import com.squareup.workflow1.RuntimeConfigOptions.STABLE_EVENT_HANDLERS
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
@@ -30,7 +32,196 @@ public abstract class StatelessWorkflow<in PropsT, out OutputT, out RenderingT> 
   public inner class RenderContext internal constructor(
     baseContext: BaseRenderContext<PropsT, *, OutputT>
   ) : BaseRenderContext<@UnsafeVariance PropsT, Nothing, @UnsafeVariance OutputT> by
-  baseContext as BaseRenderContext<PropsT, Nothing, OutputT>
+  baseContext as BaseRenderContext<PropsT, Nothing, OutputT> {
+    @PublishedApi
+    @OptIn(WorkflowExperimentalRuntime::class)
+    internal val stableEventHandlers: Boolean =
+      baseContext.runtimeConfig.contains(STABLE_EVENT_HANDLERS)
+
+    /**
+     * Given an [update] function, wraps it in a lambda suitable for use
+     * as an event handler on a rendered view model.
+     * See [StatefulWorkflow.RenderContext.eventHandler] for details.
+     *
+     * @param name If [remember] is true, used as a unique key to distinguish
+     * event handlers with same number and type of parameters. Also used
+     * for descriptive logging and error messages.
+     *
+     * @param remember When true uses [RenderContext.remember] to ensure
+     * that the same lambda is returned across multiple render passes,
+     * allowing Compose to avoid unnecessary recomposition on updates.
+     *
+     * When false a new lambda is created on each call, and [name]
+     * is used only for descriptive logging and error messages.
+     *
+     * When `null` a default value of `false` is used unless
+     * [STABLE_EVENT_HANDLERS] has been specified in the [runtimeConfig].
+     *
+     * @throws IllegalArgumentException if [remember] is true and [name]
+     * has already been used in the current [render] call for a lambda of
+     * the same shape
+     */
+    public fun eventHandler(
+      name: String,
+      remember: Boolean? = null,
+      update: Updater<PropsT, *, OutputT>.() -> Unit
+    ): () -> Unit = eventHandler0(name, remember ?: stableEventHandlers, update)
+
+    public inline fun <reified EventT> eventHandler(
+      name: String,
+      remember: Boolean? = null,
+      noinline update: Updater<PropsT, *, OutputT>.(EventT) -> Unit
+    ): (EventT) -> Unit = eventHandler1(name, remember ?: stableEventHandlers, update)
+
+    public inline fun <reified E1, reified E2> eventHandler(
+      name: String,
+      remember: Boolean? = null,
+      noinline update: Updater<PropsT, *, OutputT>.(E1, E2) -> Unit
+    ): (E1, E2) -> Unit = eventHandler2(name, remember ?: stableEventHandlers, update)
+
+    public inline fun <reified E1, reified E2, reified E3> eventHandler(
+      name: String,
+      remember: Boolean? = null,
+      noinline update: Updater<PropsT, *, OutputT>.(E1, E2, E3) -> Unit
+    ): (E1, E2, E3) -> Unit = eventHandler3(name, remember ?: stableEventHandlers, update)
+
+    public inline fun <reified E1, reified E2, reified E3, reified E4> eventHandler(
+      name: String,
+      remember: Boolean? = null,
+      noinline update: Updater<PropsT, *, OutputT>.(E1, E2, E3, E4) -> Unit
+    ): (E1, E2, E3, E4) -> Unit = eventHandler4(name, remember ?: stableEventHandlers, update)
+
+    public inline fun <reified E1, reified E2, reified E3, reified E4, reified E5> eventHandler(
+      name: String,
+      remember: Boolean? = null,
+      noinline update: Updater<PropsT, *, OutputT>.(E1, E2, E3, E4, E5) -> Unit
+    ): (E1, E2, E3, E4, E5) -> Unit = eventHandler5(name, remember ?: stableEventHandlers, update)
+
+    public inline fun <
+      reified E1,
+      reified E2,
+      reified E3,
+      reified E4,
+      reified E5,
+      reified E6,
+      > eventHandler(
+      name: String,
+      remember: Boolean? = null,
+      noinline update: Updater<PropsT, *, OutputT>.(
+        E1,
+        E2,
+        E3,
+        E4,
+        E5,
+        E6,
+      ) -> Unit
+    ): (E1, E2, E3, E4, E5, E6) -> Unit =
+      eventHandler6(name, remember ?: stableEventHandlers, update)
+
+    public inline fun <
+      reified E1,
+      reified E2,
+      reified E3,
+      reified E4,
+      reified E5,
+      reified E6,
+      reified E7,
+      > eventHandler(
+      name: String,
+      remember: Boolean? = null,
+      noinline update: Updater<PropsT, *, OutputT>.(
+        E1,
+        E2,
+        E3,
+        E4,
+        E5,
+        E6,
+        E7,
+      ) -> Unit
+    ): (E1, E2, E3, E4, E5, E6, E7) -> Unit =
+      eventHandler7(name, remember ?: stableEventHandlers, update)
+
+    public inline fun <
+      reified E1,
+      reified E2,
+      reified E3,
+      reified E4,
+      reified E5,
+      reified E6,
+      reified E7,
+      reified E8,
+      > eventHandler(
+      name: String,
+      remember: Boolean? = null,
+      noinline update: Updater<PropsT, *, OutputT>.(
+        E1,
+        E2,
+        E3,
+        E4,
+        E5,
+        E6,
+        E7,
+        E8,
+      ) -> Unit
+    ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit =
+      eventHandler8(name, remember ?: stableEventHandlers, update)
+
+    public inline fun <
+      reified E1,
+      reified E2,
+      reified E3,
+      reified E4,
+      reified E5,
+      reified E6,
+      reified E7,
+      reified E8,
+      reified E9,
+      > eventHandler(
+      name: String,
+      remember: Boolean? = null,
+      noinline update: Updater<PropsT, *, OutputT>.(
+        E1,
+        E2,
+        E3,
+        E4,
+        E5,
+        E6,
+        E7,
+        E8,
+        E9,
+      ) -> Unit
+    ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit =
+      eventHandler9(name, remember ?: stableEventHandlers, update)
+
+    public inline fun <
+      reified E1,
+      reified E2,
+      reified E3,
+      reified E4,
+      reified E5,
+      reified E6,
+      reified E7,
+      reified E8,
+      reified E9,
+      reified E10,
+      > eventHandler(
+      name: String,
+      remember: Boolean? = null,
+      noinline update: Updater<PropsT, *, OutputT>.(
+        E1,
+        E2,
+        E3,
+        E4,
+        E5,
+        E6,
+        E7,
+        E8,
+        E9,
+        E10,
+      ) -> Unit
+    ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit =
+      eventHandler10(name, remember ?: stableEventHandlers, update)
+  }
 
   /**
    * Class type returned by [asStatefulWorkflow].
@@ -136,7 +327,11 @@ public fun <PropsT, OutputT, RenderingT> RenderContext(
  * their own internal state.
  */
 public inline fun <PropsT, OutputT, RenderingT> Workflow.Companion.stateless(
-  crossinline render: BaseRenderContext<PropsT, Nothing, OutputT>.(props: PropsT) -> RenderingT
+  crossinline render: StatelessWorkflow<
+    PropsT,
+    OutputT,
+    RenderingT
+    >.RenderContext.(props: PropsT) -> RenderingT
 ): Workflow<PropsT, OutputT, RenderingT> =
   object : StatelessWorkflow<PropsT, OutputT, RenderingT>() {
     override fun render(
@@ -163,9 +358,9 @@ public fun <RenderingT> Workflow.Companion.rendering(
  */
 public fun <PropsT, OutputT, RenderingT>
   StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
-    name: String,
-    update: WorkflowAction<PropsT, *, OutputT>.Updater.() -> Unit
-  ): WorkflowAction<PropsT, Nothing, OutputT> = action({ name }, update)
+  name: String,
+  update: Updater<PropsT, *, OutputT>.() -> Unit
+): WorkflowAction<PropsT, Nothing, OutputT> = action({ name }, update)
 
 /**
  * Convenience to create a [WorkflowAction] with parameter types matching those
@@ -177,11 +372,12 @@ public fun <PropsT, OutputT, RenderingT>
  *  [WorkflowAction.toString].
  * @param update Function that defines the workflow update.
  */
+@Suppress("UnusedReceiverParameter")
 public fun <PropsT, OutputT, RenderingT>
   StatelessWorkflow<PropsT, OutputT, RenderingT>.action(
-    name: () -> String,
-    update: WorkflowAction<PropsT, *, OutputT>.Updater.() -> Unit
-  ): WorkflowAction<PropsT, Nothing, OutputT> = object : WorkflowAction<PropsT, Nothing, OutputT>() {
+  name: () -> String,
+  update: Updater<PropsT, *, OutputT>.() -> Unit
+): WorkflowAction<PropsT, Nothing, OutputT> = object : WorkflowAction<PropsT, Nothing, OutputT>() {
   override val debuggingName: String
     get() = name()
 

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowAction.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkflowAction.kt
@@ -9,6 +9,11 @@ import kotlin.jvm.JvmName
 import kotlin.jvm.JvmOverloads
 
 /**
+ * Convenience alias for working with [WorkflowAction.Updater].
+ */
+public typealias Updater<P, S, O> = WorkflowAction<P, S, O>.Updater
+
+/**
  * An atomic operation that updates the state of a [Workflow], and also optionally emits an output.
  *
  * A [WorkflowAction]'s [apply] method is executed in the context of an [Updater][WorkflowAction.Updater],
@@ -184,7 +189,7 @@ public object ActionsExhausted : ActionProcessingResult
  * @param stateChanged: whether or not the action changed the state.
  *
  * Note this is NOT a data class to avoid binary compatibility issues with future updates.
- * @see [here](https://jakewharton.com/public-api-challenges-in-kotlin/) for more on this.
+ * [See here](https://jakewharton.com/public-api-challenges-in-kotlin/) for more on this.
  *
  * Also note that since we have decided to allow destructuring and implemented componentN()
  * functions, we should only ever add new properties to the end of this constructor.

--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -22,21 +22,6 @@ public final class com/squareup/workflow1/RenderingAndSnapshot {
 	public final fun getSnapshot ()Lcom/squareup/workflow1/TreeSnapshot;
 }
 
-public final class com/squareup/workflow1/RuntimeConfigOptions : java/lang/Enum {
-	public static final field CONFLATE_STALE_RENDERINGS Lcom/squareup/workflow1/RuntimeConfigOptions;
-	public static final field Companion Lcom/squareup/workflow1/RuntimeConfigOptions$Companion;
-	public static final field PARTIAL_TREE_RENDERING Lcom/squareup/workflow1/RuntimeConfigOptions;
-	public static final field RENDER_ONLY_WHEN_STATE_CHANGES Lcom/squareup/workflow1/RuntimeConfigOptions;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/squareup/workflow1/RuntimeConfigOptions;
-	public static fun values ()[Lcom/squareup/workflow1/RuntimeConfigOptions;
-}
-
-public final class com/squareup/workflow1/RuntimeConfigOptions$Companion {
-	public final fun getDEFAULT_CONFIG ()Ljava/util/Set;
-	public final fun getRENDER_PER_ACTION ()Ljava/util/Set;
-}
-
 public class com/squareup/workflow1/SimpleLoggingWorkflowInterceptor : com/squareup/workflow1/WorkflowInterceptor {
 	public fun <init> ()V
 	protected fun log (Ljava/lang/String;)V
@@ -64,9 +49,6 @@ public final class com/squareup/workflow1/TreeSnapshot$Companion {
 	public final fun parse (Lokio/ByteString;)Lcom/squareup/workflow1/TreeSnapshot;
 }
 
-public abstract interface annotation class com/squareup/workflow1/WorkflowExperimentalRuntime : java/lang/annotation/Annotation {
-}
-
 public abstract interface class com/squareup/workflow1/WorkflowInterceptor {
 	public abstract fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public abstract fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
@@ -89,12 +71,14 @@ public final class com/squareup/workflow1/WorkflowInterceptor$DefaultImpls {
 
 public abstract interface class com/squareup/workflow1/WorkflowInterceptor$RenderContextInterceptor {
 	public abstract fun onActionSent (Lcom/squareup/workflow1/WorkflowAction;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun onRemember (Ljava/lang/String;Lkotlin/reflect/KType;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;)Ljava/lang/Object;
 	public abstract fun onRenderChild (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;)Ljava/lang/Object;
 	public abstract fun onRunningSideEffect (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class com/squareup/workflow1/WorkflowInterceptor$RenderContextInterceptor$DefaultImpls {
 	public static fun onActionSent (Lcom/squareup/workflow1/WorkflowInterceptor$RenderContextInterceptor;Lcom/squareup/workflow1/WorkflowAction;Lkotlin/jvm/functions/Function1;)V
+	public static fun onRemember (Lcom/squareup/workflow1/WorkflowInterceptor$RenderContextInterceptor;Ljava/lang/String;Lkotlin/reflect/KType;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;)Ljava/lang/Object;
 	public static fun onRenderChild (Lcom/squareup/workflow1/WorkflowInterceptor$RenderContextInterceptor;Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;)Ljava/lang/Object;
 	public static fun onRunningSideEffect (Lcom/squareup/workflow1/WorkflowInterceptor$RenderContextInterceptor;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
 }

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/RememberedNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/RememberedNode.kt
@@ -1,0 +1,14 @@
+package com.squareup.workflow1.internal
+
+import com.squareup.workflow1.internal.InlineLinkedList.InlineListNode
+import kotlin.reflect.KType
+
+internal class RememberedNode<ResultT>(
+  val key: String,
+  val resultType: KType,
+  val inputs: Array<out Any?>,
+  val lastCalculated: ResultT
+) : InlineListNode<RememberedNode<*>> {
+
+  override var nextListNode: RememberedNode<*>? = null
+}

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/SimpleLoggingWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/SimpleLoggingWorkflowInterceptorTest.kt
@@ -4,6 +4,7 @@ import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -92,6 +93,7 @@ internal class SimpleLoggingWorkflowInterceptorTest {
   }
 
   private object FakeRenderContext : BaseRenderContext<Unit, Unit, Unit> {
+    override val runtimeConfig: RuntimeConfig = emptySet()
     override val actionSink: Sink<WorkflowAction<Unit, Unit, Unit>>
       get() = fail()
     override val workflowTracer: WorkflowTracer? = null
@@ -109,6 +111,15 @@ internal class SimpleLoggingWorkflowInterceptorTest {
       key: String,
       sideEffect: suspend CoroutineScope.() -> Unit
     ) {
+      fail()
+    }
+
+    override fun <ResultT> remember(
+      key: String,
+      resultType: KType,
+      vararg inputs: Any?,
+      calculation: () -> ResultT
+    ): ResultT {
       fail()
     }
   }

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptorTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.reflect.KType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
@@ -36,7 +37,6 @@ import kotlin.test.fail
  * parameters and return value to ensure that all values are being threaded through appropriately.
  */
 internal class ChainedWorkflowInterceptorTest {
-
   @Test fun chained_returns_Noop_when_list_is_empty() {
     val list = emptyList<WorkflowInterceptor>()
     val chained = list.chained()
@@ -321,6 +321,7 @@ internal class ChainedWorkflowInterceptorTest {
   private fun Snapshot?.readUtf8() = this?.bytes?.parse { it.readUtf8() }
 
   private object FakeRenderContext : BaseRenderContext<String, String, String> {
+    override val runtimeConfig: RuntimeConfig = emptySet()
     override val actionSink: Sink<WorkflowAction<String, String, String>>
       get() = fail()
     override val workflowTracer: WorkflowTracer? = null
@@ -340,6 +341,13 @@ internal class ChainedWorkflowInterceptorTest {
     ) {
       fail()
     }
+
+    override fun <ResultT> remember(
+      key: String,
+      resultType: KType,
+      vararg inputs: Any?,
+      calculation: () -> ResultT
+    ): ResultT = fail()
   }
 
   object TestSession : WorkflowSession {

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ParameterizedTestRunner.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/ParameterizedTestRunner.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
  * Simple parameterized test as we are in KMP commonTest code and don't have junit
  * libraries like jupiter.
  *
- * We do our best to tell you what the parameter was when the failure occured by wrapping
+ * We do our best to tell you what the parameter was when the failure occurred by wrapping
  * assertions from kotlin.test and injecting our own message.
  */
 class ParameterizedTestRunner<P : Any> {

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
@@ -57,7 +57,9 @@ internal class SubtreeManagerTest {
       return Rendering(
         renderProps,
         renderState,
-        eventHandler = context.eventHandler("") { out -> setOutput("workflow output:$out") }
+        eventHandler = context.eventHandler("") { out ->
+          setOutput("workflow output:$out")
+        }
       )
     }
 

--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -64,9 +64,12 @@ public final class com/squareup/workflow1/testing/RenderTesterKt {
 	public static synthetic fun expectWorkflow$default (Lcom/squareup/workflow1/testing/RenderTester;Lcom/squareup/workflow1/WorkflowIdentifier;Ljava/lang/Object;Lcom/squareup/workflow1/WorkflowOutput;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTester;
 	public static synthetic fun expectWorkflow$default (Lcom/squareup/workflow1/testing/RenderTester;Lcom/squareup/workflow1/WorkflowIdentifier;Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTester;
 	public static synthetic fun expectWorkflow$default (Lcom/squareup/workflow1/testing/RenderTester;Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowOutput;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTester;
-	public static final fun testRender (Lcom/squareup/workflow1/SessionWorkflow;Ljava/lang/Object;Lkotlinx/coroutines/CoroutineScope;)Lcom/squareup/workflow1/testing/RenderTester;
-	public static final fun testRender (Lcom/squareup/workflow1/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTester;
-	public static final fun testRender (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTester;
+	public static final fun testRender (Lcom/squareup/workflow1/SessionWorkflow;Ljava/lang/Object;Lkotlinx/coroutines/CoroutineScope;Ljava/util/Set;)Lcom/squareup/workflow1/testing/RenderTester;
+	public static final fun testRender (Lcom/squareup/workflow1/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Set;)Lcom/squareup/workflow1/testing/RenderTester;
+	public static final fun testRender (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/util/Set;)Lcom/squareup/workflow1/testing/RenderTester;
+	public static synthetic fun testRender$default (Lcom/squareup/workflow1/SessionWorkflow;Ljava/lang/Object;Lkotlinx/coroutines/CoroutineScope;Ljava/util/Set;ILjava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTester;
+	public static synthetic fun testRender$default (Lcom/squareup/workflow1/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Set;ILjava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTester;
+	public static synthetic fun testRender$default (Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/util/Set;ILjava/lang/Object;)Lcom/squareup/workflow1/testing/RenderTester;
 }
 
 public final class com/squareup/workflow1/testing/RenderTesterWorkersKt {
@@ -104,9 +107,10 @@ public final class com/squareup/workflow1/testing/WorkerTesterKt {
 
 public final class com/squareup/workflow1/testing/WorkflowTestParams {
 	public fun <init> ()V
-	public fun <init> (Lcom/squareup/workflow1/testing/WorkflowTestParams$StartMode;Z)V
-	public synthetic fun <init> (Lcom/squareup/workflow1/testing/WorkflowTestParams$StartMode;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/squareup/workflow1/testing/WorkflowTestParams$StartMode;ZLjava/util/Set;)V
+	public synthetic fun <init> (Lcom/squareup/workflow1/testing/WorkflowTestParams$StartMode;ZLjava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCheckRenderIdempotence ()Z
+	public final fun getRuntimeConfig ()Ljava/util/Set;
 	public final fun getStartFrom ()Lcom/squareup/workflow1/testing/WorkflowTestParams$StartMode;
 }
 

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTestParams.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTestParams.kt
@@ -1,5 +1,6 @@
 package com.squareup.workflow1.testing
 
+import com.squareup.workflow1.RuntimeConfig
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.TreeSnapshot
 import com.squareup.workflow1.testing.WorkflowTestParams.StartMode
@@ -20,11 +21,15 @@ import org.jetbrains.annotations.TestOnly
  * for any given state, so performing side effects in `render` will almost always result in bugs.
  * It is recommended to leave this on, but if you need to debug a test and don't want to have to
  * deal with the extra passes, you can temporarily set it to false.
+ * @param runtimeConfig Runtime configuration to apply. If `null` we use
+ * [JvmTestRuntimeConfigTools.getTestRuntimeConfig][com.squareup.workflow1.config.JvmTestRuntimeConfigTools.getTestRuntimeConfig]
+ * instead.
  */
 @TestOnly
 public class WorkflowTestParams<out StateT>(
   public val startFrom: StartMode<StateT> = StartFresh,
-  public val checkRenderIdempotence: Boolean = true
+  public val checkRenderIdempotence: Boolean = true,
+  public val runtimeConfig: RuntimeConfig? = null
 ) {
   /**
    * Defines how to start the workflow for tests.

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTestRuntime.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTestRuntime.kt
@@ -1,4 +1,5 @@
 @file:OptIn(ExperimentalCoroutinesApi::class)
+@file:Suppress("ktlint:standard:indent")
 
 package com.squareup.workflow1.testing
 
@@ -176,11 +177,11 @@ public class WorkflowTestRuntime<PropsT, OutputT, RenderingT> @TestOnly internal
 @TestOnly
 public fun <T, PropsT, OutputT, RenderingT>
   Workflow<PropsT, OutputT, RenderingT>.launchForTestingFromStartWith(
-    props: PropsT,
-    testParams: WorkflowTestParams<Nothing> = WorkflowTestParams(),
-    context: CoroutineContext = EmptyCoroutineContext,
-    block: WorkflowTestRuntime<PropsT, OutputT, RenderingT>.() -> T
-  ): T = asStatefulWorkflow().launchForTestingWith(props, testParams, context, block)
+  props: PropsT,
+  testParams: WorkflowTestParams<Nothing> = WorkflowTestParams(),
+  context: CoroutineContext = EmptyCoroutineContext,
+  block: WorkflowTestRuntime<PropsT, OutputT, RenderingT>.() -> T
+): T = asStatefulWorkflow().launchForTestingWith(props, testParams, context, block)
 
 /**
  * Creates a [WorkflowTestRuntime] to run this workflow for unit testing.
@@ -190,10 +191,10 @@ public fun <T, PropsT, OutputT, RenderingT>
 @TestOnly
 public fun <T, OutputT, RenderingT>
   Workflow<Unit, OutputT, RenderingT>.launchForTestingFromStartWith(
-    testParams: WorkflowTestParams<Nothing> = WorkflowTestParams(),
-    context: CoroutineContext = EmptyCoroutineContext,
-    block: WorkflowTestRuntime<Unit, OutputT, RenderingT>.() -> T
-  ): T = launchForTestingFromStartWith(Unit, testParams, context, block)
+  testParams: WorkflowTestParams<Nothing> = WorkflowTestParams(),
+  context: CoroutineContext = EmptyCoroutineContext,
+  block: WorkflowTestRuntime<Unit, OutputT, RenderingT>.() -> T
+): T = launchForTestingFromStartWith(Unit, testParams, context, block)
 
 /**
  * Creates a [WorkflowTestRuntime] to run this workflow for unit testing.
@@ -205,11 +206,11 @@ public fun <T, OutputT, RenderingT>
 @TestOnly
 public fun <T, PropsT, StateT, OutputT, RenderingT>
   StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.launchForTestingFromStateWith(
-    props: PropsT,
-    initialState: StateT,
-    context: CoroutineContext = EmptyCoroutineContext,
-    block: WorkflowTestRuntime<PropsT, OutputT, RenderingT>.() -> T
-  ): T = launchForTestingWith(
+  props: PropsT,
+  initialState: StateT,
+  context: CoroutineContext = EmptyCoroutineContext,
+  block: WorkflowTestRuntime<PropsT, OutputT, RenderingT>.() -> T
+): T = launchForTestingWith(
   props,
   WorkflowTestParams(StartFromState(initialState)),
   context,
@@ -226,10 +227,10 @@ public fun <T, PropsT, StateT, OutputT, RenderingT>
 @TestOnly
 public fun <StateT, OutputT, RenderingT>
   StatefulWorkflow<Unit, StateT, OutputT, RenderingT>.launchForTestingFromStateWith(
-    initialState: StateT,
-    context: CoroutineContext = EmptyCoroutineContext,
-    block: WorkflowTestRuntime<Unit, OutputT, RenderingT>.() -> Unit
-  ): Unit = launchForTestingFromStateWith(Unit, initialState, context, block)
+  initialState: StateT,
+  context: CoroutineContext = EmptyCoroutineContext,
+  block: WorkflowTestRuntime<Unit, OutputT, RenderingT>.() -> Unit
+): Unit = launchForTestingFromStateWith(Unit, initialState, context, block)
 
 /**
  * Creates a [WorkflowTestRuntime] to run this workflow for unit testing.
@@ -239,11 +240,11 @@ public fun <StateT, OutputT, RenderingT>
 @TestOnly
 public fun <T, PropsT, StateT, OutputT, RenderingT>
   StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.launchForTestingWith(
-    props: PropsT,
-    testParams: WorkflowTestParams<StateT> = WorkflowTestParams(),
-    context: CoroutineContext = EmptyCoroutineContext,
-    block: WorkflowTestRuntime<PropsT, OutputT, RenderingT>.() -> T
-  ): T {
+  props: PropsT,
+  testParams: WorkflowTestParams<StateT> = WorkflowTestParams(),
+  context: CoroutineContext = EmptyCoroutineContext,
+  block: WorkflowTestRuntime<PropsT, OutputT, RenderingT>.() -> T
+): T {
   val propsFlow = MutableStateFlow(props)
 
   // Any exceptions that are thrown from a launch will be reported to the coroutine's uncaught
@@ -274,7 +275,7 @@ public fun <T, PropsT, StateT, OutputT, RenderingT>
     props = propsFlow,
     initialSnapshot = snapshot,
     interceptors = interceptors,
-    runtimeConfig = JvmTestRuntimeConfigTools.getTestRuntimeConfig()
+    runtimeConfig = testParams.runtimeConfig ?: JvmTestRuntimeConfigTools.getTestRuntimeConfig()
   ) { output -> outputs.send(output) }
   val tester = WorkflowTestRuntime(propsFlow, renderingsAndSnapshots, outputs)
   tester.collectFromWorkflowIn(workflowScope)

--- a/workflow-testing/src/test/java/com/squareup/workflow1/StatefulWorkflowEventHandlerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/StatefulWorkflowEventHandlerTest.kt
@@ -1,0 +1,267 @@
+package com.squareup.workflow1
+
+import com.squareup.workflow1.RuntimeConfigOptions.STABLE_EVENT_HANDLERS
+import com.squareup.workflow1.testing.WorkflowTestParams
+import com.squareup.workflow1.testing.launchForTestingFromStartWith
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+/**
+ * A lot of duplication here with [StatelessWorkflowEventHandlerTest]
+ */
+@OptIn(WorkflowExperimentalApi::class, WorkflowExperimentalRuntime::class)
+class StatefulWorkflowEventHandlerTest {
+  private data class Params(
+    val remember: Boolean?,
+    val runtimeConfig: RuntimeConfig
+  ) {
+    val remembering = remember ?: runtimeConfig.contains(STABLE_EVENT_HANDLERS)
+  }
+
+  private val rememberValues = sequenceOf(true, false, null)
+  private val configValues = sequenceOf(emptySet(), setOf(STABLE_EVENT_HANDLERS))
+  private val values = rememberValues.flatMap { remember ->
+    configValues.map { Params(remember, it) }
+  }
+  private val parameterizedTestRunner = ParameterizedTestRunner<Params>()
+
+  @Test fun eventHandler0() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateful(Unit) {
+        eventHandler("", remember = params.remembering) { setOutput("yay") }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke()
+        assertEquals("yay", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler1() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateful<Unit, S, (S) -> Unit>(Unit) {
+        eventHandler("", remember = params.remembering) { e1 ->
+          setOutput(e1)
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("yay")
+        assertEquals("yay", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler2() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateful<Unit, S, (S, S) -> Unit>(Unit) {
+        eventHandler("", remember = params.remembering) { e1, e2 ->
+          setOutput("$e1-$e2")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b")
+        assertEquals("a-b", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler3() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateful<Unit, S, (S, S, S) -> Unit>(Unit) {
+        eventHandler("", remember = params.remembering) { e1, e2, e3 ->
+          setOutput("$e1-$e2-$e3")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c")
+        assertEquals("a-b-c", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler4() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateful<Unit, S, (S, S, S, S) -> Unit>(Unit) {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4 ->
+          setOutput("$e1-$e2-$e3-$e4")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d")
+        assertEquals("a-b-c-d", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler5() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateful<Unit, S, (S, S, S, S, S) -> Unit>(Unit) {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4, e5 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d", "e")
+        assertEquals("a-b-c-d-e", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler6() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateful<Unit, S, (S, S, S, S, S, S) -> Unit>(Unit) {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4, e5, e6 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5-$e6")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d", "e", "f")
+        assertEquals("a-b-c-d-e-f", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler7() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateful<Unit, S, (S, S, S, S, S, S, S) -> Unit>(Unit) {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4, e5, e6, e7 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d", "e", "f", "g")
+        assertEquals("a-b-c-d-e-f-g", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler8() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateful<Unit, S, (S, S, S, S, S, S, S, S) -> Unit>(Unit) {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4, e5, e6, e7, e8 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d", "e", "f", "g", "h")
+        assertEquals("a-b-c-d-e-f-g-h", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler9() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateful<Unit, S, (S, S, S, S, S, S, S, S, S) -> Unit>(Unit) {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8-$e9")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d", "e", "f", "g", "h", "i")
+        assertEquals("a-b-c-d-e-f-g-h-i", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler10() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateful<Unit, S, (S, S, S, S, S, S, S, S, S, S) -> Unit>(Unit) {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8-$e9-$e10")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d", "e", "f", "g", "h", "i", "k")
+        assertEquals("a-b-c-d-e-f-g-h-i-k", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+}

--- a/workflow-testing/src/test/java/com/squareup/workflow1/StatefulWorkflowSafeEventHandlerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/StatefulWorkflowSafeEventHandlerTest.kt
@@ -1,0 +1,267 @@
+package com.squareup.workflow1
+
+import com.squareup.workflow1.StatefulWorkflowSafeEventHandlerTest.State.Able
+import com.squareup.workflow1.StatefulWorkflowSafeEventHandlerTest.State.Baker
+import com.squareup.workflow1.testing.launchForTestingFromStartWith
+import com.squareup.workflow1.testing.launchForTestingFromStateWith
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StatefulWorkflowSafeEventHandlerTest {
+  private sealed interface State {
+    data object Able : State
+    data object Baker : State
+  }
+
+  private var failedCast = ""
+  private val onFailedCast: (name: S, type: KClass<*>, state: State) -> Unit =
+    { name, expectedType, state ->
+      failedCast = "$name expected: ${expectedType.simpleName} got: $state"
+    }
+
+  @Test fun safeEventHandler0() {
+    val w = Workflow.stateful<State, S, () -> Unit>(Able) {
+      safeEventHandler<Able>(
+        "name",
+        update = { setOutput("yay") },
+        onFailedCast = onFailedCast
+      )
+    }
+    w.launchForTestingFromStartWith {
+      val first = awaitNextRendering()
+      first.invoke()
+      assertEquals("yay", awaitNextOutput())
+      assertNoFailedCast()
+    }
+    w.launchForTestingFromStateWith(Baker) {
+      val first = awaitNextRendering()
+      first.invoke()
+      assertFailedCast()
+    }
+  }
+
+  @Test fun safeEventHandler1() {
+    val w = Workflow.stateful<State, S, (S) -> Unit>(Able) {
+      safeEventHandler<Able, S>(
+        "name",
+        update = { _, e1 -> setOutput(e1) },
+        onFailedCast = onFailedCast
+      )
+    }
+    w.launchForTestingFromStartWith {
+      val first = awaitNextRendering()
+      first.invoke("yay")
+      assertEquals("yay", awaitNextOutput())
+      assertNoFailedCast()
+    }
+    w.launchForTestingFromStateWith(Baker) {
+      val first = awaitNextRendering()
+      first.invoke("yay")
+      assertFailedCast()
+    }
+  }
+
+  @Test fun safeEventHandler2() {
+    val w = Workflow.stateful<State, S, (S, S) -> Unit>(Able) {
+      safeEventHandler<Able, S, S>(
+        "name",
+        update = { _, e1, e2 -> setOutput("$e1-$e2") },
+        onFailedCast = onFailedCast
+      )
+    }
+    w.launchForTestingFromStartWith {
+      val first = awaitNextRendering()
+      first.invoke("a", "b")
+      assertEquals("a-b", awaitNextOutput())
+      assertNoFailedCast()
+    }
+    w.launchForTestingFromStateWith(Baker) {
+      val first = awaitNextRendering()
+      first.invoke("", "")
+      assertFailedCast()
+    }
+  }
+
+  @Test fun safeEventHandler3() {
+    val w = Workflow.stateful<State, S, (S, S, S) -> Unit>(Able) {
+      safeEventHandler<Able, S, S, S>(
+        "name",
+        update = { _, e1, e2, e3 -> setOutput("$e1-$e2-$e3") },
+        onFailedCast = onFailedCast
+      )
+    }
+    w.launchForTestingFromStartWith {
+      val first = awaitNextRendering()
+      first.invoke("a", "b", "c")
+      assertEquals("a-b-c", awaitNextOutput())
+      assertNoFailedCast()
+    }
+    w.launchForTestingFromStateWith(Baker) {
+      val first = awaitNextRendering()
+      first.invoke("", "", "")
+      assertFailedCast()
+    }
+  }
+
+  @Test fun safeEventHandler4() {
+    val w = Workflow.stateful<State, S, (S, S, S, S) -> Unit>(Able) {
+      safeEventHandler<Able, S, S, S, S>(
+        "name",
+        update = { _, e1, e2, e3, e4 -> setOutput("$e1-$e2-$e3-$e4") },
+        onFailedCast = onFailedCast
+      )
+    }
+    w.launchForTestingFromStartWith {
+      val first = awaitNextRendering()
+      first.invoke("a", "b", "c", "d")
+      assertEquals("a-b-c-d", awaitNextOutput())
+      assertNoFailedCast()
+    }
+    w.launchForTestingFromStateWith(Baker) {
+      val first = awaitNextRendering()
+      first.invoke("", "", "", "")
+      assertFailedCast()
+    }
+  }
+
+  @Test fun safeEventHandler5() {
+    val w = Workflow.stateful<State, S, (S, S, S, S, S) -> Unit>(Able) {
+      safeEventHandler<Able, S, S, S, S, S>(
+        "name",
+        update = { _, e1, e2, e3, e4, e5 -> setOutput("$e1-$e2-$e3-$e4-$e5") },
+        onFailedCast = onFailedCast
+      )
+    }
+    w.launchForTestingFromStartWith {
+      val first = awaitNextRendering()
+      first.invoke("a", "b", "c", "d", "e")
+      assertEquals("a-b-c-d-e", awaitNextOutput())
+      assertNoFailedCast()
+    }
+    w.launchForTestingFromStateWith(Baker) {
+      val first = awaitNextRendering()
+      first.invoke("", "", "", "", "")
+      assertFailedCast()
+    }
+  }
+
+  @Test fun safeEventHandler6() {
+    val w = Workflow.stateful<State, S, (S, S, S, S, S, S) -> Unit>(Able) {
+      safeEventHandler<Able, S, S, S, S, S, S>(
+        "name",
+        update = { _, e1, e2, e3, e4, e5, e6 -> setOutput("$e1-$e2-$e3-$e4-$e5-$e6") },
+        onFailedCast = onFailedCast
+      )
+    }
+    w.launchForTestingFromStartWith {
+      val first = awaitNextRendering()
+      first.invoke("a", "b", "c", "d", "e", "f")
+      assertEquals("a-b-c-d-e-f", awaitNextOutput())
+      assertNoFailedCast()
+    }
+    w.launchForTestingFromStateWith(Baker) {
+      val first = awaitNextRendering()
+      first.invoke("", "", "", "", "", "")
+      assertFailedCast()
+    }
+  }
+
+  @Test fun safeEventHandler7() {
+    val w = Workflow.stateful<State, S, (S, S, S, S, S, S, S) -> Unit>(Able) {
+      safeEventHandler<Able, S, S, S, S, S, S, S>(
+        "name",
+        update = { _, e1, e2, e3, e4, e5, e6, e7 -> setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7") },
+        onFailedCast = onFailedCast
+      )
+    }
+    w.launchForTestingFromStartWith {
+      val first = awaitNextRendering()
+      first.invoke("a", "b", "c", "d", "e", "f", "g")
+      assertEquals("a-b-c-d-e-f-g", awaitNextOutput())
+      assertNoFailedCast()
+    }
+    w.launchForTestingFromStateWith(Baker) {
+      val first = awaitNextRendering()
+      first.invoke("", "", "", "", "", "", "")
+      assertFailedCast()
+    }
+  }
+
+  @Test fun safeEventHandler8() {
+    val w = Workflow.stateful<State, S, (S, S, S, S, S, S, S, S) -> Unit>(Able) {
+      safeEventHandler<Able, S, S, S, S, S, S, S, S>(
+        "name",
+        update = { _, e1, e2, e3, e4, e5, e6, e7, e8 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8")
+        },
+        onFailedCast = onFailedCast
+      )
+    }
+    w.launchForTestingFromStartWith {
+      val first = awaitNextRendering()
+      first.invoke("a", "b", "c", "d", "e", "f", "g", "h")
+      assertEquals("a-b-c-d-e-f-g-h", awaitNextOutput())
+      assertNoFailedCast()
+    }
+    w.launchForTestingFromStateWith(Baker) {
+      val first = awaitNextRendering()
+      first.invoke("", "", "", "", "", "", "", "")
+      assertFailedCast()
+    }
+  }
+
+  @Test fun safeEventHandler9() {
+    val w = Workflow.stateful<State, S, (S, S, S, S, S, S, S, S, S) -> Unit>(Able) {
+      safeEventHandler<Able, S, S, S, S, S, S, S, S, S>(
+        "name",
+        update = { _, e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8-$e9")
+        },
+        onFailedCast = onFailedCast
+      )
+    }
+    w.launchForTestingFromStartWith {
+      val first = awaitNextRendering()
+      first.invoke("a", "b", "c", "d", "e", "f", "g", "h", "i")
+      assertEquals("a-b-c-d-e-f-g-h-i", awaitNextOutput())
+      assertNoFailedCast()
+    }
+    w.launchForTestingFromStateWith(Baker) {
+      val first = awaitNextRendering()
+      first.invoke("", "", "", "", "", "", "", "", "")
+      assertFailedCast()
+    }
+  }
+
+  @Test fun safeEventHandler10() {
+    val w = Workflow.stateful<State, S, (S, S, S, S, S, S, S, S, S, S) -> Unit>(Able) {
+      safeEventHandler<Able, S, S, S, S, S, S, S, S, S, S>(
+        "name",
+        update = { _, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8-$e9-$e10")
+        },
+        onFailedCast = onFailedCast
+      )
+    }
+    w.launchForTestingFromStartWith {
+      val first = awaitNextRendering()
+      first.invoke("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+      assertEquals("a-b-c-d-e-f-g-h-i-j", awaitNextOutput())
+      assertNoFailedCast()
+    }
+    w.launchForTestingFromStateWith(Baker) {
+      val first = awaitNextRendering()
+      first.invoke("", "", "", "", "", "", "", "", "", "")
+      assertFailedCast()
+    }
+  }
+
+  private fun assertNoFailedCast() {
+    assertEquals("", failedCast)
+  }
+
+  private fun assertFailedCast() {
+    assertEquals("name expected: Able got: Baker", failedCast)
+  }
+}

--- a/workflow-testing/src/test/java/com/squareup/workflow1/StatelessWorkflowEventHandlerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/StatelessWorkflowEventHandlerTest.kt
@@ -1,0 +1,267 @@
+package com.squareup.workflow1
+
+import com.squareup.workflow1.RuntimeConfigOptions.STABLE_EVENT_HANDLERS
+import com.squareup.workflow1.testing.WorkflowTestParams
+import com.squareup.workflow1.testing.launchForTestingFromStartWith
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+/**
+ * A lot of duplication here with [StatefulWorkflowEventHandlerTest]
+ */
+@OptIn(WorkflowExperimentalApi::class, WorkflowExperimentalRuntime::class)
+class StatelessWorkflowEventHandlerTest {
+  private data class Params(
+    val remember: Boolean?,
+    val runtimeConfig: RuntimeConfig
+  ) {
+    val remembering = remember ?: runtimeConfig.contains(STABLE_EVENT_HANDLERS)
+  }
+
+  private val rememberValues = sequenceOf(true, false, null)
+  private val configValues = sequenceOf(emptySet(), setOf(STABLE_EVENT_HANDLERS))
+  private val values = rememberValues.flatMap { remember ->
+    configValues.map { Params(remember, it) }
+  }
+  private val parameterizedTestRunner = ParameterizedTestRunner<Params>()
+
+  @Test fun eventHandler0() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateless<Unit, S, () -> Unit> {
+        eventHandler("", remember = params.remembering) { setOutput("yay") }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke()
+        assertEquals("yay", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler1() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateless<Unit, S, (S) -> Unit> {
+        eventHandler("", remember = params.remembering) { e1 ->
+          setOutput(e1)
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("yay")
+        assertEquals("yay", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler2() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateless<Unit, S, (S, S) -> Unit> {
+        eventHandler("", remember = params.remembering) { e1, e2 ->
+          setOutput("$e1-$e2")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b")
+        assertEquals("a-b", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler3() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateless<Unit, S, (S, S, S) -> Unit> {
+        eventHandler("", remember = params.remembering) { e1, e2, e3 ->
+          setOutput("$e1-$e2-$e3")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c")
+        assertEquals("a-b-c", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler4() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateless<Unit, S, (S, S, S, S) -> Unit> {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4 ->
+          setOutput("$e1-$e2-$e3-$e4")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d")
+        assertEquals("a-b-c-d", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler5() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateless<Unit, S, (S, S, S, S, S) -> Unit> {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4, e5 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d", "e")
+        assertEquals("a-b-c-d-e", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler6() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateless<Unit, S, (S, S, S, S, S, S) -> Unit> {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4, e5, e6 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5-$e6")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d", "e", "f")
+        assertEquals("a-b-c-d-e-f", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler7() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateless<Unit, S, (S, S, S, S, S, S, S) -> Unit> {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4, e5, e6, e7 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d", "e", "f", "g")
+        assertEquals("a-b-c-d-e-f-g", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler8() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateless<Unit, S, (S, S, S, S, S, S, S, S) -> Unit> {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4, e5, e6, e7, e8 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d", "e", "f", "g", "h")
+        assertEquals("a-b-c-d-e-f-g-h", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler9() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateless<Unit, S, (S, S, S, S, S, S, S, S, S) -> Unit> {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8-$e9")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d", "e", "f", "g", "h", "i")
+        assertEquals("a-b-c-d-e-f-g-h-i", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+
+  @Test fun eventHandler10() {
+    parameterizedTestRunner.runParametrizedTest(values) { params ->
+      Workflow.stateless<Unit, S, (S, S, S, S, S, S, S, S, S, S) -> Unit> {
+        eventHandler("", remember = params.remembering) { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
+          setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8-$e9-$e10")
+        }
+      }.launchForTestingFromStartWith(
+        testParams = WorkflowTestParams(runtimeConfig = params.runtimeConfig)
+      ) {
+        val first = awaitNextRendering()
+        first.invoke("a", "b", "c", "d", "e", "f", "g", "h", "i", "k")
+        assertEquals("a-b-c-d-e-f-g-h-i-k", awaitNextOutput())
+        val next = awaitNextRendering()
+        if (params.remembering) {
+          assertSame(first, next)
+        } else {
+          assertNotSame(first, next)
+        }
+      }
+    }
+  }
+}

--- a/workflow-testing/src/test/java/com/squareup/workflow1/StringTypeAlias.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/StringTypeAlias.kt
@@ -1,0 +1,7 @@
+package com.squareup.workflow1
+
+/**
+ * We go nuts with param types in a lot of these tests.
+ * This lets us be a bit more concise.
+ */
+internal typealias S = String


### PR DESCRIPTION
Workflow makes it very convenient to render view models with anonymous lambdas as their event handler functions. Compose hates that.

To address that mismatch without forcing everyone to retrofit their apps to use event objects instead of lambdas (it's a little late for that!) we introduce support for stable event handlers: anonymous lambdas whose identity looks the same to Compose across updates.

In order to do this we're breaking the existing `eventHandler` and `safeEventHandler` functions a bit.

- We introduce a new optional `remember: Boolean? = null` parameter. Set that true to get the new stability. If you leave it to the default `null` we look for a new `STABLE_EVENT_HANDLER : RuntimeConfigOption` to decide what to do. If you set that config option on an existing app and make no other changes, all of your existing `eventHandler` functions will be stable.

- When `remember` is true, the existing `name` parameter becomes weight bearing. It's no longer just a logging aid, it's part of a key identifying your stable lambda. The other parts of the key are its return type, and the types of any of its parameters. Duplicating a key within a particular `render()` call is a runtime error, similar to the rules for `renderChild`, `runningWorker`, and `runningSideEffect`.

- To make it easier to find fix and prevent those new runtime errors, `testRender` and `WorkflowTestParams` now accept optional `RuntimeConfig` parameters, and throw appropriate errors if `STABLE_EVENT_HANDLER` is set. `testRender` also now honors `JvmTestRuntimeConfigTools.getTestRuntimeConfig()`.

- Most of the `eventHandler` functions have also been changed to `inline` -- necessary so that we can reify their parameter types for the key scheme described above

All of this is built on a new `BaseRenderContext.remember` primitive, which provides a light weight mechanism to save a bit of state across a workflow session without having to find room for it in `StateT`.

`BaseRenderContext` also now provides `val runtimeConfig: RuntimeConfig` in support of all of the above.