### PR TITLE
CSR pass old rendering, do not render again if can skip

### DIFF
--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -88,7 +88,10 @@ public final class com/squareup/workflow1/WorkflowInterceptor$RenderContextInter
 }
 
 public final class com/squareup/workflow1/WorkflowInterceptor$RenderPassSkipped : com/squareup/workflow1/WorkflowInterceptor$RuntimeLoopOutcome {
-	public static final field INSTANCE Lcom/squareup/workflow1/WorkflowInterceptor$RenderPassSkipped;
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getEndOfTick ()Z
 }
 
 public final class com/squareup/workflow1/WorkflowInterceptor$RenderPassesComplete : com/squareup/workflow1/WorkflowInterceptor$RuntimeLoopOutcome {

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/WorkflowInterceptor.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/WorkflowInterceptor.kt
@@ -157,7 +157,23 @@ public interface WorkflowInterceptor {
   ): Unit = Unit
 
   public sealed interface RuntimeLoopOutcome
-  public object RenderPassSkipped : RuntimeLoopOutcome
+
+  /**
+   * @param endOfTick This is true if this skip was the end of the loop iteration (i.e. no update
+   *        was passed to the UI. It is false otherwise. An example of when it can be false is if
+   *        we have an action that causes a state change, but then we can process more while the
+   *        `CONFLATE_STALE_RENDERINGS` optimization is enabled. We may skip rendering based on
+   *        the subsequent action not changing state, but we will need to finish the loop and update
+   *        the UI from the previous action that changed state.
+   */
+  public class RenderPassSkipped(
+    public val endOfTick: Boolean = true
+  ) : RuntimeLoopOutcome
+
+  /**
+   * @param renderingAndSnapshot This is the rendering and snapshot that was passed out of the
+   *        Workflow runtime.
+   */
   public class RenderPassesComplete<R>(
     public val renderingAndSnapshot: RenderingAndSnapshot<R>
   ) : RuntimeLoopOutcome


### PR DESCRIPTION
If there was a change from any previous rendering with CSR then we need to make sure to pass the updated rendering out of the runtime and to the UI in case the current action is the last.

However, we can still skip rendering if our current action has not actually changed state, so we do that and then pass the rendering.

Unique edge case that we only just caught. I've added a test for it that fails without this logic.