### PR TITLE
Revert yield() for CSR

### DIFF
--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/RenderWorkflow.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/RenderWorkflow.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.yield
 
 /**
  * Launches the [workflow] in a new coroutine in [scope] and returns a [StateFlow] of its
@@ -196,10 +195,6 @@ public fun <PropsT, OutputT, RenderingT> renderWorkflowIn(
         var conflationHasChangedState = false
         conflate@ while (isActive && actionResult is ActionApplied<*> && actionResult.output == null) {
           conflationHasChangedState = conflationHasChangedState || actionResult.stateChanged
-          // We start by yielding, because if we are on an Unconfined dispatcher, we want to give
-          // other signals (like Workers listening to the same result) a chance to get dispatched
-          // and queue their actions.
-          yield()
           // We may have more actions we can process, this rendering could be stale.
           actionResult = runner.processAction(waitForAnAction = false)
 


### PR DESCRIPTION
As it turns out, `yield()` on the `Main.Immediate` dispatcher does not drain the "inner" event loop of continuations that are queued for immediate dispatch. Instead it actually falls back to the Main dispatcher itself and dispatches with a new Runnable to the main thread.

This ensures fairness across the main thread but unfortunately it changes a previously undocumented assumption we had when using Workflow with the `Main.Immediate` dispatcher: "All workflow action processing and rendering that occurs from a single event will happen in a single main thread message frame."

In register we based some of our performance monitoring on that unwritten assumption. Adding `yield()` breaks that assumption and requires some modifications to how we monitor performance - including via an extension to the `WorkflowInterceptor` API. We are still evaluating the benefits and impacts of this, so we are not ready to release a version that has the `CONFLATE_STALE_RENDERINGS` optimization use `yield()`, yet.

As a result, we need to remove this from the `main` branch. Note that none of the tests have changed and all still pass etc.