### PR TITLE
Punches up composite rendering API and demonstrates nav logging.

### DIFF
--- a/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoetryActivity.kt
+++ b/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoetryActivity.kt
@@ -17,9 +17,11 @@ import com.squareup.workflow1.config.AndroidRuntimeConfigTools
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.renderWorkflowIn
+import com.squareup.workflow1.ui.unwrap
 import com.squareup.workflow1.ui.withRegistry
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import timber.log.Timber
 
 private val viewRegistry = SampleContainers
@@ -44,13 +46,15 @@ class PoetryActivity : AppCompatActivity() {
 }
 
 class PoetryModel(savedState: SavedStateHandle) : ViewModel() {
-  val renderings: StateFlow<Screen> by lazy {
+  val renderings: Flow<Screen> by lazy {
     renderWorkflowIn(
       workflow = RealPoemsBrowserWorkflow(RealPoemWorkflow()),
       scope = viewModelScope,
       prop = 0 to 0 to Poem.allPoems,
       savedStateHandle = savedState,
       runtimeConfig = AndroidRuntimeConfigTools.getAppWorkflowRuntimeConfig()
-    )
+    ).onEach {
+      Timber.i("Navigated to %s", it.unwrap())
+    }
   }
 }

--- a/samples/containers/app-raven/src/main/java/com/squareup/sample/ravenapp/RavenActivity.kt
+++ b/samples/containers/app-raven/src/main/java/com/squareup/sample/ravenapp/RavenActivity.kt
@@ -17,10 +17,12 @@ import com.squareup.workflow1.config.AndroidRuntimeConfigTools
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.renderWorkflowIn
+import com.squareup.workflow1.ui.unwrap
 import com.squareup.workflow1.ui.withRegistry
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -53,7 +55,7 @@ class RavenActivity : AppCompatActivity() {
 class RavenModel(savedState: SavedStateHandle) : ViewModel() {
   private val running = Job()
 
-  val renderings: StateFlow<Screen> by lazy {
+  val renderings: Flow<Screen> by lazy {
     renderWorkflowIn(
       workflow = RealPoemWorkflow(),
       scope = viewModelScope,
@@ -62,6 +64,8 @@ class RavenModel(savedState: SavedStateHandle) : ViewModel() {
       runtimeConfig = AndroidRuntimeConfigTools.getAppWorkflowRuntimeConfig()
     ) {
       running.complete()
+    }.onEach {
+      Timber.i("Navigated to %s", it.unwrap())
     }
   }
 

--- a/samples/containers/common/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailScreen.kt
+++ b/samples/containers/common/src/main/java/com/squareup/sample/container/overviewdetail/OverviewDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.squareup.sample.container.overviewdetail
 
 import com.squareup.workflow1.ui.Screen
+import com.squareup.workflow1.ui.Unwrappable
 import com.squareup.workflow1.ui.navigation.BackStackScreen
 import com.squareup.workflow1.ui.navigation.plus
 
@@ -19,7 +20,7 @@ class OverviewDetailScreen<out T : Screen> private constructor(
   val overviewRendering: BackStackScreen<T>,
   val detailRendering: BackStackScreen<T>? = null,
   val selectDefault: (() -> Unit)? = null
-) : Screen {
+) : Screen, Unwrappable {
   constructor(
     overviewRendering: BackStackScreen<T>,
     detailRendering: BackStackScreen<T>
@@ -36,6 +37,12 @@ class OverviewDetailScreen<out T : Screen> private constructor(
 
   operator fun component1(): BackStackScreen<T> = overviewRendering
   operator fun component2(): BackStackScreen<T>? = detailRendering
+
+  /**
+   * For nicer logging. See the call to [unwrap][com.squareup.workflow1.ui.unwrap]
+   * in the activity.
+   */
+  override val unwrapped = detailRendering ?: overviewRendering
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/AreYouSureWorkflow.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/AreYouSureWorkflow.kt
@@ -14,6 +14,7 @@ import com.squareup.workflow1.ui.AndroidScreen
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ScreenViewFactory
 import com.squareup.workflow1.ui.ScreenViewFactory.Companion.map
+import com.squareup.workflow1.ui.Unwrappable
 import com.squareup.workflow1.ui.navigation.AlertOverlay
 import com.squareup.workflow1.ui.navigation.AlertOverlay.Button.NEGATIVE
 import com.squareup.workflow1.ui.navigation.AlertOverlay.Button.POSITIVE
@@ -37,12 +38,19 @@ object AreYouSureWorkflow :
   ): State = snapshot?.toParcelable() ?: Running
 
   class Rendering(
-    val base: Screen,
-    val alert: AlertOverlay? = null
-  ) : AndroidScreen<Rendering> {
+    private val base: Screen,
+    private val alert: AlertOverlay? = null
+  ) : AndroidScreen<Rendering>, Unwrappable {
     override val viewFactory: ScreenViewFactory<Rendering> = map { newRendering ->
       BodyAndOverlaysScreen(newRendering.base, listOfNotNull(newRendering.alert))
     }
+
+    /**
+     * For nicer logging. See the call to [unwrap][com.squareup.workflow1.ui.unwrap]
+     * in [HelloBackButtonActivity].
+     */
+    override val unwrapped: Any
+      get() = alert ?: base
   }
 
   @Parcelize

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonActivity.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonActivity.kt
@@ -15,11 +15,14 @@ import com.squareup.workflow1.config.AndroidRuntimeConfigTools
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.renderWorkflowIn
+import com.squareup.workflow1.ui.unwrap
 import com.squareup.workflow1.ui.withRegistry
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 private val viewRegistry = SampleContainers
 
@@ -39,12 +42,18 @@ class HelloBackButtonActivity : AppCompatActivity() {
       finish()
     }
   }
+
+  companion object {
+    init {
+      Timber.plant(Timber.DebugTree())
+    }
+  }
 }
 
 class HelloBackButtonModel(savedState: SavedStateHandle) : ViewModel() {
   private val running = Job()
 
-  val renderings: StateFlow<Screen> by lazy {
+  val renderings: Flow<Screen> by lazy {
     renderWorkflowIn(
       workflow = AreYouSureWorkflow,
       scope = viewModelScope,
@@ -54,6 +63,8 @@ class HelloBackButtonModel(savedState: SavedStateHandle) : ViewModel() {
       // This workflow handles the back button itself, so the activity can't.
       // Instead, the workflow emits an output to signal that it's time to shut things down.
       running.complete()
+    }.onEach {
+      Timber.i("Navigated to %s", it.unwrap())
     }
   }
 

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -226,6 +226,7 @@ public final class com/squareup/workflow1/ui/navigation/BackButtonScreen : com/s
 	public synthetic fun getContent ()Ljava/lang/Object;
 	public final fun getOnBackPressed ()Lkotlin/jvm/functions/Function0;
 	public final fun getShadow ()Z
+	public fun getUnwrapped ()Ljava/lang/Object;
 	public fun getViewFactory ()Lcom/squareup/workflow1/ui/ScreenViewFactory;
 	public synthetic fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/Container;
 	public synthetic fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/Wrapper;

--- a/workflow-ui/core-common/api/core-common.api
+++ b/workflow-ui/core-common/api/core-common.api
@@ -12,9 +12,25 @@ public final class com/squareup/workflow1/ui/CompatibleKt {
 	public static final fun compatible (Ljava/lang/Object;Ljava/lang/Object;)Z
 }
 
-public abstract interface class com/squareup/workflow1/ui/Container {
+public abstract interface class com/squareup/workflow1/ui/Composite : com/squareup/workflow1/ui/Unwrappable {
 	public abstract fun asSequence ()Lkotlin/sequences/Sequence;
+	public abstract fun getUnwrapped ()Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow1/ui/Composite$DefaultImpls {
+	public static fun getUnwrapped (Lcom/squareup/workflow1/ui/Composite;)Ljava/lang/Object;
+}
+
+public abstract interface class com/squareup/workflow1/ui/Container : com/squareup/workflow1/ui/Composite {
 	public abstract fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/Container;
+}
+
+public final class com/squareup/workflow1/ui/Container$DefaultImpls {
+	public static fun getUnwrapped (Lcom/squareup/workflow1/ui/Container;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow1/ui/ContainerKt {
+	public static final fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/squareup/workflow1/ui/EnvironmentScreen : com/squareup/workflow1/ui/Screen, com/squareup/workflow1/ui/Wrapper {
@@ -25,6 +41,7 @@ public final class com/squareup/workflow1/ui/EnvironmentScreen : com/squareup/wo
 	public fun getContent ()Lcom/squareup/workflow1/ui/Screen;
 	public synthetic fun getContent ()Ljava/lang/Object;
 	public final fun getEnvironment ()Lcom/squareup/workflow1/ui/ViewEnvironment;
+	public fun getUnwrapped ()Ljava/lang/Object;
 	public synthetic fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/Container;
 	public fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/EnvironmentScreen;
 	public synthetic fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/Wrapper;
@@ -49,6 +66,7 @@ public final class com/squareup/workflow1/ui/NamedScreen : com/squareup/workflow
 	public fun getContent ()Lcom/squareup/workflow1/ui/Screen;
 	public synthetic fun getContent ()Ljava/lang/Object;
 	public final fun getName ()Ljava/lang/String;
+	public fun getUnwrapped ()Ljava/lang/Object;
 	public fun hashCode ()I
 	public synthetic fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/Container;
 	public fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/NamedScreen;
@@ -68,6 +86,10 @@ public abstract interface class com/squareup/workflow1/ui/TextController {
 public final class com/squareup/workflow1/ui/TextControllerKt {
 	public static final fun TextController (Ljava/lang/String;)Lcom/squareup/workflow1/ui/TextController;
 	public static synthetic fun TextController$default (Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/TextController;
+}
+
+public abstract interface class com/squareup/workflow1/ui/Unwrappable {
+	public abstract fun getUnwrapped ()Ljava/lang/Object;
 }
 
 public final class com/squareup/workflow1/ui/ViewEnvironment {
@@ -138,6 +160,7 @@ public abstract interface class com/squareup/workflow1/ui/Wrapper : com/squareup
 public final class com/squareup/workflow1/ui/Wrapper$DefaultImpls {
 	public static fun asSequence (Lcom/squareup/workflow1/ui/Wrapper;)Lkotlin/sequences/Sequence;
 	public static fun getCompatibilityKey (Lcom/squareup/workflow1/ui/Wrapper;)Ljava/lang/String;
+	public static fun getUnwrapped (Lcom/squareup/workflow1/ui/Wrapper;)Ljava/lang/Object;
 }
 
 public final class com/squareup/workflow1/ui/navigation/AlertOverlay : com/squareup/workflow1/ui/navigation/ModalOverlay {
@@ -218,6 +241,7 @@ public final class com/squareup/workflow1/ui/navigation/BackStackScreen : com/sq
 	public final fun getFrames ()Ljava/util/List;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getTop ()Lcom/squareup/workflow1/ui/Screen;
+	public fun getUnwrapped ()Ljava/lang/Object;
 	public fun hashCode ()I
 	public synthetic fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/Container;
 	public fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/navigation/BackStackScreen;
@@ -241,13 +265,15 @@ public final class com/squareup/workflow1/ui/navigation/BackStackScreenKt {
 	public static synthetic fun toBackStackScreenOrNull$default (Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow1/ui/navigation/BackStackScreen;
 }
 
-public final class com/squareup/workflow1/ui/navigation/BodyAndOverlaysScreen : com/squareup/workflow1/ui/Compatible, com/squareup/workflow1/ui/Screen {
+public final class com/squareup/workflow1/ui/navigation/BodyAndOverlaysScreen : com/squareup/workflow1/ui/Compatible, com/squareup/workflow1/ui/Composite, com/squareup/workflow1/ui/Screen {
 	public fun <init> (Lcom/squareup/workflow1/ui/Screen;Ljava/util/List;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/squareup/workflow1/ui/Screen;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun asSequence ()Lkotlin/sequences/Sequence;
 	public final fun getBody ()Lcom/squareup/workflow1/ui/Screen;
 	public fun getCompatibilityKey ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOverlays ()Ljava/util/List;
+	public fun getUnwrapped ()Ljava/lang/Object;
 	public final fun mapBody (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/navigation/BodyAndOverlaysScreen;
 	public final fun mapOverlays (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/navigation/BodyAndOverlaysScreen;
 }
@@ -258,6 +284,7 @@ public final class com/squareup/workflow1/ui/navigation/FullScreenModal : com/sq
 	public fun getCompatibilityKey ()Ljava/lang/String;
 	public fun getContent ()Lcom/squareup/workflow1/ui/Screen;
 	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getUnwrapped ()Ljava/lang/Object;
 	public synthetic fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/Container;
 	public synthetic fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/Wrapper;
 	public fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/ui/navigation/FullScreenModal;
@@ -278,5 +305,6 @@ public abstract interface class com/squareup/workflow1/ui/navigation/ScreenOverl
 public final class com/squareup/workflow1/ui/navigation/ScreenOverlay$DefaultImpls {
 	public static fun asSequence (Lcom/squareup/workflow1/ui/navigation/ScreenOverlay;)Lkotlin/sequences/Sequence;
 	public static fun getCompatibilityKey (Lcom/squareup/workflow1/ui/navigation/ScreenOverlay;)Ljava/lang/String;
+	public static fun getUnwrapped (Lcom/squareup/workflow1/ui/navigation/ScreenOverlay;)Ljava/lang/Object;
 }
 

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/navigation/BodyAndOverlaysScreen.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/navigation/BodyAndOverlaysScreen.kt
@@ -2,6 +2,7 @@ package com.squareup.workflow1.ui.navigation
 
 import com.squareup.workflow1.ui.Compatible
 import com.squareup.workflow1.ui.Compatible.Companion.keyFor
+import com.squareup.workflow1.ui.Composite
 import com.squareup.workflow1.ui.Screen
 
 /**
@@ -75,8 +76,10 @@ public class BodyAndOverlaysScreen<B : Screen, O : Overlay>(
   public val body: B,
   public val overlays: List<O> = emptyList(),
   public val name: String = ""
-) : Screen, Compatible {
+) : Screen, Compatible, Composite<Any> {
   override val compatibilityKey: String = keyFor(this, name)
+
+  override fun asSequence(): Sequence<Any> = sequenceOf(body) + overlays.asSequence()
 
   public fun <S : Screen> mapBody(transform: (B) -> S): BodyAndOverlaysScreen<S, O> {
     return BodyAndOverlaysScreen(transform(body), overlays, name)

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/ContainerTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/ContainerTest.kt
@@ -1,0 +1,105 @@
+package com.squareup.workflow1.ui
+
+import com.squareup.workflow1.ui.navigation.BackStackScreen
+import com.squareup.workflow1.ui.navigation.BodyAndOverlaysScreen
+import com.squareup.workflow1.ui.navigation.Overlay
+import com.squareup.workflow1.ui.navigation.ScreenOverlay
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class ContainerTest {
+  private data class TestScreen(val id: Int = 0) : Screen
+
+  private data class TestScreenContainer<T : Screen>(
+    val children: List<T>
+  ) : Screen, Container<Screen, T> {
+    override fun asSequence(): Sequence<T> = children.asSequence()
+
+    override fun <D : Screen> map(transform: (T) -> D) =
+      TestScreenContainer(children.map(transform))
+  }
+
+  private data class TestOverlay(val id: Int = 0) : Overlay
+
+  private data class TestScreenOverlay<S : Screen>(
+    override val content: S
+  ) : ScreenOverlay<S> {
+    override fun <ContentU : Screen> map(
+      transform: (S) -> ContentU
+    ) = TestScreenOverlay(transform(content))
+  }
+
+  @Test
+  fun `unwrap returns this`() {
+    val screen = TestScreen()
+    assertSame(screen, screen.unwrap())
+  }
+
+  @Test
+  fun `unwrap returns last`() {
+    assertEquals(
+      TestScreen(2),
+      TestScreenContainer(listOf(TestScreen(0), TestScreen(1), TestScreen(2))).unwrap()
+    )
+  }
+
+  @Test
+  fun `unwrap returns deepest content from nested wrappers`() {
+    val container = TestScreenContainer(
+      listOf(
+        TestScreen(0),
+        TestScreen(1),
+        TestScreenContainer(
+          listOf(
+            TestScreen(2),
+            TestScreen(3),
+            TestScreenContainer(listOf(TestScreen(4), TestScreen(5)))
+          )
+        ),
+      )
+    )
+    assertEquals(TestScreen(5), container.unwrap())
+  }
+
+  @Test
+  fun `unwrap prefers outer last`() {
+    val container = TestScreenContainer(
+      listOf(
+        TestScreen(0),
+        TestScreenContainer(listOf(TestScreen(1), TestScreen(2), TestScreen(3))),
+        TestScreen(4),
+      )
+    )
+    assertEquals(TestScreen(4), container.unwrap())
+  }
+
+  @Test fun `can unwrap through BodyAndOverlaysScreen to Body`() {
+    val container = BodyAndOverlaysScreen(body = TestScreen(), overlays = emptyList())
+    assertEquals(TestScreen(), container.unwrap())
+  }
+
+  @Test
+  fun `can unwrap through BodyAndOverlaysScreen to an Overlay`() {
+    val container = BodyAndOverlaysScreen(
+      body = TestScreen(),
+      overlays = listOf(TestOverlay(0), TestOverlay(1))
+    )
+
+    assertEquals(TestOverlay(1), container.unwrap())
+  }
+
+  @Test
+  fun `can unwrap through BodyAndOverlaysScreen through ScreenOverlay and then some`() {
+    val container = BodyAndOverlaysScreen(
+      body = TestScreen(),
+      overlays = listOf(
+        TestOverlay(0),
+        TestOverlay(1),
+        TestScreenOverlay(BackStackScreen(TestScreen(0), TestScreen(1)))
+      )
+    )
+
+    assertEquals(TestScreen(1), container.unwrap())
+  }
+}


### PR DESCRIPTION
Introduces a few interfaces to make it easier to navigate composite rendering structures, useful for both production logging and workflow unit testing.

Updates some samples (hellobackbutton, ravenapp and poetryapp) to demonstrate their use for navigation logging.

For example, from this naive snippet in  `HelloBackButtonActivity`:

```kotlin
    }.onEach {
      Timber.i("Navigated to %s", it.unwrap())
    }
```

we get this very useful logcat:

```
Navigated to HelloBackButtonScreen(message=Able, onClick=Function0<kotlin.Unit>, onBackPressed=null)
Navigated to HelloBackButtonScreen(message=Baker, onClick=Function0<kotlin.Unit>, onBackPressed=Function0<kotlin.Unit>)
Navigated to HelloBackButtonScreen(message=Charlie, onClick=Function0<kotlin.Unit>, onBackPressed=Function0<kotlin.Unit>)
Navigated to HelloBackButtonScreen(message=Baker, onClick=Function0<kotlin.Unit>, onBackPressed=Function0<kotlin.Unit>)
Navigated to HelloBackButtonScreen(message=Able, onClick=Function0<kotlin.Unit>, onBackPressed=null)
Navigated to AlertOverlay(buttons={POSITIVE=I'm Positive, NEGATIVE=Negatory}, message=Are you sure you want to do this thing?, title=, cancelable=true, onEvent=Function1<com.squareup.workflow1.ui.navigation.AlertOverlay$Event, kotlin.Unit>)
```

Emphasis on the naive. To keep the samples simple I didn't debounce anything, so in a more complex app you'd actually see a "Navigate to…" each time you update something in place. But that's a trivial fix:

```kotlin
    ).onEach {
      NavLogger.log(it)
    }
  }

  private object NavLogger {
    var lastKey = ""

    fun log(dest: Any) {
      val unwrapped = dest.unwrap()
      Compatible.keyFor(unwrapped).takeIf { it != lastKey }?.let { newKey ->
        Timber.i("Navigated to: %s", unwrapped)
        lastKey = newKey
      }
    }
  }
```