### PR TITLE
Eliminates top level subprojects, allprojects gradle blocks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,17 +31,6 @@ plugins {
 
 shardConnectedCheckTasks(project)
 
-subprojects {
-
-  afterEvaluate {
-    configurations.configureEach {
-      // There could be transitive dependencies in tests with a lower version. This could cause
-      // problems with a newer Kotlin version that we use.
-      resolutionStrategy.force(libs.kotlin.reflect)
-    }
-  }
-}
-
 apply(from = rootProject.file(".buildscript/binary-validation.gradle"))
 
 // This plugin needs to be applied to the root projects for the dokkaGfmCollector task we use to
@@ -109,20 +98,6 @@ subprojects {
 subprojects {
   tasks.withType(AbstractPublishToMaven::class.java)
     .configureEach { mustRunAfter(tasks.matching { it is Sign }) }
-}
-
-allprojects {
-
-  configurations.all {
-    resolutionStrategy.eachDependency {
-      // This ensures that any time a dependency has a transitive dependency upon androidx.lifecycle,
-      // it uses the same version as the rest of the project.  This is crucial, since Androidx
-      // libraries are never in sync and lifecycle 2.4.0 introduced api-breaking changes.
-      if (requested.group == "androidx.lifecycle") {
-        useVersion(libs.versions.androidx.lifecycle.get())
-      }
-    }
-  }
 }
 
 // This task is invoked by the documentation site generator script in the main workflow project (not


### PR DESCRIPTION
Which suddenly have become a gradle race (?) with version catalog init.