### PR TITLE
No Strict Mode for Workflow Trace Viewer

### DIFF
--- a/build-logic/src/main/java/com/squareup/workflow1/buildsrc/KotlinCommonSettings.kt
+++ b/build-logic/src/main/java/com/squareup/workflow1/buildsrc/KotlinCommonSettings.kt
@@ -33,6 +33,7 @@ fun Project.kotlinCommonSettings(bomConfigurationName: String) {
   tasks.withType(KotlinCompile::class.java).configureEach { kotlinCompile ->
     kotlinCompile.apply {
       if (!(path.startsWith(":samples") || path.startsWith(":benchmarks") ||
+          path.startsWith(":workflow-trace-viewer") ||
           name.contains("test", ignoreCase = true))
       ) {
         explicitApiMode.set(Strict)


### PR DESCRIPTION
Added by https://github.com/square/workflow-kotlin/pull/1322 and we do not need strict mode there.