### PR TITLE
Tweak to default `onNavigate()`

### DIFF
--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/navigation/NavigationMonitor.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/navigation/NavigationMonitor.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.onEach
  */
 public class NavigationMonitor(
   skipFirstScreen: Boolean = false,
-  private val onNavigate: (Any) -> Unit = { println(it) }
+  private val onNavigate: (Any) -> Unit = { println(Compatible.keyFor(it)) }
 ) {
   @Volatile
   private var lastKey: String? = if (skipFirstScreen) null else ""


### PR DESCRIPTION
Log `keyFor(it)` by default instead of `it.toString()`. Latter is almost guaranteed to be noisy and inefficient.