### PR TITLE
Introduces Activity.workflowContentView, workflowContentViewOrNull

### DIFF
--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoetryActivity.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoetryActivity.kt
@@ -1,7 +1,6 @@
 package com.squareup.benchmarks.performance.complex.poetry
 
 import android.content.pm.ApplicationInfo
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -26,9 +25,9 @@ import com.squareup.workflow1.WorkflowInterceptor
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ViewEnvironment.Companion.EMPTY
 import com.squareup.workflow1.ui.ViewRegistry
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.renderWorkflowIn
 import com.squareup.workflow1.ui.withEnvironment
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -97,13 +96,9 @@ class PerformancePoetryActivity : AppCompatActivity() {
       model.renderings
     }
 
-    setContentView(
-      WorkflowLayout(this).apply {
-        take(
-          lifecycle,
-          instrumentedRenderings.map { it.withEnvironment(viewEnvironment) }
-        )
-      }
+    workflowContentView.take(
+      lifecycle,
+      instrumentedRenderings.map { it.withEnvironment(viewEnvironment) }
     )
 
     // We can report this here as the first rendering from the Workflow is rendered synchronously.
@@ -125,7 +120,7 @@ class PerformancePoetryActivity : AppCompatActivity() {
     val traceMain = intent.getBooleanExtra(EXTRA_TRACE_ALL_MAIN_THREAD_MESSAGES, false)
     val traceSelectOnTimeout = intent.getBooleanExtra(EXTRA_TRACE_SELECT_TIMEOUTS, false)
     val areTracingViaMainLooperCurrently = traceMain || traceSelectOnTimeout
-    val ableToTrace = Build.VERSION.SDK_INT != 28 && (debuggable || profileable)
+    val ableToTrace = debuggable || profileable
 
     if (areTracingViaMainLooperCurrently && ableToTrace) {
       // Add main message tracing to see everything happening in Perfetto.

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloBindingActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloBindingActivity.kt
@@ -15,11 +15,11 @@ import com.squareup.workflow1.mapRendering
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewRegistry
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.compose.withComposeInteropSupport
 import com.squareup.workflow1.ui.plus
 import com.squareup.workflow1.ui.renderWorkflowIn
 import com.squareup.workflow1.ui.withEnvironment
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.flow.StateFlow
 
 private val viewEnvironment =
@@ -37,13 +37,9 @@ class HelloBindingActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
 
     val model: HelloBindingModel by viewModels()
-    setContentView(
-      WorkflowLayout(this).apply {
-        take(
-          lifecycle = lifecycle,
-          renderings = model.renderings,
-        )
-      }
+    workflowContentView.take(
+      lifecycle = lifecycle,
+      renderings = model.renderings,
     )
   }
 

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/HelloComposeWorkflowActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/HelloComposeWorkflowActivity.kt
@@ -13,19 +13,17 @@ import com.squareup.workflow1.config.AndroidRuntimeConfigTools
 import com.squareup.workflow1.mapRendering
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ViewEnvironment
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.compose.withComposeInteropSupport
 import com.squareup.workflow1.ui.renderWorkflowIn
 import com.squareup.workflow1.ui.withEnvironment
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.flow.StateFlow
 
 class HelloComposeWorkflowActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     val model: HelloComposeModel by viewModels()
-    setContentView(
-      WorkflowLayout(this).apply { take(lifecycle, model.renderings) }
-    )
+    workflowContentView.take(lifecycle, model.renderings)
   }
 
   class HelloComposeModel(savedState: SavedStateHandle) : ViewModel() {

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingActivity.kt
@@ -13,10 +13,10 @@ import com.squareup.workflow1.config.AndroidRuntimeConfigTools
 import com.squareup.workflow1.mapRendering
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ViewEnvironment
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.compose.withComposeInteropSupport
 import com.squareup.workflow1.ui.renderWorkflowIn
 import com.squareup.workflow1.ui.withEnvironment
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -27,9 +27,7 @@ class InlineRenderingActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
 
     val model: HelloBindingModel by viewModels()
-    setContentView(
-      WorkflowLayout(this).apply { take(lifecycle, model.renderings) }
-    )
+    workflowContentView.take(lifecycle, model.renderings)
   }
 
   class HelloBindingModel(savedState: SavedStateHandle) : ViewModel() {

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/NestedRenderingsActivity.kt
@@ -16,11 +16,11 @@ import com.squareup.workflow1.mapRendering
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewRegistry
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.compose.withComposeInteropSupport
 import com.squareup.workflow1.ui.plus
 import com.squareup.workflow1.ui.renderWorkflowIn
 import com.squareup.workflow1.ui.withEnvironment
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.flow.StateFlow
 
 private val viewRegistry = ViewRegistry(RecursiveComposableFactory)
@@ -38,14 +38,7 @@ class NestedRenderingsActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
 
     val model: NestedRenderingsModel by viewModels()
-    setContentView(
-      WorkflowLayout(this).apply {
-        take(
-          lifecycle = lifecycle,
-          renderings = model.renderings,
-        )
-      }
-    )
+    workflowContentView.take(lifecycle = lifecycle, renderings = model.renderings)
   }
 
   class NestedRenderingsModel(savedState: SavedStateHandle) : ViewModel() {

--- a/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoetryActivity.kt
+++ b/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoetryActivity.kt
@@ -15,10 +15,10 @@ import com.squareup.sample.poetry.model.Poem
 import com.squareup.workflow1.WorkflowExperimentalRuntime
 import com.squareup.workflow1.config.AndroidRuntimeConfigTools
 import com.squareup.workflow1.ui.Screen
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.navigation.reportNavigation
 import com.squareup.workflow1.ui.renderWorkflowIn
 import com.squareup.workflow1.ui.withRegistry
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
@@ -30,11 +30,7 @@ class PoetryActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
 
     val model: PoetryModel by viewModels()
-    setContentView(
-      WorkflowLayout(this).apply {
-        take(lifecycle, model.renderings.map { it.withRegistry(viewRegistry) })
-      }
-    )
+    workflowContentView.take(lifecycle, model.renderings.map { it.withRegistry(viewRegistry) })
   }
 
   companion object {

--- a/samples/containers/app-raven/src/main/java/com/squareup/sample/ravenapp/RavenActivity.kt
+++ b/samples/containers/app-raven/src/main/java/com/squareup/sample/ravenapp/RavenActivity.kt
@@ -15,10 +15,10 @@ import com.squareup.sample.poetry.model.Raven
 import com.squareup.workflow1.WorkflowExperimentalRuntime
 import com.squareup.workflow1.config.AndroidRuntimeConfigTools
 import com.squareup.workflow1.ui.Screen
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.navigation.reportNavigation
 import com.squareup.workflow1.ui.renderWorkflowIn
 import com.squareup.workflow1.ui.withRegistry
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -32,11 +32,7 @@ class RavenActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
 
     val model: RavenModel by viewModels()
-    setContentView(
-      WorkflowLayout(this).apply {
-        take(lifecycle, model.renderings.map { it.withRegistry(viewRegistry) })
-      }
-    )
+    workflowContentView.take(lifecycle, model.renderings.map { it.withRegistry(viewRegistry) })
 
     lifecycleScope.launch {
       model.waitForExit()

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonActivity.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonActivity.kt
@@ -13,10 +13,10 @@ import com.squareup.sample.container.SampleContainers
 import com.squareup.workflow1.WorkflowExperimentalRuntime
 import com.squareup.workflow1.config.AndroidRuntimeConfigTools
 import com.squareup.workflow1.ui.Screen
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.navigation.reportNavigation
 import com.squareup.workflow1.ui.renderWorkflowIn
 import com.squareup.workflow1.ui.withRegistry
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -30,11 +30,7 @@ class HelloBackButtonActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
 
     val model: HelloBackButtonModel by viewModels()
-    setContentView(
-      WorkflowLayout(this).apply {
-        take(lifecycle, model.renderings.map { it.withRegistry(viewRegistry) })
-      }
-    )
+    workflowContentView.take(lifecycle, model.renderings.map { it.withRegistry(viewRegistry) })
 
     lifecycleScope.launch {
       model.waitForExit()

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonActivity.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonActivity.kt
@@ -3,8 +3,8 @@ package com.squareup.sample.dungeon
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.withRegistry
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.flow.map
 
 class DungeonActivity : AppCompatActivity() {
@@ -16,9 +16,7 @@ class DungeonActivity : AppCompatActivity() {
     val component = Component(this)
     val model: TimeMachineModel by viewModels { component.timeMachineModelFactory }
 
-    val contentView = WorkflowLayout(this).apply {
-      take(lifecycle, model.renderings.map { it.withRegistry(component.viewRegistry) })
-    }
-    setContentView(contentView)
+    workflowContentView
+      .take(lifecycle, model.renderings.map { it.withRegistry(component.viewRegistry) })
   }
 }

--- a/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflowActivity.kt
+++ b/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflowActivity.kt
@@ -10,8 +10,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.squareup.workflow1.WorkflowExperimentalRuntime
 import com.squareup.workflow1.config.AndroidRuntimeConfigTools
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.renderWorkflowIn
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.flow.StateFlow
 
 class HelloWorkflowActivity : AppCompatActivity() {
@@ -22,9 +22,7 @@ class HelloWorkflowActivity : AppCompatActivity() {
     // by the first call to viewModels(), and that original instance is returned by
     // succeeding calls.
     val model: HelloViewModel by viewModels()
-    setContentView(
-      WorkflowLayout(this).apply { take(lifecycle, model.renderings) }
-    )
+    workflowContentView.take(lifecycle, model.renderings)
   }
 }
 

--- a/samples/nested-overlays/src/main/java/com/squareup/sample/nestedoverlays/NestedOverlaysActivity.kt
+++ b/samples/nested-overlays/src/main/java/com/squareup/sample/nestedoverlays/NestedOverlaysActivity.kt
@@ -11,8 +11,8 @@ import androidx.lifecycle.viewModelScope
 import com.squareup.workflow1.WorkflowExperimentalRuntime
 import com.squareup.workflow1.config.AndroidRuntimeConfigTools
 import com.squareup.workflow1.ui.Screen
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.renderWorkflowIn
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.flow.StateFlow
 
 class NestedOverlaysActivity : AppCompatActivity() {
@@ -23,9 +23,7 @@ class NestedOverlaysActivity : AppCompatActivity() {
     // by the first call to viewModels(), and that original instance is returned by
     // succeeding calls.
     val model: NestedOverlaysViewModel by viewModels()
-    setContentView(
-      WorkflowLayout(this).apply { take(lifecycle, model.renderings) }
-    )
+    workflowContentView.take(lifecycle, model.renderings)
   }
 }
 

--- a/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityActivity.kt
+++ b/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityActivity.kt
@@ -11,8 +11,8 @@ import androidx.lifecycle.viewModelScope
 import com.squareup.workflow1.WorkflowExperimentalRuntime
 import com.squareup.workflow1.config.AndroidRuntimeConfigTools
 import com.squareup.workflow1.ui.Screen
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.renderWorkflowIn
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.flow.StateFlow
 
 class StubVisibilityActivity : AppCompatActivity() {
@@ -20,9 +20,7 @@ class StubVisibilityActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
 
     val model: StubVisibilityModel by viewModels()
-    setContentView(
-      WorkflowLayout(this).apply { take(lifecycle, model.renderings) }
-    )
+    workflowContentView.take(lifecycle, model.renderings)
   }
 }
 

--- a/samples/tictactoe/app/src/main/java/com/squareup/sample/mainactivity/TicTacToeActivity.kt
+++ b/samples/tictactoe/app/src/main/java/com/squareup/sample/mainactivity/TicTacToeActivity.kt
@@ -8,9 +8,9 @@ import androidx.test.espresso.IdlingResource
 import com.squareup.sample.authworkflow.AuthViewFactories
 import com.squareup.sample.container.SampleContainers
 import com.squareup.sample.gameworkflow.TicTacToeViewFactories
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.plus
 import com.squareup.workflow1.ui.withRegistry
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -27,11 +27,7 @@ class TicTacToeActivity : AppCompatActivity() {
 
     idlingResource = component.idlingResource
 
-    setContentView(
-      WorkflowLayout(this).apply {
-        take(lifecycle, model.renderings.map { it.withRegistry(viewRegistry) })
-      }
-    )
+    workflowContentView.take(lifecycle, model.renderings.map { it.withRegistry(viewRegistry) })
 
     lifecycleScope.launch {
       model.renderings.collect { Timber.d("rendering: %s", it) }

--- a/samples/todo-android/app/src/main/java/com/squareup/sample/todo/ToDoActivity.kt
+++ b/samples/todo-android/app/src/main/java/com/squareup/sample/todo/ToDoActivity.kt
@@ -14,9 +14,9 @@ import com.squareup.workflow1.config.AndroidRuntimeConfigTools
 import com.squareup.workflow1.diagnostic.tracing.TracingWorkflowInterceptor
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ViewRegistry
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.renderWorkflowIn
 import com.squareup.workflow1.ui.withRegistry
+import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import java.io.File
@@ -28,14 +28,11 @@ class ToDoActivity : AppCompatActivity() {
 
     val model: ToDoModel by viewModels()
 
-    setContentView(
-      WorkflowLayout(this).apply {
-        take(
-          lifecycle,
-          model.ensureWorkflow(traceFilesDir = filesDir).map { it.withRegistry(viewRegistry) }
-        )
-      }
-    )
+    workflowContentView
+      .take(
+        lifecycle,
+        model.ensureWorkflow(traceFilesDir = filesDir).map { it.withRegistry(viewRegistry) }
+      )
   }
 
   private companion object {

--- a/workflow-ui/core-android/api/core-android.api
+++ b/workflow-ui/core-android/api/core-android.api
@@ -1,3 +1,8 @@
+public final class com/squareup/workflow1/ui/ActivityWorkflowContentViewKt {
+	public static final fun getWorkflowContentView (Landroid/app/Activity;)Lcom/squareup/workflow1/ui/WorkflowLayout;
+	public static final fun getWorkflowContentViewOrNull (Landroid/app/Activity;)Lcom/squareup/workflow1/ui/WorkflowLayout;
+}
+
 public final class com/squareup/workflow1/ui/AndroidRenderWorkflowKt {
 	public static final fun removeWorkflowState (Landroidx/lifecycle/SavedStateHandle;)V
 	public static final fun renderWorkflowIn (Lcom/squareup/workflow1/Workflow;Lkotlinx/coroutines/CoroutineScope;Landroidx/lifecycle/SavedStateHandle;Ljava/util/List;Ljava/util/Set;Lcom/squareup/workflow1/WorkflowTracer;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/StateFlow;

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/AndroidRenderWorkflowInTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/AndroidRenderWorkflowInTest.kt
@@ -38,9 +38,7 @@ internal class AndroidRenderWorkflowInTest {
         savedStateHandle = model.savedStateHandle
       )
 
-      val layout = WorkflowLayout(activity)
-      activity.setContentView(layout)
-
+      val layout = activity.workflowContentView
       assertThat(model.savedStateHandle.contains(KEY)).isFalse()
 
       job = layout.take(activity.lifecycle, renderings)

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/navigation/DialogIntegrationTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/navigation/DialogIntegrationTest.kt
@@ -22,8 +22,8 @@ import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ScreenViewFactory
 import com.squareup.workflow1.ui.ScreenViewHolder
 import com.squareup.workflow1.ui.ViewEnvironment
-import com.squareup.workflow1.ui.WorkflowLayout
 import com.squareup.workflow1.ui.withEnvironment
+import com.squareup.workflow1.ui.workflowContentView
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -76,9 +76,7 @@ internal class DialogIntegrationTest {
     )
 
     scenario.onActivity { activity ->
-      val root = WorkflowLayout(activity)
-      activity.setContentView(root)
-      root.show(screen)
+      activity.workflowContentView.show(screen)
     }
     onView(withText("content")).inRoot(isDialog()).check(matches(isDisplayed()))
 
@@ -92,12 +90,9 @@ internal class DialogIntegrationTest {
       ContentRendering("body"),
       listOf(DialogRendering("dialog", ContentRendering("content")))
     )
-    lateinit var root: WorkflowLayout
 
     scenario.onActivity { activity ->
-      root = WorkflowLayout(activity)
-      activity.setContentView(root)
-      root.show(oneDialog)
+      activity.workflowContentView.show(oneDialog)
     }
 
     val dialog2 = DialogRendering("dialog2", ContentRendering("content2"))
@@ -109,8 +104,8 @@ internal class DialogIntegrationTest {
       )
     )
 
-    scenario.onActivity {
-      root.show(twoDialogs)
+    scenario.onActivity { activity ->
+      activity.workflowContentView.show(twoDialogs)
       val lastOverlay = latestDialog?.overlay
       assertThat(lastOverlay).isEqualTo(dialog2)
     }
@@ -128,12 +123,8 @@ internal class DialogIntegrationTest {
       listOf(DialogRendering("dialog", ContentRendering("content")))
     ).withEnvironment(stickyEnvironment)
 
-    lateinit var root: WorkflowLayout
-
     scenario.onActivity { activity ->
-      root = WorkflowLayout(activity)
-      activity.setContentView(root)
-      root.show(oneDialog)
+      activity.workflowContentView.show(oneDialog)
     }
 
     val dialog2 = DialogRendering("dialog2", ContentRendering("content2"))
@@ -145,8 +136,8 @@ internal class DialogIntegrationTest {
       )
     ).withEnvironment(stickyEnvironment)
 
-    scenario.onActivity {
-      root.show(twoDialogs)
+    scenario.onActivity { activity ->
+      activity.workflowContentView.show(twoDialogs)
       val lastOverlay = latestDialog?.overlay
       assertThat(lastOverlay).isEqualTo(dialog2)
     }
@@ -158,18 +149,15 @@ internal class DialogIntegrationTest {
     val overlayZero = DialogRendering("dialog0", ContentRendering("content"))
     val overlayOne = DialogRendering("dialog1", ContentRendering("content"))
     val showingBoth = BodyAndOverlaysScreen(body, listOf(overlayZero, overlayOne))
-    lateinit var root: WorkflowLayout
     lateinit var originalDialogOne: Dialog
     scenario.onActivity { activity ->
-      root = WorkflowLayout(activity)
-      activity.setContentView(root)
-      root.show(showingBoth)
+      activity.workflowContentView.show(showingBoth)
       originalDialogOne = latestDialog!!
       assertThat(originalDialogOne.overlayOrNull).isSameInstanceAs(overlayOne)
     }
     val closedZero = BodyAndOverlaysScreen(body, listOf(overlayOne))
-    scenario.onActivity {
-      root.show(closedZero)
+    scenario.onActivity { activity ->
+      activity.workflowContentView.show(closedZero)
       assertThat(latestDialog!!.overlayOrNull).isSameInstanceAs(overlayOne)
       assertThat(latestDialog).isSameInstanceAs(originalDialogOne)
     }
@@ -182,9 +170,7 @@ internal class DialogIntegrationTest {
     )
 
     scenario.onActivity { activity ->
-      val root = WorkflowLayout(activity)
-      activity.setContentView(root)
-      root.show(screen)
+      activity.workflowContentView.show(screen)
     }
     onView(withText("content")).inRoot(isDialog()).check(matches(isDisplayed()))
 

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ActivityWorkflowContentView.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/ActivityWorkflowContentView.kt
@@ -1,0 +1,24 @@
+package com.squareup.workflow1.ui
+
+import android.app.Activity
+import android.view.View
+
+/**
+ * Returns the [WorkflowLayout] serving as the [contentView][Activity.setContentView]
+ * of the receiving [Activity], creating it (and replacing the existing view) if
+ * necessary.
+ */
+val Activity.workflowContentView: WorkflowLayout
+  get() {
+    return workflowContentViewOrNull ?: WorkflowLayout(this).also {
+      it.id = R.id.workflow_content_view
+      setContentView(it)
+    }
+  }
+
+/**
+ * Returns the [WorkflowLayout] serving as the [contentView][Activity.setContentView]
+ * of the receiving [Activity], or null if there isn't one.
+ */
+val Activity.workflowContentViewOrNull: WorkflowLayout?
+  get() = (findViewById<View>(R.id.workflow_content_view) as? WorkflowLayout)

--- a/workflow-ui/core-android/src/main/res/values/ids.xml
+++ b/workflow-ui/core-android/src/main/res/values/ids.xml
@@ -21,6 +21,8 @@
   <item name="workflow_back_stack_container" type="id"/>
   <!-- ID used by BodyAndModalsContainer to opt in to view persistence. -->
   <item name="workflow_body_and_modals_container" type="id"/>
+  <!-- id used by WorkflowLayout managed by Activity.workflowContentView. -->
+  <item name="workflow_content_view" type="id"/>
   <!-- Default id used by WorkflowLayout to opt in to view persistence. -->
   <item name="workflow_layout" type="id"/>
   <!-- View Tag for the ViewEnvironment that last updated this view. -->


### PR DESCRIPTION
Simplifies creating a `WorkflowLayout` and using it as the `contentView` of an `Activity`. Written with an eye toward making it easy to hand off from one workflow runtime to another, or doing something like `activity.workflowContentView.show(LoadingScreen)` before any workflow runtime is put in place.
