### PR TITLE
1340: Changing `RenderContext` from an inner class to a nested class with its own generics

### DIFF
--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/MaybeLoadingGatekeeperWorkflow.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/MaybeLoadingGatekeeperWorkflow.kt
@@ -27,7 +27,7 @@ class MaybeLoadingGatekeeperWorkflow<T : Any>(
   override fun render(
     renderProps: Unit,
     renderState: IsLoading,
-    context: RenderContext
+    context: RenderContext<Unit, IsLoading, Unit>
   ): MayBeLoadingScreen {
     context.runningWorker(isLoading.asTraceableWorker("GatekeeperLoading")) {
       action("GatekeeperLoading") {

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemWorkflow.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemWorkflow.kt
@@ -96,7 +96,7 @@ class PerformancePoemWorkflow(
   override fun render(
     renderProps: Poem,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Poem, State, ClosePoem>
   ): OverviewDetailScreen<*> {
     if (simulatedPerfConfig.simultaneousActions > 0) {
       repeat(simulatedPerfConfig.simultaneousActions) { index ->

--- a/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemsBrowserWorkflow.kt
+++ b/benchmarks/performance-poetry/complex-poetry/src/main/java/com/squareup/benchmarks/performance/complex/poetry/PerformancePoemsBrowserWorkflow.kt
@@ -86,7 +86,7 @@ class PerformancePoemsBrowserWorkflow(
   override fun render(
     renderProps: ConfigAndPoems,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<ConfigAndPoems, State, Unit>
   ): OverviewDetailScreen<*> {
     when (renderState) {
       is Recurse -> {

--- a/design-docs/compose-based-workflows-design.md
+++ b/design-docs/compose-based-workflows-design.md
@@ -282,7 +282,7 @@ A more interesting, comprehensive example that ties this in with the First Primi
 ```kotlin
 class IdentityWorkflow(
   private val child: Workflow<Props, Output, Rendering>
-) : StatelessWorkflow<Props, Output, Rendering {
+) : StatelessWorkflow<Props, Output, Rendering> {
   override fun render(props: Props, context: RenderContext): Rendering {
     return context.renderComposable {
       renderWorkflow(child, props, onOutput = { output ->
@@ -379,8 +379,7 @@ public abstract class ComposeWorkflow<
 To implement the `Workflow` interface, we need to have a function that returns a `StatefulWorkflow` with the actual implementation. That's trivial: we just return a really simple workflow that does nothing but call `renderComposable` from above in its render method:
 
 ```kotlin
-  private inner class ComposeWorkflowWrapper :
-    StatefulWorkflow<PropsT, Unit, OutputT, RenderingT>() {
+  inner class ComposeWorkflowWrapper : StatefulWorkflow<PropsT, Unit, OutputT, RenderingT>() {
 
     override fun initialState(
       props: PropsT,
@@ -392,7 +391,7 @@ To implement the `Workflow` interface, we need to have a function that returns a
     override fun render(
       renderProps: PropsT,
       renderState: Unit,
-      context: RenderContext
+      context: StatefulWorkflow.RenderContext<PropsT,Unit,OutputT>
     ): RenderingT = context.renderComposable {
       // Explicitly remember the output function since we know that actionSink
       // is stable even though Compose might not know that.

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/HelloComposeWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/HelloComposeWorkflow.kt
@@ -32,7 +32,7 @@ object HelloComposeWorkflow : StatefulWorkflow<Unit, State, Nothing, HelloCompos
   override fun render(
     renderProps: Unit,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Unit, State, Nothing>
   ): HelloComposeScreen = HelloComposeScreen(
     message = renderState.name,
     onClick = { context.actionSink.send(helloAction) }

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposebinding/HelloWorkflow.kt
@@ -39,7 +39,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
   override fun render(
     renderProps: Unit,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Unit, State, Nothing>
   ): Rendering {
     return Rendering(
       message = renderState.name,

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/ComposeWorkflowImpl.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/ComposeWorkflowImpl.kt
@@ -59,7 +59,7 @@ internal class ComposeWorkflowImpl<PropsT, OutputT : Any>(
   override fun render(
     renderProps: PropsT,
     renderState: State<PropsT, OutputT>,
-    context: RenderContext
+    context: RenderContext<PropsT, State<PropsT, OutputT>, OutputT>
   ): ComposeScreen {
     // The first render pass needs to cache the sink. The sink is reusable, so we can just pass the
     // same one every time.

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/HelloWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocomposeworkflow/HelloWorkflow.kt
@@ -37,7 +37,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, ComposeScreen>() {
   override fun render(
     renderProps: Unit,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Unit, State, Nothing>
   ): ComposeScreen =
     context.renderChild(HelloComposeWorkflow, renderState.name) { helloAction }
 

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
@@ -35,7 +35,7 @@ object InlineRenderingWorkflow : StatefulWorkflow<Unit, Int, Nothing, Screen>() 
   override fun render(
     renderProps: Unit,
     renderState: Int,
-    context: RenderContext
+    context: RenderContext<Unit, Int, Nothing>
   ): ComposeScreen {
     val onClick = context.eventHandler("increment") { state += 1 }
     return ComposeScreen {

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/RecursiveWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/nestedrenderings/RecursiveWorkflow.kt
@@ -57,7 +57,7 @@ object RecursiveWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>() {
   override fun render(
     renderProps: Unit,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Unit, State, Nothing>
   ): Rendering {
     return Rendering(
       children = List(renderState.children) { i ->

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/TextInputWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/textinput/TextInputWorkflow.kt
@@ -33,7 +33,7 @@ object TextInputWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
   override fun render(
     renderProps: Unit,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Unit, State, Nothing>
   ): Rendering = Rendering(
     textController = if (renderState.showingTextA) renderState.textA else renderState.textB,
     onSwapText = { context.actionSink.send(swapText) }

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/AreYouSureWorkflow.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/AreYouSureWorkflow.kt
@@ -30,8 +30,7 @@ import kotlinx.parcelize.Parcelize
  * Wraps [HelloBackButtonWorkflow] to (sometimes) pop a confirmation alert when the back
  * button is pressed.
  */
-object AreYouSureWorkflow :
-  StatefulWorkflow<Unit, State, Finished, Rendering>() {
+object AreYouSureWorkflow : StatefulWorkflow<Unit, State, Finished, Rendering>() {
   override fun initialState(
     props: Unit,
     snapshot: Snapshot?
@@ -64,7 +63,7 @@ object AreYouSureWorkflow :
   override fun render(
     renderProps: Unit,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Unit, State, Finished>
   ): Rendering {
     val ableBakerCharlie = context.renderChild(HelloBackButtonWorkflow, Unit) { noAction() }
 

--- a/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
+++ b/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonWorkflow.kt
@@ -28,7 +28,7 @@ object HelloBackButtonWorkflow : StatefulWorkflow<Unit, State, Nothing, HelloBac
   override fun render(
     renderProps: Unit,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Unit, State, Nothing>
   ): HelloBackButtonScreen {
     return HelloBackButtonScreen(
       message = "$renderState",

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemListWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemListWorkflow.kt
@@ -16,7 +16,7 @@ object PoemListWorkflow : StatelessWorkflow<Props, Int, PoemListScreen>() {
 
   override fun render(
     renderProps: Props,
-    context: RenderContext
+    context: RenderContext<Props, Int>
   ): PoemListScreen {
     return PoemListScreen(
       poems = renderProps.poems,

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/RealPoemWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/RealPoemWorkflow.kt
@@ -38,7 +38,7 @@ class RealPoemWorkflow : PoemWorkflow,
   override fun render(
     renderProps: Poem,
     renderState: SelectedStanza,
-    context: RenderContext
+    context: RenderContext<Poem, SelectedStanza, ClosePoem>
   ): OverviewDetailScreen<*> {
     val previousStanzas: List<StanzaScreen> =
       if (renderState == NO_SELECTED_STANZA) {

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/RealPoemsBrowserWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/RealPoemsBrowserWorkflow.kt
@@ -37,7 +37,7 @@ class RealPoemsBrowserWorkflow(
   override fun render(
     renderProps: ConfigAndPoems,
     renderState: SelectedPoem,
-    context: RenderContext
+    context: RenderContext<ConfigAndPoems, SelectedPoem, Unit>
   ): OverviewDetailScreen<*> {
     val poems =
       context.renderChild(PoemListWorkflow, Props(poems = renderProps.second)) { selected ->

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
@@ -22,7 +22,7 @@ object StanzaListWorkflow : StatelessWorkflow<Props, SelectedStanza, StanzaListS
 
   override fun render(
     renderProps: Props,
-    context: RenderContext
+    context: RenderContext<Props, SelectedStanza>
   ): StanzaListScreen {
     val poem = renderProps.poem
     return StanzaListScreen(

--- a/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
+++ b/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
@@ -23,7 +23,7 @@ object StanzaWorkflow : StatelessWorkflow<Props, Output, StanzaScreen>() {
 
   override fun render(
     renderProps: Props,
-    context: RenderContext
+    context: RenderContext<Props, Output>
   ): StanzaScreen {
     with(renderProps) {
       val onGoBack: (() -> Unit)? = when (index) {

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
@@ -41,7 +41,7 @@ class DungeonAppWorkflow(
   override fun render(
     renderProps: Props,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Props, State, Nothing>
   ): BodyAndOverlaysScreen<Screen, Overlay> = when (renderState) {
     LoadingBoardList -> {
       context.runningWorker(boardLoader.loadAvailableBoards()) { displayBoards(it) }

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameSessionWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameSessionWorkflow.kt
@@ -51,7 +51,7 @@ class GameSessionWorkflow(
   override fun render(
     renderProps: Props,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Props, State, Nothing>
   ): BodyAndOverlaysScreen<Screen, Overlay> = when (renderState) {
     Loading -> {
       context.runningWorker(boardLoader.loadBoard(renderProps.boardPath)) { StartRunning(it) }

--- a/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/TimeMachineAppWorkflow.kt
+++ b/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/TimeMachineAppWorkflow.kt
@@ -30,7 +30,7 @@ class TimeMachineAppWorkflow(
 
   override fun render(
     renderProps: BoardPath,
-    context: RenderContext
+    context: RenderContext<BoardPath, Nothing>
   ): ShakeableTimeMachineScreen {
     val propsFactory = PropsFactory { recording ->
       Props(paused = !recording)

--- a/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/AiWorkflow.kt
+++ b/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/AiWorkflow.kt
@@ -54,7 +54,7 @@ class AiWorkflow(
   override fun render(
     renderProps: ActorProps,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<ActorProps, State, Nothing>
   ): ActorRendering {
     context.runningWorker(renderState.directionTicker) { updateDirection }
 

--- a/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/GameWorkflow.kt
+++ b/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/GameWorkflow.kt
@@ -93,7 +93,7 @@ class GameWorkflow(
   override fun render(
     renderProps: Props,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Props, State, Output>
   ): GameRendering {
     val running = !renderProps.paused && !renderState.game.isPlayerEaten
     // Stop actors from ticking if the game is paused or finished.

--- a/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/PlayerWorkflow.kt
+++ b/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/PlayerWorkflow.kt
@@ -47,7 +47,7 @@ class PlayerWorkflow(
   override fun render(
     renderProps: ActorProps,
     renderState: Movement,
-    context: RenderContext
+    context: RenderContext<ActorProps, Movement, Nothing>
   ): Rendering = Rendering(
     actorRendering = ActorRendering(avatar = avatar, movement = renderState),
     onStartMoving = { context.actionSink.send(StartMoving(it)) },

--- a/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineWorkflow.kt
+++ b/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineWorkflow.kt
@@ -54,7 +54,7 @@ class ShakeableTimeMachineWorkflow<P, O : Any, out R : Screen>(
   override fun render(
     renderProps: PropsFactory<P>,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<PropsFactory<P>, State, O>
   ): ShakeableTimeMachineScreen {
     // Only listen to shakes when recording.
     if (renderState === Recording) context.runningWorker(shakeWorker) { onShake }

--- a/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/RecorderWorkflow.kt
+++ b/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/RecorderWorkflow.kt
@@ -76,7 +76,7 @@ internal class RecorderWorkflow<T>(
   override fun render(
     renderProps: RecorderProps<T>,
     renderState: Recording<T>,
-    context: RenderContext
+    context: RenderContext<RecorderProps<T>, Recording<T>, Nothing>
   ): TimeMachineRendering<T> {
     val value = when (renderProps) {
       is RecordValue -> renderProps.value

--- a/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/TimeMachineWorkflow.kt
+++ b/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/TimeMachineWorkflow.kt
@@ -68,7 +68,7 @@ class TimeMachineWorkflow<P, O : Any, out R>(
 
   override fun render(
     renderProps: TimeMachineProps<P>,
-    context: RenderContext
+    context: RenderContext<TimeMachineProps<P>, O>
   ): TimeMachineRendering<R> {
     // Always render the delegate, even if in playback mode, to keep it alive.
     val delegateRendering =

--- a/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
+++ b/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
@@ -35,7 +35,7 @@ class BlinkingCursorWorkflow(
   override fun render(
     renderProps: Unit,
     renderState: Boolean,
-    context: RenderContext
+    context: RenderContext<Unit, Boolean, Nothing>
   ): String {
     context.runningWorker(intervalWorker) { setCursorShowing(it) }
     return if (renderState) cursorString else ""

--- a/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/HelloTerminalWorkflow.kt
+++ b/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/HelloTerminalWorkflow.kt
@@ -37,7 +37,7 @@ class HelloTerminalWorkflow : TerminalWorkflow,
   override fun render(
     renderProps: TerminalProps,
     renderState: State,
-    context: RenderContext
+    context: StatefulWorkflow.RenderContext<TerminalProps, State, ExitCode>
   ): TerminalRendering {
     val (rows, columns) = renderProps.size
     val header = """

--- a/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
+++ b/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
@@ -49,7 +49,7 @@ class EditTextWorkflow : StatefulWorkflow<EditTextProps, EditTextState, String, 
   override fun render(
     renderProps: EditTextProps,
     renderState: EditTextState,
-    context: RenderContext
+    context: StatefulWorkflow.RenderContext<EditTextProps, EditTextState, String>
   ): String {
     context.runningWorker(
       renderProps.terminalProps.keyStrokes

--- a/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/TodoWorkflow.kt
+++ b/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/TodoWorkflow.kt
@@ -63,7 +63,7 @@ class TodoWorkflow : TerminalWorkflow,
   override fun render(
     renderProps: TerminalProps,
     renderState: TodoList,
-    context: RenderContext
+    context: StatefulWorkflow.RenderContext<TerminalProps, TodoList, ExitCode>
   ): TerminalRendering {
     context.runningWorker(renderProps.keyStrokes) { onKeystroke(it) }
 

--- a/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
+++ b/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
@@ -23,7 +23,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, HelloRendering>() 
   override fun render(
     renderProps: Unit,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Unit, State, Nothing>
   ): HelloRendering {
     return HelloRendering(
       message = renderState.name,

--- a/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
+++ b/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
@@ -23,7 +23,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, HelloRendering>() 
   override fun render(
     renderProps: Unit,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Unit, State, Nothing>
   ): HelloRendering {
     return HelloRendering(
       message = renderState.name,

--- a/samples/nested-overlays/src/main/java/com/squareup/sample/nestedoverlays/NestedOverlaysWorkflow.kt
+++ b/samples/nested-overlays/src/main/java/com/squareup/sample/nestedoverlays/NestedOverlaysWorkflow.kt
@@ -25,7 +25,7 @@ object NestedOverlaysWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>()
   override fun render(
     renderProps: Unit,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Unit, State, Nothing>
   ): Screen {
     if (renderState.nuked) {
       return ButtonBar(Button(R.string.reset, context.eventHandler("reset") { state = State() }))
@@ -126,7 +126,7 @@ object NestedOverlaysWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>()
 
   override fun snapshotState(state: State) = null
 
-  private fun RenderContext.topBottomBar(
+  private fun RenderContext<Unit, State, Nothing>.topBottomBar(
     top: Boolean,
     renderState: State
   ): ButtonBar {
@@ -145,7 +145,7 @@ object NestedOverlaysWorkflow : StatefulWorkflow<Unit, State, Nothing, Screen>()
     )
   }
 
-  private fun RenderContext.toggleInnerSheetButton(
+  private fun RenderContext<Unit, State, Nothing>.toggleInnerSheetButton(
     name: String,
     renderState: State
   ) =

--- a/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityWorkflow.kt
+++ b/samples/stub-visibility/src/main/java/com/squareup/sample/stubvisibility/StubVisibilityWorkflow.kt
@@ -25,7 +25,7 @@ object StubVisibilityWorkflow : StatefulWorkflow<Unit, State, Nothing, OuterRend
   override fun render(
     renderProps: Unit,
     renderState: State,
-    context: RenderContext
+    context: RenderContext<Unit, State, Nothing>
   ): OuterRendering = when (renderState) {
     HideBottom -> OuterRendering(
       top = ClickyTextRendering(message = "Click to show footer") {

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
@@ -68,7 +68,7 @@ class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
   override fun render(
     renderProps: Unit,
     renderState: AuthState,
-    context: RenderContext
+    context: RenderContext<Unit, AuthState, AuthResult>
   ): BackStackScreen<*> = when (renderState) {
     is LoginPrompt -> {
       BackStackScreen(

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
@@ -73,7 +73,7 @@ class RealRunGameWorkflow(
   override fun render(
     renderProps: Unit,
     renderState: RunGameState,
-    context: RenderContext
+    context: RenderContext<Unit, RunGameState, RunGameResult>
   ): RunGameRendering =
     when (renderState) {
       is NewGame -> {
@@ -189,12 +189,14 @@ class RealRunGameWorkflow(
       }
     }
 
-  private fun RenderContext.playAgain() = safeEventHandler<GameOver>("playAgain") { oldState ->
+  private fun RenderContext<Unit, RunGameState, RunGameResult>.playAgain() = safeEventHandler<GameOver>(
+    "playAgain"
+  ) { oldState ->
     val (x, o) = oldState.playerInfo
     state = NewGame(x, o)
   }
 
-  private fun RenderContext.trySaveAgain() =
+  private fun RenderContext<Unit, RunGameState, RunGameResult>.trySaveAgain() =
     safeEventHandler<GameOver>("trySaveAgain") { oldState ->
       check(oldState.syncState == SAVE_FAILED) {
         "Should only fire trySaveAgain in syncState $SAVE_FAILED, " +

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
@@ -69,7 +69,7 @@ class RealTakeTurnsWorkflow : TakeTurnsWorkflow,
   override fun render(
     renderProps: TakeTurnsProps,
     renderState: Turn,
-    context: RenderContext
+    context: RenderContext<TakeTurnsProps, Turn, CompletedGame>
   ): GamePlayScreen = GamePlayScreen(
     playerInfo = renderProps.playerInfo,
     gameState = renderState,

--- a/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/TicTacToeWorkflow.kt
+++ b/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/TicTacToeWorkflow.kt
@@ -52,7 +52,7 @@ class TicTacToeWorkflow(
   override fun render(
     renderProps: Unit,
     renderState: MainState,
-    context: RenderContext
+    context: RenderContext<Unit, MainState, Unit>
   ): BodyAndOverlaysScreen<ScrimScreen<*>, *> {
     val bodyAndOverlays: BodyAndOverlaysScreen<*, *> = when (renderState) {
       is Authenticating -> {

--- a/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
+++ b/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
@@ -24,8 +24,7 @@ sealed class TodoEditorOutput {
  * in this sample but would be inadequate in real life. To change that,
  * add an implementation of [onPropsChanged].
  */
-class TodoEditorWorkflow :
-  StatefulWorkflow<TodoList, TodoEditingSession, TodoEditorOutput, TodoEditorScreen>() {
+class TodoEditorWorkflow : StatefulWorkflow<TodoList, TodoEditingSession, TodoEditorOutput, TodoEditorScreen>() {
   override fun initialState(
     props: TodoList,
     snapshot: Snapshot?
@@ -36,7 +35,7 @@ class TodoEditorWorkflow :
   override fun render(
     renderProps: TodoList,
     renderState: TodoEditingSession,
-    context: RenderContext
+    context: StatefulWorkflow.RenderContext<TodoList, TodoEditingSession, TodoEditorOutput>
   ): TodoEditorScreen {
     // Monitor the title and each row for text changes.
     context.runningWorker(renderState.title.onTextChanged.asWorker(), "title") { textChanged }

--- a/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
+++ b/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
@@ -61,7 +61,7 @@ object TodoListsAppWorkflow :
   override fun render(
     renderProps: Unit,
     renderState: TodoListsAppState,
-    context: RenderContext
+    context: RenderContext<Unit, TodoListsAppState, Nothing>
   ): OverviewDetailScreen<*> {
     val listOfLists: TodoListsScreen = context.renderChild(
       listsWorkflow,

--- a/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
+++ b/samples/todo-android/app/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
@@ -13,7 +13,7 @@ import com.squareup.workflow1.StatelessWorkflow
 class TodoListsWorkflow : StatelessWorkflow<List<TodoList>, Int, TodoListsScreen>() {
   override fun render(
     renderProps: List<TodoList>,
-    context: RenderContext
+    context: RenderContext<List<TodoList>, Int>
   ): TodoListsScreen {
     return TodoListsScreen(
       lists = renderProps,

--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -240,9 +240,9 @@ public final class com/squareup/workflow1/Snapshots {
 }
 
 public abstract class com/squareup/workflow1/StatefulWorkflow : com/squareup/workflow1/IdCacheable, com/squareup/workflow1/Workflow {
+	public static final field Companion Lcom/squareup/workflow1/StatefulWorkflow$Companion;
 	public fun <init> ()V
 	public final fun asStatefulWorkflow ()Lcom/squareup/workflow1/StatefulWorkflow;
-	public final fun defaultOnFailedCast (Ljava/lang/String;Lkotlin/reflect/KClass;Ljava/lang/Object;)V
 	public fun getCachedIdentifier ()Lcom/squareup/workflow1/WorkflowIdentifier;
 	public abstract fun initialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;)Ljava/lang/Object;
 	public fun initialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlinx/coroutines/CoroutineScope;)Ljava/lang/Object;
@@ -250,6 +250,10 @@ public abstract class com/squareup/workflow1/StatefulWorkflow : com/squareup/wor
 	public abstract fun render (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/StatefulWorkflow$RenderContext;)Ljava/lang/Object;
 	public fun setCachedIdentifier (Lcom/squareup/workflow1/WorkflowIdentifier;)V
 	public abstract fun snapshotState (Ljava/lang/Object;)Lcom/squareup/workflow1/Snapshot;
+}
+
+public final class com/squareup/workflow1/StatefulWorkflow$Companion {
+	public final fun defaultOnFailedCast (Ljava/lang/String;Lkotlin/reflect/KClass;Ljava/lang/Object;)V
 }
 
 public final class com/squareup/workflow1/StatefulWorkflow$RenderContext : com/squareup/workflow1/BaseRenderContext {

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/SessionWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/SessionWorkflow.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.CoroutineScope
  * [CoroutineScope] must be implemented.
  */
 @WorkflowExperimentalApi
-public abstract class SessionWorkflow<
+abstract class SessionWorkflow<
   PropsT,
   StateT,
   OutputT,
@@ -150,7 +150,7 @@ public inline fun <PropsT, StateT, OutputT, RenderingT> Workflow.Companion.sessi
     override fun render(
       renderProps: PropsT,
       renderState: StateT,
-      context: RenderContext
+      context: StatefulWorkflow.RenderContext<PropsT, StateT, OutputT>
     ): RenderingT = render(context, renderProps, renderState)
 
     override fun snapshotState(state: StateT) = snapshot(state)

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
@@ -917,7 +917,9 @@ public inline fun <PropsT, StateT, OutputT, RenderingT> Workflow.Companion.state
  */
 public inline fun <StateT, OutputT, RenderingT> Workflow.Companion.stateful(
   crossinline initialState: (Snapshot?) -> StateT,
-  crossinline render: StatefulWorkflow.RenderContext<Unit, StateT, OutputT>.(state: StateT) -> RenderingT,
+  crossinline render: StatefulWorkflow.RenderContext<Unit, StateT, OutputT>.(
+    state: StateT
+  ) -> RenderingT,
   crossinline snapshot: (StateT) -> Snapshot?
 ): StatefulWorkflow<Unit, StateT, OutputT, RenderingT> = stateful(
   { _, initialSnapshot -> initialState(initialSnapshot) },
@@ -955,9 +957,11 @@ public inline fun <PropsT, StateT, OutputT, RenderingT> Workflow.Companion.state
  */
 public inline fun <StateT, OutputT, RenderingT> Workflow.Companion.stateful(
   initialState: StateT,
-  crossinline render: StatefulWorkflow.RenderContext<Unit,
+  crossinline render: StatefulWorkflow.RenderContext<
+    Unit,
     StateT,
-    OutputT>.(state: StateT) -> RenderingT
+    OutputT
+    >.(state: StateT) -> RenderingT
 ): StatefulWorkflow<Unit, StateT, OutputT, RenderingT> = stateful(
   { initialState },
   { _, state -> render(state) }

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkerWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkerWorkflow.kt
@@ -57,7 +57,7 @@ internal class WorkerWorkflow<OutputT>(
   override fun render(
     renderProps: Worker<OutputT>,
     renderState: Int,
-    context: RenderContext
+    context: RenderContext<Worker<OutputT>, Int, OutputT>
   ) {
     // Scope the side effect coroutine to the state value, so the worker will be re-started when
     // it changes (such that doesSameWorkAs returns false above).

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/Workflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/Workflow.kt
@@ -124,7 +124,7 @@ public fun <PropsT, OutputT, FromRenderingT, ToRenderingT>
 
     override fun render(
       renderProps: PropsT,
-      context: RenderContext
+      context: RenderContext<PropsT, OutputT>
     ): ToRenderingT {
       val rendering = context.renderChild(this@mapRendering, renderProps) { output ->
         action({ "mapRendering" }) { setOutput(output) }

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/WorkflowInterceptor.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/WorkflowInterceptor.kt
@@ -347,7 +347,7 @@ internal fun <P, S, O, R> WorkflowInterceptor.intercept(
     /**
      * Render context that we are passed.
      */
-    private var canonicalRenderContext: StatefulWorkflow<P, S, O, R>.RenderContext? = null
+    private var canonicalRenderContext: StatefulWorkflow.RenderContext<P, S, O>? = null
 
     /**
      * Render context interceptor that we are passed.
@@ -357,7 +357,7 @@ internal fun <P, S, O, R> WorkflowInterceptor.intercept(
     /**
      * Cache of the intercepted render context.
      */
-    private var cachedInterceptedRenderContext: StatefulWorkflow<P, S, O, R>.RenderContext? = null
+    private var cachedInterceptedRenderContext: StatefulWorkflow.RenderContext<P, S, O>? = null
 
     override fun initialState(
       props: P,
@@ -374,7 +374,7 @@ internal fun <P, S, O, R> WorkflowInterceptor.intercept(
     override fun render(
       renderProps: P,
       renderState: S,
-      context: RenderContext
+      context: RenderContext<P, S, O>
     ): R = onRender(
       renderProps,
       renderState,

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowInterceptorTest.kt
@@ -200,7 +200,7 @@ internal class WorkflowInterceptorTest {
     override fun render(
       renderProps: String,
       renderState: String,
-      context: RenderContext
+      context: RenderContext<String, String, String>
     ): String = "$renderProps|$renderState"
 
     override fun snapshotState(state: String): Snapshot = Snapshot.of(state)
@@ -216,7 +216,7 @@ internal class WorkflowInterceptorTest {
     override fun render(
       renderProps: String,
       renderState: String,
-      context: RenderContext
+      context: RenderContext<String, String, String>
     ): TestRendering {
       return TestRendering(
         onEvent = {
@@ -245,7 +245,7 @@ internal class WorkflowInterceptorTest {
     override fun render(
       renderProps: String,
       renderState: String,
-      context: RenderContext
+      context: RenderContext<String, String, String>
     ): String {
       context.runningSideEffect("sideEffectKey") {
         if (expectContextElementInSideEffect) assertNotNull(coroutineContext[TestElement.key])

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowOperatorsTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/WorkflowOperatorsTest.kt
@@ -23,7 +23,7 @@ class WorkflowOperatorsTest {
       override fun toString(): String = "ChildWorkflow"
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Nothing>
       ): Nothing = fail()
     }
     val mappedWorkflow = workflow.mapRendering { fail() }
@@ -225,7 +225,7 @@ class WorkflowOperatorsTest {
     override fun render(
       renderProps: Unit,
       renderState: T,
-      context: RenderContext
+      context: RenderContext<Unit, T, Nothing>
     ): T {
       // Listen to the flow to trigger a re-render when it updates.
       context.runningWorker(rerenderWorker) { output: T ->

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/RealRenderContextTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/RealRenderContextTest.kt
@@ -83,7 +83,7 @@ internal class RealRenderContextTest {
     override fun render(
       renderProps: String,
       renderState: String,
-      context: RenderContext
+      context: StatefulWorkflow.RenderContext<String, String, String>
     ): Rendering {
       fail("This shouldn't actually be called.")
     }

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
@@ -52,7 +52,7 @@ internal class SubtreeManagerTest {
     override fun render(
       renderProps: String,
       renderState: String,
-      context: RenderContext
+      context: StatefulWorkflow.RenderContext<String, String, String>
     ): Rendering {
       return Rendering(
         renderProps,
@@ -82,7 +82,7 @@ internal class SubtreeManagerTest {
     override fun render(
       renderProps: Unit,
       renderState: Unit,
-      context: RenderContext
+      context: RenderContext<Unit, Unit, Nothing>
     ) {
     }
 

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -57,7 +57,7 @@ import kotlin.test.fail
 @Suppress("UNCHECKED_CAST")
 internal class WorkflowNodeTest {
 
-  private abstract class StringWorkflow : StatefulWorkflow<String, String, String, String>() {
+  abstract class StringWorkflow : StatefulWorkflow<String, String, String, String>() {
     override fun snapshotState(state: String): Snapshot = fail("not expected")
   }
 
@@ -87,7 +87,7 @@ internal class WorkflowNodeTest {
     override fun render(
       renderProps: String,
       renderState: String,
-      context: RenderContext
+      context: StatefulWorkflow.RenderContext<String, String, String>
     ): String {
       return """
         props:$renderProps
@@ -168,7 +168,7 @@ internal class WorkflowNodeTest {
       override fun render(
         renderProps: String,
         renderState: String,
-        context: RenderContext
+        context: RenderContext<String, String, String>
       ): (String) -> Unit {
         return context.eventHandler("") { event -> setOutput(event) }
       }
@@ -210,7 +210,7 @@ internal class WorkflowNodeTest {
       override fun render(
         renderProps: String,
         renderState: String,
-        context: RenderContext
+        context: RenderContext<String, String, String>
       ): (String) -> Unit {
         return context.eventHandler("") { event -> setOutput(event) }
       }
@@ -261,7 +261,7 @@ internal class WorkflowNodeTest {
       override fun render(
         renderProps: String,
         renderState: String,
-        context: RenderContext
+        context: RenderContext<String, String, String>
       ): String {
         sink = context.actionSink
         return ""

--- a/workflow-testing/src/test/java/com/squareup/workflow1/TreeWorkflow.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/TreeWorkflow.kt
@@ -38,7 +38,7 @@ internal class TreeWorkflow(
   override fun render(
     renderProps: String,
     renderState: String,
-    context: RenderContext
+    context: RenderContext<String, String, Nothing>
   ): Rendering {
     val childRenderings = children
       .mapIndexed { index, child ->

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/RealRenderTesterTest.kt
@@ -600,7 +600,7 @@ internal class RealRenderTesterTest {
     class Child : OutputNothingChild, StatelessWorkflow<Unit, Nothing, Unit>() {
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Nothing>
       ) {
         // Nothing to do.
       }
@@ -647,7 +647,7 @@ internal class RealRenderTesterTest {
     val child = object : StatelessWorkflow<Unit, Unit, Int>() {
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Unit>
       ): Int = 42
     }
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
@@ -671,7 +671,7 @@ internal class RealRenderTesterTest {
     val child = object : StatelessWorkflow<Unit, Unit, Int>() {
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Unit>
       ): Int = 42
     }
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
@@ -706,7 +706,7 @@ internal class RealRenderTesterTest {
     val child = object : StatelessWorkflow<Unit, Unit, Wrapper<Int>>() {
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Unit>
       ): Wrapper<Int> = Wrapper(42)
     }
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
@@ -734,7 +734,7 @@ internal class RealRenderTesterTest {
     val child = object : StatelessWorkflow<Unit, Unit, Wrapper<Int>>() {
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Unit>
       ): Wrapper<Int> = Wrapper(42)
     }
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
@@ -769,7 +769,7 @@ internal class RealRenderTesterTest {
     val child = object : StatelessWorkflow<Unit, Unit, Wrapper<Int>>() {
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Unit>
       ): Wrapper<Int> = Wrapper(42)
     }
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
@@ -802,7 +802,7 @@ internal class RealRenderTesterTest {
     val child = object : StatelessWorkflow<Unit, Unit, Wrapper<Int>>() {
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Unit>
       ): Wrapper<Int> = Wrapper(42)
     }
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
@@ -838,7 +838,7 @@ internal class RealRenderTesterTest {
     val child = object : StatelessWorkflow<Unit, Wrapper<Unit>, Int>() {
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Wrapper<Unit>>
       ): Int = 42
     }
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
@@ -871,7 +871,7 @@ internal class RealRenderTesterTest {
     val child = object : StatelessWorkflow<Unit, Wrapper<Unit>, Int>() {
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Wrapper<Unit>>
       ): Int = 42
     }
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
@@ -903,7 +903,7 @@ internal class RealRenderTesterTest {
     val child = object : StatelessWorkflow<Unit, Unit, Int>() {
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Unit>
       ): Int = 42
     }
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
@@ -1217,7 +1217,7 @@ internal class RealRenderTesterTest {
     val child = object : OutputNothingChild, StatelessWorkflow<Unit, Nothing, Unit>() {
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Nothing>
       ) {
         // Do nothing.
       }
@@ -1658,7 +1658,7 @@ internal class RealRenderTesterTest {
   }
 
   @Test fun `enforces frozen failures on late renderChild call`() {
-    lateinit var capturedContext: StatelessWorkflow<Unit, Nothing, Unit>.RenderContext
+    lateinit var capturedContext: StatelessWorkflow.RenderContext<Unit, Nothing>
     val workflow = Workflow.stateless { capturedContext = this }
 
     workflow.testRender(Unit)
@@ -1670,7 +1670,7 @@ internal class RealRenderTesterTest {
   }
 
   @Test fun `enforces frozen failures on late runningSideEffect call`() {
-    lateinit var capturedContext: StatelessWorkflow<Unit, Nothing, Unit>.RenderContext
+    lateinit var capturedContext: StatelessWorkflow.RenderContext<Unit, Nothing>
     val workflow = Workflow.stateless { capturedContext = this }
 
     workflow.testRender(Unit)
@@ -1682,7 +1682,7 @@ internal class RealRenderTesterTest {
   }
 
   @Test fun `enforces frozen failures on late remember call`() {
-    lateinit var capturedContext: StatelessWorkflow<Unit, Nothing, Unit>.RenderContext
+    lateinit var capturedContext: StatelessWorkflow.RenderContext<Unit, Nothing>
     val workflow = Workflow.stateless { capturedContext = this }
 
     workflow.testRender(Unit)
@@ -1844,7 +1844,7 @@ internal class RealRenderTesterTest {
       override fun render(
         renderProps: String,
         renderState: Double,
-        context: RenderContext
+        context: RenderContext<String, Double, Int>
       ) = throw NotImplementedError()
 
       override fun snapshotState(state: Double): Snapshot = throw NotImplementedError()
@@ -1862,7 +1862,7 @@ internal class RealRenderTesterTest {
     val workflow = object : StatelessWorkflow<String, Int, Unit>() {
       override fun render(
         renderProps: String,
-        context: RenderContext
+        context: RenderContext<String, Int>
       ) = throw NotImplementedError()
     }
     val invocation = createRenderChildInvocation(workflow, "props", "key")
@@ -1884,7 +1884,7 @@ internal class RealRenderTesterTest {
       override fun render(
         renderProps: String,
         renderState: Double,
-        context: RenderContext
+        context: RenderContext<String, Double, Int>
       ) = throw NotImplementedError()
 
       override fun snapshotState(state: Double): Snapshot = throw NotImplementedError()
@@ -1904,7 +1904,7 @@ internal class RealRenderTesterTest {
     class TestWorkflow : StatelessWorkflow<String, Int, Unit>() {
       override fun render(
         renderProps: String,
-        context: RenderContext
+        context: RenderContext<String, Int>
       ) = throw NotImplementedError()
     }
 
@@ -1922,7 +1922,7 @@ internal class RealRenderTesterTest {
     class ChildWorkflow : StatelessWorkflow<Unit, Nothing, Int>() {
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Nothing>
       ): Int = fail()
     }
 
@@ -1942,7 +1942,7 @@ internal class RealRenderTesterTest {
     class ChildWorkflow : StatelessWorkflow<Unit, Nothing, Int>() {
       override fun render(
         renderProps: Unit,
-        context: RenderContext
+        context: RenderContext<Unit, Nothing>
       ): Int = fail()
     }
 

--- a/workflow-tracing/src/test/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptorTest.kt
+++ b/workflow-tracing/src/test/java/com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInterceptorTest.kt
@@ -87,7 +87,7 @@ internal class TracingWorkflowInterceptorTest {
     assertEquals(expected, buffer.readUtf8().removeActionHashCodes())
   }
 
-  private inner class TestWorkflow : StatefulWorkflow<Int, String, String, String>() {
+  inner class TestWorkflow : StatefulWorkflow<Int, String, String, String>() {
 
     private val channel = Channel<String>(UNLIMITED)
 
@@ -119,7 +119,7 @@ internal class TracingWorkflowInterceptorTest {
     override fun render(
       renderProps: Int,
       renderState: String,
-      context: RenderContext
+      context: StatefulWorkflow.RenderContext<Int, String, String>
     ): String {
       if (renderProps == 0) return "initial"
       if (renderProps in 1..6) context.renderChild(this, 0) { bubbleUp(it) }

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/RenderAsStateTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/RenderAsStateTest.kt
@@ -359,8 +359,7 @@ internal class RenderAsStateTest {
   }
 
   // Seems to be a problem accessing Workflow.stateful.
-  private class SnapshottingWorkflow :
-    StatefulWorkflow<Unit, String, Nothing, SnapshottedRendering>() {
+  private class SnapshottingWorkflow : StatefulWorkflow<Unit, String, Nothing, SnapshottedRendering>() {
 
     data class SnapshottedRendering(
       val string: String,
@@ -375,7 +374,7 @@ internal class RenderAsStateTest {
     override fun render(
       renderProps: Unit,
       renderState: String,
-      context: RenderContext
+      context: RenderContext<Unit, String, Nothing>
     ) = SnapshottedRendering(
       string = renderState,
       updateString = { newString -> context.actionSink.send(updateString(newString)) }

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/AndroidRenderWorkflowInTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/AndroidRenderWorkflowInTest.kt
@@ -77,7 +77,7 @@ internal class AndroidRenderWorkflowInTest {
   object SomeWorkflow : StatelessWorkflow<Unit, Nothing, Screen>() {
     override fun render(
       renderProps: Unit,
-      context: RenderContext
+      context: RenderContext<Unit, Nothing>
     ): Screen {
       return SomeScreen
     }


### PR DESCRIPTION
Yes, this means we have to provide type parameters every time we use it.

However, it also means we won't break the `out RenderingT` variance (which will not be allowed come the K2 compiler).

This will fix #1340 as we will no longer be consuming `RenderingT` (via the Workflow instance to get the `PropsT` and `OutpuT` types) when we pass `RenderContext` into `render()` as its types - for `PropsT` and `OutpuT` will be provided explicitly.