### PR TITLE
`DRAIN_EXCLUSIVE_ACTIONS` implementation

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -180,6 +180,27 @@ jobs :
           build-root-directory : samples/tutorial
           restore-cache-key : main-build-artifacts
 
+  jvm-drainExclusive-runtime-test :
+    name : Conflate Stale Renderings Runtime JVM Tests
+    runs-on : ubuntu-latest
+    timeout-minutes : 20
+    steps :
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name : Check with Gradle
+        uses : ./.github/actions/gradle-task
+        with :
+          task : jvmTest --continue -Pworkflow.runtime=drainExclusive
+          restore-cache-key : main-build-artifacts
+
+      # Report as GitHub Pull Request Check.
+      - name : Publish Test Report
+        uses : mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if : always() # always run even if the previous step fails
+        with :
+          report_paths : '**/build/test-results/test/TEST-*.xml'
+
   jvm-conflate-runtime-test :
     name : Conflate Stale Renderings Runtime JVM Tests
     runs-on : ubuntu-latest
@@ -306,6 +327,111 @@ jobs :
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
+  jvm-conflate-drainExclusive-runtime-test:
+    name: Conflate Stale Renderings Runtime JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=conflate-drainExclusive
+          restore-cache-key: main-build-artifacts
+
+      # Report as GitHub Pull Request Check.
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+  jvm-stateChange-drainExclusive-runtime-test:
+    name: Render On State Change Only Runtime JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=stateChange-drainExclusive
+          restore-cache-key: main-build-artifacts
+
+      # Report as GitHub Pull Request Check.
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+  jvm-partial-drainExclusive-runtime-test:
+    name: Partial Tree Rendering Only Runtime JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=partial-drainExclusive
+          restore-cache-key: main-build-artifacts
+
+      # Report as GitHub Pull Request Check.
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+  jvm-conflate-stateChange-drainExclusive-runtime-test:
+    name: Render On State Change Only and Conflate Stale Runtime JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=conflate-stateChange-drainExclusive
+          restore-cache-key: main-build-artifacts
+
+      # Report as GitHub Pull Request Check.
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+  jvm-conflate-partial-drainExclusive-runtime-test:
+    name: Render On State Change Only and Conflate Stale Runtime JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=conflate-partial-drainExclusive
+          restore-cache-key: main-build-artifacts
+
+      # Report as GitHub Pull Request Check.
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
   ios-tests :
     name : iOS Tests
     runs-on : macos-latest
@@ -412,7 +538,7 @@ jobs :
         ### <start-connected-check-shards>
         shardNum: [ 1, 2, 3 ]
         ### <end-connected-check-shards>
-        runtime : [ conflate, stateChange, conflate-stateChange, partial, conflate-partial, stable ]
+        runtime : [ conflate, stateChange, drainExclusive, conflate-stateChange, partial, conflate-partial, stable, conflate-drainExclusive, stateChange-drainExclusive, partial-drainExclusive, conflate-partial-drainExclusive ]
     steps :
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/workflow-config/config-android/src/main/java/com/squareup/workflow1/config/AndroidRuntimeConfigTools.kt
+++ b/workflow-config/config-android/src/main/java/com/squareup/workflow1/config/AndroidRuntimeConfigTools.kt
@@ -3,6 +3,7 @@ package com.squareup.workflow1.config
 import com.squareup.workflow1.RuntimeConfig
 import com.squareup.workflow1.RuntimeConfigOptions
 import com.squareup.workflow1.RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS
+import com.squareup.workflow1.RuntimeConfigOptions.DRAIN_EXCLUSIVE_ACTIONS
 import com.squareup.workflow1.RuntimeConfigOptions.PARTIAL_TREE_RENDERING
 import com.squareup.workflow1.RuntimeConfigOptions.RENDER_ONLY_WHEN_STATE_CHANGES
 import com.squareup.workflow1.RuntimeConfigOptions.STABLE_EVENT_HANDLERS
@@ -33,6 +34,10 @@ public class AndroidRuntimeConfigTools {
      *
      * - `stable` Enables stable event handlers (changes the default value of the `remember`
      *    parameter of `RenderContext.eventHandler` functions from `false` to `true`)
+     *
+     * - `drainExclusive` Enables draining exclusive actions. If we have more actions to process
+     *    that are queued on nodes not affected by the last action application, then we will
+     *    continue to process those actions before another render pass.
      */
     @WorkflowExperimentalRuntime
     public fun getAppWorkflowRuntimeConfig(): RuntimeConfig {
@@ -48,6 +53,7 @@ public class AndroidRuntimeConfigTools {
           "stateChange" -> config.add(RENDER_ONLY_WHEN_STATE_CHANGES)
           "partial" -> config.addAll(setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING))
           "stable" -> config.add(STABLE_EVENT_HANDLERS)
+          "drainExclusive" -> config.add(DRAIN_EXCLUSIVE_ACTIONS)
           else -> throw IllegalArgumentException("Unrecognized runtime config option \"$it\"")
         }
       }

--- a/workflow-config/config-jvm/src/main/java/com/squareup/workflow1/config/JvmTestRuntimeConfigTools.kt
+++ b/workflow-config/config-jvm/src/main/java/com/squareup/workflow1/config/JvmTestRuntimeConfigTools.kt
@@ -3,6 +3,7 @@ package com.squareup.workflow1.config
 import com.squareup.workflow1.RuntimeConfig
 import com.squareup.workflow1.RuntimeConfigOptions
 import com.squareup.workflow1.RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS
+import com.squareup.workflow1.RuntimeConfigOptions.DRAIN_EXCLUSIVE_ACTIONS
 import com.squareup.workflow1.RuntimeConfigOptions.PARTIAL_TREE_RENDERING
 import com.squareup.workflow1.RuntimeConfigOptions.RENDER_ONLY_WHEN_STATE_CHANGES
 import com.squareup.workflow1.RuntimeConfigOptions.STABLE_EVENT_HANDLERS
@@ -35,6 +36,10 @@ public class JvmTestRuntimeConfigTools {
      *
      * - `stable` Enables stable event handlers (changes the default value of the `remember`
      *    parameter of `RenderContext.eventHandler` functions from `false` to `true`)
+     *
+     * - `drainExclusive` Enables draining exclusive actions. If we have more actions to process
+     *    that are queued on nodes not affected by the last action application, then we will
+     *    continue to process those actions before another render pass.
      */
     @OptIn(WorkflowExperimentalRuntime::class)
     public fun getTestRuntimeConfig(): RuntimeConfig {
@@ -50,6 +55,7 @@ public class JvmTestRuntimeConfigTools {
           "stateChange" -> config.add(RENDER_ONLY_WHEN_STATE_CHANGES)
           "partial" -> config.addAll(setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING))
           "stable" -> config.add(STABLE_EVENT_HANDLERS)
+          "drainExclusive" -> config.add(DRAIN_EXCLUSIVE_ACTIONS)
           else -> throw IllegalArgumentException("Unrecognized runtime config option \"$it\"")
         }
       }

--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -164,6 +164,7 @@ public final class com/squareup/workflow1/PropsUpdated : com/squareup/workflow1/
 public final class com/squareup/workflow1/RuntimeConfigOptions : java/lang/Enum {
 	public static final field CONFLATE_STALE_RENDERINGS Lcom/squareup/workflow1/RuntimeConfigOptions;
 	public static final field Companion Lcom/squareup/workflow1/RuntimeConfigOptions$Companion;
+	public static final field DRAIN_EXCLUSIVE_ACTIONS Lcom/squareup/workflow1/RuntimeConfigOptions;
 	public static final field PARTIAL_TREE_RENDERING Lcom/squareup/workflow1/RuntimeConfigOptions;
 	public static final field RENDER_ONLY_WHEN_STATE_CHANGES Lcom/squareup/workflow1/RuntimeConfigOptions;
 	public static final field STABLE_EVENT_HANDLERS Lcom/squareup/workflow1/RuntimeConfigOptions;

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/RuntimeConfig.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/RuntimeConfig.kt
@@ -66,6 +66,14 @@ public enum class RuntimeConfigOptions {
    */
   @WorkflowExperimentalRuntime
   STABLE_EVENT_HANDLERS,
+
+  /**
+   * If we have more actions to process that are queued on nodes not affected by the last
+   * action application, then we will continue to process those actions before another render
+   * pass.
+   */
+  @WorkflowExperimentalRuntime
+  DRAIN_EXCLUSIVE_ACTIONS,
   ;
 
   public companion object {

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
@@ -150,11 +150,14 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
    *
    * @return [Boolean] whether or not the children action queues are empty.
    */
-  fun onNextChildAction(selector: SelectBuilder<ActionProcessingResult>): Boolean {
+  fun onNextChildAction(
+    selector: SelectBuilder<ActionProcessingResult>,
+    skipChangedNodes: Boolean = false
+  ): Boolean {
     var empty = true
     children.forEachActive { child ->
       // Do this separately so the compiler doesn't avoid it if empty is already false.
-      val childEmpty = child.workflowNode.onNextAction(selector)
+      val childEmpty = child.workflowNode.onNextAction(selector, skipChangedNodes)
       empty = childEmpty && empty
     }
     return empty

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
@@ -96,7 +96,16 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   private val eventActionsChannel =
     Channel<WorkflowAction<PropsT, StateT, OutputT>>(capacity = UNLIMITED)
   private var state: StateT
-  private var subtreeStateDidChange: Boolean = true
+
+  /**
+   * The state of this node or that of one of our descendants changed.
+   */
+  private var subtreeStateDirty: Boolean = true
+
+  /**
+   * The state of this node changed.
+   */
+  private var selfStateDirty: Boolean = true
 
   private val baseRenderContext = RealRenderContext(
     renderer = subtreeManager,
@@ -212,16 +221,29 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
    *    time of suspending.
    */
   @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
-  fun onNextAction(selector: SelectBuilder<ActionProcessingResult>): Boolean {
-    // Listen for any child workflow updates.
-    var empty = subtreeManager.onNextChildAction(selector)
+  fun onNextAction(
+    selector: SelectBuilder<ActionProcessingResult>,
+    skipChangedNodes: Boolean = false
+  ): Boolean {
+    val shouldListenForEvents = !skipChangedNodes || !selfStateDirty
+
+    var empty = if (shouldListenForEvents) {
+      // Listen for any child workflow events.
+      subtreeManager.onNextChildAction(selector, skipChangedNodes)
+    } else {
+      // Our state changed and we are skipping changed nodes, so our actions are empty from
+      // this node down.
+      true
+    }
 
     empty = empty && (eventActionsChannel.isEmpty || eventActionsChannel.isClosedForReceive)
 
-    // Listen for any events.
-    with(selector) {
-      eventActionsChannel.onReceive { action ->
-        return@onReceive applyAction(action)
+    if (shouldListenForEvents) {
+      // Listen for any events.
+      with(selector) {
+        eventActionsChannel.onReceive { action ->
+          return@onReceive applyAction(action)
+        }
       }
     }
     return empty
@@ -267,7 +289,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
 
     if (!runtimeConfig.contains(PARTIAL_TREE_RENDERING) ||
       !lastRendering.isInitialized ||
-      subtreeStateDidChange
+      subtreeStateDirty
     ) {
       // If we haven't already updated the cached instance, better do it now!
       maybeUpdateCachedWorkflowInstance(workflow)
@@ -287,7 +309,8 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
       }
       // After we have rendered this subtree, we need another action in order for us to be
       // considered dirty again.
-      subtreeStateDidChange = false
+      subtreeStateDirty = false
+      selfStateDirty = false
     }
 
     return lastRendering.getOrThrow()
@@ -296,7 +319,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   /**
    * Update props if they have changed. If that happens, then check to see if we need
    * to update the cached workflow instance, then call [StatefulWorkflow.onPropsChanged] and
-   * update the state from that. We consider any change to props as [subtreeStateDidChange] because
+   * update the state from that. We consider any change to props as dirty because
    * the props themselves are used in [StatefulWorkflow.render] (they are the 'external' part of
    * the state) so we must re-render.
    */
@@ -308,7 +331,8 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
       maybeUpdateCachedWorkflowInstance(workflow)
       val newState = interceptedWorkflowInstance.onPropsChanged(lastProps, newProps, state)
       state = newState
-      subtreeStateDidChange = true
+      subtreeStateDirty = true
+      selfStateDirty = true
     }
     lastProps = newProps
   }
@@ -330,8 +354,10 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
       // Changing state is sticky, we pass it up if it ever changed.
       stateChanged = actionApplied.stateChanged || (childResult?.stateChanged ?: false)
     )
+    // Our state changed.
+    selfStateDirty = actionApplied.stateChanged
     // Our state changed or one of our children's state changed.
-    subtreeStateDidChange = aggregateActionApplied.stateChanged
+    subtreeStateDirty = aggregateActionApplied.stateChanged
     return if (actionApplied.output != null ||
       runtimeConfig.contains(PARTIAL_TREE_RENDERING)
     ) {
@@ -344,7 +370,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
       //
       // However, the root and the path down to the changed nodes must always
       // re-render now, so this is the implementation detail of how we get
-      // subtreeStateDidChange = true on that entire path to the root.
+      // subtreeStateDirty = true on that entire path to the root.
       emitAppliedActionToParent(aggregateActionApplied)
     } else {
       aggregateActionApplied

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowRunnerTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowRunnerTest.kt
@@ -5,6 +5,7 @@ import com.squareup.workflow1.NoopWorkflowInterceptor
 import com.squareup.workflow1.RuntimeConfig
 import com.squareup.workflow1.RuntimeConfigOptions
 import com.squareup.workflow1.RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS
+import com.squareup.workflow1.RuntimeConfigOptions.DRAIN_EXCLUSIVE_ACTIONS
 import com.squareup.workflow1.RuntimeConfigOptions.PARTIAL_TREE_RENDERING
 import com.squareup.workflow1.RuntimeConfigOptions.RENDER_ONLY_WHEN_STATE_CHANGES
 import com.squareup.workflow1.Worker
@@ -38,6 +39,17 @@ internal class WorkflowRunnerTest {
     setOf(CONFLATE_STALE_RENDERINGS, RENDER_ONLY_WHEN_STATE_CHANGES),
     setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING),
     setOf(CONFLATE_STALE_RENDERINGS, RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING),
+    setOf(DRAIN_EXCLUSIVE_ACTIONS),
+    setOf(RENDER_ONLY_WHEN_STATE_CHANGES, DRAIN_EXCLUSIVE_ACTIONS),
+    setOf(CONFLATE_STALE_RENDERINGS, DRAIN_EXCLUSIVE_ACTIONS),
+    setOf(CONFLATE_STALE_RENDERINGS, RENDER_ONLY_WHEN_STATE_CHANGES, DRAIN_EXCLUSIVE_ACTIONS),
+    setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING, DRAIN_EXCLUSIVE_ACTIONS),
+    setOf(
+      CONFLATE_STALE_RENDERINGS,
+      RENDER_ONLY_WHEN_STATE_CHANGES,
+      PARTIAL_TREE_RENDERING,
+      DRAIN_EXCLUSIVE_ACTIONS
+    ),
   ).asSequence()
 
   private fun setup() {

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowsLifecycleTests.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowsLifecycleTests.kt
@@ -1,6 +1,7 @@
 package com.squareup.workflow1
 
 import com.squareup.workflow1.RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS
+import com.squareup.workflow1.RuntimeConfigOptions.DRAIN_EXCLUSIVE_ACTIONS
 import com.squareup.workflow1.RuntimeConfigOptions.PARTIAL_TREE_RENDERING
 import com.squareup.workflow1.RuntimeConfigOptions.RENDER_ONLY_WHEN_STATE_CHANGES
 import com.squareup.workflow1.testing.headlessIntegrationTest
@@ -24,6 +25,17 @@ class WorkflowsLifecycleTests {
     setOf(CONFLATE_STALE_RENDERINGS, RENDER_ONLY_WHEN_STATE_CHANGES),
     setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING),
     setOf(CONFLATE_STALE_RENDERINGS, RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING),
+    setOf(DRAIN_EXCLUSIVE_ACTIONS),
+    setOf(RENDER_ONLY_WHEN_STATE_CHANGES, DRAIN_EXCLUSIVE_ACTIONS),
+    setOf(CONFLATE_STALE_RENDERINGS, DRAIN_EXCLUSIVE_ACTIONS),
+    setOf(CONFLATE_STALE_RENDERINGS, RENDER_ONLY_WHEN_STATE_CHANGES, DRAIN_EXCLUSIVE_ACTIONS),
+    setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING, DRAIN_EXCLUSIVE_ACTIONS),
+    setOf(
+      CONFLATE_STALE_RENDERINGS,
+      RENDER_ONLY_WHEN_STATE_CHANGES,
+      PARTIAL_TREE_RENDERING,
+      DRAIN_EXCLUSIVE_ACTIONS
+    ),
   ).asSequence()
 
   private val runtimeTestRunner = ParameterizedTestRunner<RuntimeConfig>()
@@ -229,7 +241,9 @@ class WorkflowsLifecycleTests {
         setState.invoke(1)
         setState.invoke(2)
         awaitNextRendering()
-        if (!runtimeConfig.contains(CONFLATE_STALE_RENDERINGS)) {
+        if (!runtimeConfig.contains(CONFLATE_STALE_RENDERINGS) &&
+          !runtimeConfig.contains(DRAIN_EXCLUSIVE_ACTIONS)
+        ) {
           // 2 rendering or 1 depending on runtime config.
           awaitNextRendering()
         }


### PR DESCRIPTION
If there are multiple actions that are prepared to be applied that are in separate (exclusive) areas of the tree, then apply them all before rendering again.

Also ensure that we track if any of the chained actions have changed state. If they have, then pass the new rendering to the UI!

Update tests to test this behavior.