### PR TITLE
replace deprecated `gradle/wrapper-validation-action` with `gradle/actions/wrapper-validation`

### DIFF
--- a/.github/actions/gradle-task/action.yml
+++ b/.github/actions/gradle-task/action.yml
@@ -91,7 +91,7 @@ runs:
           ${{runner.os}}-${{inputs.restore-cache-key}}-${{steps.hashes.outputs.lib_versions}}
           ${{runner.os}}-${{inputs.restore-cache-key}}
 
-    - uses: gradle/wrapper-validation-action@699bb18358f12c5b78b37bb0111d3a0e2276e0e2 # v2
+    - uses: gradle/actions/wrapper-validation@94baf225fe0a508e581a564467443d0e2379123b # v4
 
     # Run the actual task.  Note that this still uses gradle-build-action for more fine-grained caching.
     - name: Run ${{inputs.task}}


### PR DESCRIPTION
It's the same action, just renamed and much more current.  The rename meant that Renovate didn't recognize the update.