### PR TITLE
Change publish snapshot timeout to 45 as checks taking longer now

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -11,7 +11,7 @@ jobs:
     # macos-latest is too slow. -14 will become latest in Q2 '24
     runs-on: macos-14
     if: github.repository == 'square/workflow-kotlin'
-    timeout-minutes: 35
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
We keep hitting the 35 minute publish-snapshot timeout due to tests taking a long time https://github.com/square/workflow-kotlin/actions/workflows/publish-snapshot.yml 