### PR TITLE
Makes `DialogCollator` handle redundant `scheduleUpdate` calls.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.squareup.workflow1
-VERSION_NAME=1.16.0
+VERSION_NAME=1.16.1-SNAPSHOT
 
 POM_DESCRIPTION=Square Workflow
 

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/navigation/DialogCollator.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/navigation/DialogCollator.kt
@@ -186,10 +186,13 @@ internal class DialogCollator {
     onSessionsUpdated: (List<DialogSession>) -> Unit
   ) {
     check(expectedUpdates > 0) {
-      "Each update() call must be preceded by a call to ViewEnvironment.establishDialogCollator, " +
-        "but expectedUpdates is $expectedUpdates"
+      "Each scheduleUpdates() call must be preceded by a call to" +
+        " ViewEnvironment.establishDialogCollator, but expectedUpdates is $expectedUpdates"
     }
 
+    // Under nested ComposeView instances we may get redundant updates from the
+    // same caller. Just throw away the upstream ones.
+    this.allUpdates.removeAll { it.id == id }
     this.allUpdates.add(IdAndUpdates(id, updates, onSessionsUpdated))
     if (--expectedUpdates == 0) doUpdate()
   }


### PR DESCRIPTION
If we have nested `ComposeView` instances they can trigger redundant updates from their `onAttachedToWindow()` hooks. When `DialogCollator` gets duplicate calls from `BodyAndOverlaysContainer` in that situation it throws away earlier ones to avoid creating duplicate `Dialog` windows when `doUpdate()` fires.