### PR TITLE
1311: Enable applying Multiple Actions on immediate dispatcher for `CONFLATE_STALE_RENDERINGS`

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -64,6 +64,7 @@ include(
   ":workflow-config:config-jvm",
   ":workflow-core",
   ":workflow-runtime",
+  ":workflow-runtime-android",
   ":workflow-rx2",
   ":workflow-testing",
   ":workflow-tracing",

--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -35,6 +35,11 @@ public final class com/squareup/workflow1/BaseRenderContext$DefaultImpls {
 	public static synthetic fun renderChild$default (Lcom/squareup/workflow1/BaseRenderContext;Lcom/squareup/workflow1/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class com/squareup/workflow1/DeferredActionToBeApplied : com/squareup/workflow1/ActionProcessingResult {
+	public fun <init> (Lkotlinx/coroutines/Deferred;)V
+	public final fun getApplyAction ()Lkotlinx/coroutines/Deferred;
+}
+
 public final class com/squareup/workflow1/HandlerBox1 {
 	public field handler Lkotlin/jvm/functions/Function1;
 	public fun <init> ()V
@@ -159,6 +164,10 @@ public final class com/squareup/workflow1/NullableInitBox$Uninitialized {
 
 public final class com/squareup/workflow1/PropsUpdated : com/squareup/workflow1/ActionProcessingResult {
 	public static final field INSTANCE Lcom/squareup/workflow1/PropsUpdated;
+}
+
+public final class com/squareup/workflow1/RuntimeConfigKt {
+	public static final fun shouldDeferFirstAction (Ljava/util/Set;)Z
 }
 
 public final class com/squareup/workflow1/RuntimeConfigOptions : java/lang/Enum {
@@ -325,6 +334,7 @@ public abstract class com/squareup/workflow1/WorkflowAction {
 	public fun <init> ()V
 	public abstract fun apply (Lcom/squareup/workflow1/WorkflowAction$Updater;)V
 	public fun getDebuggingName ()Ljava/lang/String;
+	public fun isDeferrable ()Z
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -418,8 +428,10 @@ public final class com/squareup/workflow1/Workflows {
 	public static final fun action (Lcom/squareup/workflow1/StatefulWorkflow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lcom/squareup/workflow1/StatelessWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun action (Lcom/squareup/workflow1/StatelessWorkflow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
-	public static final fun action (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
-	public static final fun action (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
+	public static final fun action (Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
+	public static final fun action (Lkotlin/jvm/functions/Function0;ZLkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/WorkflowAction;
+	public static synthetic fun action$default (Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/WorkflowAction;
+	public static synthetic fun action$default (Lkotlin/jvm/functions/Function0;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow1/WorkflowAction;
 	public static final fun applyTo (Lcom/squareup/workflow1/WorkflowAction;Ljava/lang/Object;Ljava/lang/Object;)Lkotlin/Pair;
 	public static final fun collectToSink (Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow1/Sink;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun contraMap (Lcom/squareup/workflow1/Sink;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow1/Sink;

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/HandlerBox.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/HandlerBox.kt
@@ -12,7 +12,16 @@ internal fun <P, S, O> BaseRenderContext<P, S, O>.eventHandler0(
   remember: Boolean,
   update: Updater<P, S, O>.() -> Unit
 ): () -> Unit {
-  val handler = { actionSink.send(action("eH: $name", update)) }
+  val handler = {
+    actionSink.send(
+      action(
+        name = "eH: $name",
+        // Event handlers are *never* deferrable since they respond to UI input.
+        isDeferrable = false,
+        apply = update,
+      )
+    )
+  }
   return if (remember) {
     val box = remember(name) { HandlerBox0() }
     box.handler = handler
@@ -34,7 +43,14 @@ internal inline fun <P, S, O, reified EventT> BaseRenderContext<P, S, O>.eventHa
   remember: Boolean,
   noinline update: Updater<P, S, O>.(EventT) -> Unit
 ): (EventT) -> Unit {
-  val handler = { e: EventT -> actionSink.send(action("eH: $name") { update(e) }) }
+  val handler = { e: EventT ->
+    actionSink.send(
+      action(
+        name = "eH: $name",
+        isDeferrable = false,
+      ) { update(e) }
+    )
+  }
   return if (remember) {
     val box = remember(name, typeOf<EventT>()) { HandlerBox1<EventT>() }
     box.handler = handler
@@ -56,7 +72,14 @@ internal inline fun <P, S, O, reified E1, reified E2> BaseRenderContext<P, S, O>
   remember: Boolean,
   noinline update: Updater<P, S, O>.(E1, E2) -> Unit
 ): (E1, E2) -> Unit {
-  val handler = { e1: E1, e2: E2 -> actionSink.send(action("eH: $name") { update(e1, e2) }) }
+  val handler = { e1: E1, e2: E2 ->
+    actionSink.send(
+      action(
+        name = "eH: $name",
+        isDeferrable = false,
+      ) { update(e1, e2) }
+    )
+  }
   return if (remember) {
     val box = remember(name, typeOf<E1>(), typeOf<E2>()) { HandlerBox2<E1, E2>() }
     box.handler = handler
@@ -86,7 +109,14 @@ internal inline fun <
   noinline update: Updater<P, S, O>.(E1, E2, E3) -> Unit
 ): (E1, E2, E3) -> Unit {
   val handler =
-    { e1: E1, e2: E2, e3: E3 -> actionSink.send(action("eH: $name") { update(e1, e2, e3) }) }
+    { e1: E1, e2: E2, e3: E3 ->
+      actionSink.send(
+        action(
+          name = "eH: $name",
+          isDeferrable = false,
+        ) { update(e1, e2, e3) }
+      )
+    }
   return if (remember) {
     val box =
       remember(name, typeOf<E1>(), typeOf<E2>(), typeOf<E3>()) { HandlerBox3<E1, E2, E3>() }
@@ -118,7 +148,12 @@ internal inline fun <
   noinline update: Updater<P, S, O>.(E1, E2, E3, E4) -> Unit
 ): (E1, E2, E3, E4) -> Unit {
   val handler = { e1: E1, e2: E2, e3: E3, e4: E4 ->
-    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4) })
+    actionSink.send(
+      action(
+        name = "eH: $name",
+        isDeferrable = false,
+      ) { update(e1, e2, e3, e4) }
+    )
   }
   return if (remember) {
     val box = remember(
@@ -158,7 +193,12 @@ internal inline fun <
   noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5) -> Unit
 ): (E1, E2, E3, E4, E5) -> Unit {
   val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5 ->
-    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5) })
+    actionSink.send(
+      action(
+        name = "eH: $name",
+        isDeferrable = false,
+      ) { update(e1, e2, e3, e4, e5) }
+    )
   }
   return if (remember) {
     val box = remember(
@@ -200,7 +240,12 @@ internal inline fun <
   noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6) -> Unit
 ): (E1, E2, E3, E4, E5, E6) -> Unit {
   val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6 ->
-    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6) })
+    actionSink.send(
+      action(
+        name = "eH: $name",
+        isDeferrable = false,
+      ) { update(e1, e2, e3, e4, e5, e6) }
+    )
   }
   return if (remember) {
     val box = remember(
@@ -244,7 +289,12 @@ internal inline fun <
   noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6, E7) -> Unit
 ): (E1, E2, E3, E4, E5, E6, E7) -> Unit {
   val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7 ->
-    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6, e7) })
+    actionSink.send(
+      action(
+        name = "eH: $name",
+        isDeferrable = false,
+      ) { update(e1, e2, e3, e4, e5, e6, e7) }
+    )
   }
   return if (remember) {
     val box = remember(
@@ -290,7 +340,12 @@ internal inline fun <
   noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6, E7, E8) -> Unit
 ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit {
   val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7, e8: E8 ->
-    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6, e7, e8) })
+    actionSink.send(
+      action(
+        name = "eH: $name",
+        isDeferrable = false,
+      ) { update(e1, e2, e3, e4, e5, e6, e7, e8) }
+    )
   }
   return if (remember) {
     val box = remember(
@@ -338,7 +393,12 @@ internal inline fun <
   noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit
 ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit {
   val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7, e8: E8, e9: E9 ->
-    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6, e7, e8, e9) })
+    actionSink.send(
+      action(
+        name = "eH: $name",
+        isDeferrable = false,
+      ) { update(e1, e2, e3, e4, e5, e6, e7, e8, e9) }
+    )
   }
   return if (remember) {
     val box = remember(
@@ -389,7 +449,12 @@ internal inline fun <
 ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit {
   val handler =
     { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7, e8: E8, e9: E9, e10: E10 ->
-      actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10) })
+      actionSink.send(
+        action(
+          name = "eH: $name",
+          isDeferrable = false,
+        ) { update(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10) }
+      )
     }
   return if (remember) {
     val box = remember(

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/RuntimeConfig.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/RuntimeConfig.kt
@@ -20,6 +20,16 @@ public annotation class WorkflowExperimentalRuntime
 public typealias RuntimeConfig = Set<RuntimeConfigOptions>
 
 /**
+ * Whether or not we have an optimization enabled that should cause us to consider 'deferring'
+ * the application of the first action received after resuming from suspension in the runtime
+ * loop. We will only actually defer if [WorkflowAction.isDeferrable] is true for that action.
+ */
+@WorkflowExperimentalRuntime
+public fun RuntimeConfig.shouldDeferFirstAction(): Boolean {
+  return contains(RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS)
+}
+
+/**
  * A specification of the possible Workflow Runtime options.
  */
 public enum class RuntimeConfigOptions {

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/Sink.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/Sink.kt
@@ -99,6 +99,9 @@ internal suspend fun <
 ) {
   suspendCancellableCoroutine<Unit> { continuation ->
     val resumingAction = object : WorkflowAction<PropsT, StateT, OutputT>() {
+      override val isDeferrable: Boolean
+        get() = action.isDeferrable
+
       // Pipe through debugging name to the original action.
       override val debuggingName: String
         get() = action.debuggingName

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkerWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/WorkerWorkflow.kt
@@ -59,9 +59,10 @@ internal class WorkerWorkflow<OutputT>(
     renderState: Int,
     context: RenderContext<Worker<OutputT>, Int, OutputT>
   ) {
+    val localKey = renderState.toString()
     // Scope the side effect coroutine to the state value, so the worker will be re-started when
     // it changes (such that doesSameWorkAs returns false above).
-    context.runningSideEffect(renderState.toString()) {
+    context.runningSideEffect(localKey) {
       runWorker(renderProps, key, context.actionSink)
     }
   }
@@ -96,6 +97,11 @@ private class EmitWorkerOutputAction<P, S, O>(
 ) : WorkflowAction<P, S, O>() {
   override val debuggingName: String =
     "EmitWorkerOutputAction(worker=$worker, key=$renderKey)"
+
+  /**
+   * All actions from workers are deferrable!
+   */
+  override val isDeferrable: Boolean = true
 
   override fun Updater.apply() {
     setOutput(output)

--- a/workflow-runtime-android/README.md
+++ b/workflow-runtime-android/README.md
@@ -1,0 +1,4 @@
+# Module Workflow Runtime Android
+
+This module is an Android library that is used to test the Workflow Runtime with Android specific
+coroutine dispatchers. These are headless android-tests that run on device without UI.

--- a/workflow-runtime-android/build.gradle.kts
+++ b/workflow-runtime-android/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+  id("com.android.library")
+  id("kotlin-android")
+  id("android-defaults")
+  id("android-ui-tests")
+}
+
+android {
+  namespace = "com.squareup.workflow1"
+  testNamespace = "$namespace.test"
+}
+
+dependencies {
+  api(project(":workflow-runtime"))
+  implementation(project(":workflow-core"))
+
+  androidTestImplementation(libs.androidx.test.core)
+  androidTestImplementation(libs.androidx.test.truth)
+  androidTestImplementation(libs.kotlin.test.core)
+  androidTestImplementation(libs.kotlin.test.jdk)
+  androidTestImplementation(libs.kotlinx.coroutines.android)
+  androidTestImplementation(libs.kotlinx.coroutines.core)
+  androidTestImplementation(libs.kotlinx.coroutines.test)
+  androidTestImplementation(libs.truth)
+}

--- a/workflow-runtime-android/gradle.properties
+++ b/workflow-runtime-android/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=workflow-runtime-android
+POM_NAME=Workflow Runtime Android
+POM_PACKAGING=aar

--- a/workflow-runtime-android/src/androidTest/AndroidManifest.xml
+++ b/workflow-runtime-android/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <application>
+    <activity android:name="androidx.activity.ComponentActivity"/>
+  </application>
+</manifest>

--- a/workflow-runtime-android/src/androidTest/java/com/squareup/workflow1/AndroidRenderWorkflowInTest.kt
+++ b/workflow-runtime-android/src/androidTest/java/com/squareup/workflow1/AndroidRenderWorkflowInTest.kt
@@ -1,35 +1,39 @@
 package com.squareup.workflow1
 
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
 import com.squareup.workflow1.RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS
+import com.squareup.workflow1.RuntimeConfigOptions.PARTIAL_TREE_RENDERING
+import com.squareup.workflow1.RuntimeConfigOptions.RENDER_ONLY_WHEN_STATE_CHANGES
+import com.squareup.workflow1.RuntimeConfigOptions.STABLE_EVENT_HANDLERS
 import com.squareup.workflow1.WorkflowInterceptor.RenderPassesComplete
 import com.squareup.workflow1.WorkflowInterceptor.RuntimeLoopOutcome
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Ignore
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(WorkflowExperimentalRuntime::class, ExperimentalCoroutinesApi::class)
 class AndroidRenderWorkflowInTest {
 
-  @Ignore("#1311: Does not yet work with immediate dispatcher.")
   @Test
-  fun with_conflate_we_conflate_stacked_actions_into_one_rendering() =
+  fun conflate_renderings_for_multiple_worker_actions_same_trigger() =
     runTest(UnconfinedTestDispatcher()) {
 
-      var childHandlerActionExecuted = false
-      val trigger1 = Channel<String>(capacity = 1)
-      val trigger2 = Channel<String>(capacity = 1)
+      val trigger = MutableStateFlow("unchanged state")
       val emitted = mutableListOf<String>()
       var renderingsPassed = 0
       val countInterceptor = object : WorkflowInterceptor {
@@ -41,34 +45,55 @@ class AndroidRenderWorkflowInTest {
       }
 
       val childWorkflow = Workflow.stateful<String, String, String>(
-        initialState = "unchanging state",
+        initialState = "unchanged state",
         render = { renderState ->
           runningWorker(
-            trigger1.receiveAsFlow().asWorker()
+            worker = trigger.drop(1).asWorker(),
+            key = "Worker1"
           ) {
             action("") {
-              state = it
-              setOutput(it)
+              val newState = "$it+u1"
+              state = newState
+              setOutput(newState)
             }
           }
           renderState
         }
       )
       val workflow = Workflow.stateful<String, String, String>(
-        initialState = "unchanging state",
+        initialState = "unchanged state",
         render = { renderState ->
           renderChild(childWorkflow) { childOutput ->
             action("childHandler") {
-              childHandlerActionExecuted = true
               state = childOutput
             }
           }
           runningWorker(
-            trigger2.receiveAsFlow().asWorker()
+            worker = trigger.drop(1).asWorker(),
+            key = "Worker2"
           ) {
             action("") {
-              // Update the rendering in order to show conflation.
-              state = "$it+update"
+              // Update the state in order to show conflation.
+              state = "$state+u2"
+            }
+          }
+          runningWorker(
+            worker = trigger.drop(1).asWorker(),
+            key = "Worker3"
+          ) {
+            action("") {
+              // Update the state in order to show conflation.
+              state = "$state+u3"
+            }
+          }
+          runningWorker(
+            worker = trigger.drop(1).asWorker(),
+            key = "Worker4"
+          ) {
+            action("") {
+              // Update the state in order to show conflation.
+              state = "$state+u4"
+              // Output only on the last one!
               setOutput(state)
             }
           }
@@ -89,34 +114,387 @@ class AndroidRenderWorkflowInTest {
 
       val renderedMutex = Mutex(locked = true)
 
-      val collectionJob = launch(context = Dispatchers.Main.immediate, start = UNDISPATCHED) {
+      val collectionJob = launch(context = Dispatchers.Main.immediate) {
         // Collect this unconfined so we can get all the renderings faster than actions can
         // be processed.
         renderings.collect {
           emitted += it.rendering
-          if (it.rendering == "changed state 2+update") {
+          println("SAE: ${it.rendering}")
+          if (it.rendering == "state change+u1+u2+u3+u4") {
             renderedMutex.unlock()
           }
         }
       }
 
-      launch(context = Dispatchers.Main.immediate, start = UNDISPATCHED) {
-        trigger1.trySend("changed state 1")
-        trigger2.trySend("changed state 2")
-      }.join()
+      trigger.value = "state change"
+
+      renderedMutex.lock()
+
+      collectionJob.cancel()
+
+      // 2 renderings (initial and then the update.) Not *5* renderings.
+      assertEquals(2, emitted.size, "Expected only 2 emitted renderings when conflating actions.")
+      assertEquals(
+        2,
+        renderingsPassed,
+        "Expected only 2 renderings passed to interceptor when conflating actions."
+      )
+      assertEquals("state change+u1+u2+u3+u4", emitted.last())
+    }
+
+  @Test
+  fun conflate_renderings_for_multiple_side_effect_actions_when_deferrable() =
+    runTest(UnconfinedTestDispatcher()) {
+
+      val trigger = MutableStateFlow("unchanged state")
+      val emitted = mutableListOf<String>()
+      var renderingsPassed = 0
+      val countInterceptor = object : WorkflowInterceptor {
+        override fun onRuntimeLoopTick(outcome: RuntimeLoopOutcome) {
+          if (outcome is RenderPassesComplete<*>) {
+            renderingsPassed++
+          }
+        }
+      }
+
+      val childWorkflow = Workflow.stateful<String, String, String>(
+        initialState = "unchanged state",
+        render = { renderState ->
+          runningSideEffect("childSideEffect") {
+            trigger.drop(1).collect {
+              actionSink.send(
+                action(
+                  name = "handleChildSideEffectAction",
+                  isDeferrable = true,
+                ) {
+                  val newState = "$it+u1"
+                  state = newState
+                  setOutput(newState)
+                }
+              )
+            }
+          }
+          renderState
+        }
+      )
+      val workflow = Workflow.stateful<String, String, String>(
+        initialState = "unchanged state",
+        render = { renderState ->
+          renderChild(childWorkflow) { childOutput ->
+            action("childHandler") {
+              state = childOutput
+            }
+          }
+          runningSideEffect("parentSideEffect") {
+            trigger.drop(1).collect {
+              actionSink.send(
+                action(
+                  name = "handleParentSideEffectAction",
+                  isDeferrable = true
+                ) {
+                  state = "$state+u2"
+                }
+              )
+            }
+          }
+          renderState
+        }
+      )
+      val props = MutableStateFlow(Unit)
+      // Render this on the Main.immediate dispatcher from Android.
+      val renderings = renderWorkflowIn(
+        workflow = workflow,
+        scope = backgroundScope +
+          Dispatchers.Main.immediate,
+        props = props,
+        runtimeConfig = setOf(CONFLATE_STALE_RENDERINGS),
+        workflowTracer = null,
+        interceptors = listOf(countInterceptor)
+      ) { }
+
+      val renderedMutex = Mutex(locked = true)
+
+      val collectionJob = launch(context = Dispatchers.Main.immediate) {
+        // Collect this unconfined so we can get all the renderings faster than actions can
+        // be processed.
+        renderings.collect {
+          emitted += it.rendering
+          if (it.rendering == "state change+u1+u2") {
+            renderedMutex.unlock()
+          }
+        }
+      }
+
+      trigger.value = "state change"
 
       renderedMutex.lock()
 
       collectionJob.cancel()
 
       // 2 renderings (initial and then the update.) Not *3* renderings.
-      assertEquals(2, emitted.size, "Expected only 2 renderings when conflating actions.")
+      assertEquals(2, emitted.size, "Expected only 2 emitted renderings when conflating actions.")
       assertEquals(
         2,
         renderingsPassed,
-        "Expected only 2 renderings passed when conflating actions."
+        "Expected only 2 renderings passed to interceptor when conflating actions."
       )
-      assertEquals("changed state 2+update", emitted.last())
-      assertTrue(childHandlerActionExecuted)
+      assertEquals("state change+u1+u2", emitted.last())
     }
+
+  @Test
+  fun do_not_conflate_renderings_for_multiple_side_effect_actions_when_NOT_deferrable() =
+    runTest(UnconfinedTestDispatcher()) {
+
+      val trigger = MutableStateFlow("unchanged state")
+      val emitted = mutableListOf<String>()
+      var renderingsPassed = 0
+      val countInterceptor = object : WorkflowInterceptor {
+        override fun onRuntimeLoopTick(outcome: RuntimeLoopOutcome) {
+          if (outcome is RenderPassesComplete<*>) {
+            renderingsPassed++
+          }
+        }
+      }
+
+      val childWorkflow = Workflow.stateful<String, String, String>(
+        initialState = "unchanged state",
+        render = { renderState ->
+          runningSideEffect("childSideEffect") {
+            trigger.drop(1).collect {
+              actionSink.send(
+                action(
+                  name = "handleChildSideEffectAction",
+                ) {
+                  val newState = "$it+u1"
+                  state = newState
+                  setOutput(newState)
+                }
+              )
+            }
+          }
+          renderState
+        }
+      )
+      val workflow = Workflow.stateful<String, String, String>(
+        initialState = "unchanged state",
+        render = { renderState ->
+          renderChild(childWorkflow) { childOutput ->
+            action("childHandler") {
+              state = childOutput
+            }
+          }
+          runningSideEffect("parentSideEffect") {
+            trigger.drop(1).collect {
+              actionSink.send(
+                action(
+                  name = "handleParentSideEffectAction",
+                ) {
+                  state = "$state+u2"
+                }
+              )
+            }
+          }
+          renderState
+        }
+      )
+      val props = MutableStateFlow(Unit)
+      // Render this on the Main.immediate dispatcher from Android.
+      val renderings = renderWorkflowIn(
+        workflow = workflow,
+        scope = backgroundScope +
+          Dispatchers.Main.immediate,
+        props = props,
+        runtimeConfig = setOf(CONFLATE_STALE_RENDERINGS),
+        workflowTracer = null,
+        interceptors = listOf(countInterceptor)
+      ) { }
+
+      val renderedMutex = Mutex(locked = true)
+
+      val collectionJob = launch(context = Dispatchers.Main.immediate) {
+        // Collect this unconfined so we can get all the renderings faster than actions can
+        // be processed.
+        renderings.collect {
+          emitted += it.rendering
+          if (it.rendering == "state change+u1+u2") {
+            renderedMutex.unlock()
+          }
+        }
+      }
+
+      trigger.value = "state change"
+
+      renderedMutex.lock()
+
+      collectionJob.cancel()
+
+      // 3 renderings! each update separate.
+      assertEquals(3, emitted.size, "Expected 3 emitted renderings when conflating actions.")
+      assertEquals(
+        3,
+        renderingsPassed,
+        "Expected 3 renderings passed to interceptor when conflating actions."
+      )
+      assertEquals("state change+u1+u2", emitted.last())
+    }
+
+  private val runtimes = setOf<RuntimeConfig>(
+    RuntimeConfigOptions.RENDER_PER_ACTION,
+    setOf(RENDER_ONLY_WHEN_STATE_CHANGES),
+    setOf(CONFLATE_STALE_RENDERINGS),
+    setOf(STABLE_EVENT_HANDLERS),
+    setOf(CONFLATE_STALE_RENDERINGS, RENDER_ONLY_WHEN_STATE_CHANGES),
+    setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING),
+    setOf(CONFLATE_STALE_RENDERINGS, RENDER_ONLY_WHEN_STATE_CHANGES, STABLE_EVENT_HANDLERS),
+    setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING, STABLE_EVENT_HANDLERS),
+    setOf(CONFLATE_STALE_RENDERINGS, RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING),
+    setOf(
+      CONFLATE_STALE_RENDERINGS,
+      RENDER_ONLY_WHEN_STATE_CHANGES,
+      PARTIAL_TREE_RENDERING,
+      STABLE_EVENT_HANDLERS
+    ),
+  )
+
+  private class SimpleScreen(
+    val name: String = "Empty",
+    val callback: () -> Unit,
+  )
+
+  @Test
+  fun all_runtimes_handle_rendering_events_in_one_message_from_callback() {
+    // Main thread handler.
+    val handler = Handler(Looper.getMainLooper())
+
+    runtimes.forEach { runtimeConfig ->
+      runTest(UnconfinedTestDispatcher()) {
+
+        var nextMessageRan = false
+        val theNextMessage = Message.obtain(handler) {
+          nextMessageRan = true
+        }
+        val countDownLatch = CountDownLatch(1)
+
+        val workflow = Workflow.stateful<String, String, SimpleScreen>(
+          initialState = "neverends",
+          render = { renderState ->
+            SimpleScreen(
+              name = renderState,
+              callback = {
+                actionSink.send(
+                  action(
+                    name = "handleInput"
+                  ) {
+                    state = "$state+$state"
+                  }
+                )
+                // If we do not end the test within 1 main thread message we'll blow up.
+                assertTrue(
+                  handler.sendMessage(theNextMessage),
+                  message = "Could not send to handler. This test does not work without that."
+                )
+              }
+            )
+          }
+        )
+
+        val renderings = renderWorkflowIn(
+          workflow = workflow,
+          scope = backgroundScope +
+            Dispatchers.Main.immediate,
+          props = MutableStateFlow(Unit).asStateFlow(),
+          runtimeConfig = runtimeConfig,
+          workflowTracer = null,
+          interceptors = emptyList()
+        ) {}
+
+        val collectionJob = launch(context = Dispatchers.Main.immediate) {
+          // Collect this unconfined so we can get all the renderings faster than actions can
+          // be processed.
+          renderings.collect {
+            if (it.rendering.name == "neverends+neverends") {
+              // The rendering we were looking for!
+              assertFalse(nextMessageRan, "The sent message ran :(.")
+              countDownLatch.countDown()
+            } else {
+              it.rendering.callback()
+            }
+          }
+        }
+
+        countDownLatch.await()
+        collectionJob.cancel()
+      }
+    }
+  }
+
+  @Test
+  fun all_runtimes_handle_deferrable_actions_in_one_message_from_action_applied() {
+    // Main thread handler.
+    val handler = Handler(Looper.getMainLooper())
+
+    runtimes.forEach { runtimeConfig ->
+      runTest(UnconfinedTestDispatcher()) {
+
+        val trigger = MutableStateFlow("unchanged state")
+
+        var nextMessageRan = false
+        val theNextMessage = Message.obtain(handler) {
+          nextMessageRan = true
+        }
+        val countDownLatch = CountDownLatch(1)
+
+        val workflow = Workflow.stateful<String, String, String>(
+          initialState = "unchanged state",
+          render = { renderState ->
+            runningSideEffect("only1") {
+              trigger.drop(1).collect {
+                actionSink.send(
+                  action(
+                    name = "triggerCollect",
+                    isDeferrable = true
+                  ) {
+                    state = it
+                    // If we do not end the test within 1 main thread message we'll blow up.
+                    assertTrue(
+                      handler.sendMessage(theNextMessage),
+                      message = "Could not send to handler. This test does not work without that."
+                    )
+                  }
+                )
+              }
+            }
+            renderState
+          }
+        )
+
+        val renderings = renderWorkflowIn(
+          workflow = workflow,
+          scope = backgroundScope +
+            Dispatchers.Main.immediate,
+          props = MutableStateFlow(Unit).asStateFlow(),
+          runtimeConfig = runtimeConfig,
+          workflowTracer = null,
+          interceptors = emptyList()
+        ) {}
+
+        val collectionJob = launch(context = Dispatchers.Main.immediate) {
+          // Collect this unconfined so we can get all the renderings faster than actions can
+          // be processed.
+          renderings.collect {
+            if (it.rendering == "changed state") {
+              // The rendering we were looking for!
+              assertFalse(nextMessageRan, "The sent message ran :(.")
+              countDownLatch.countDown()
+            }
+          }
+        }
+
+        trigger.emit("changed state")
+
+        countDownLatch.await()
+        collectionJob.cancel()
+      }
+    }
+  }
 }

--- a/workflow-runtime-android/src/androidTest/java/com/squareup/workflow1/AndroidRenderWorkflowInTest.kt
+++ b/workflow-runtime-android/src/androidTest/java/com/squareup/workflow1/AndroidRenderWorkflowInTest.kt
@@ -9,7 +9,6 @@ import com.squareup.workflow1.RuntimeConfigOptions.RENDER_ONLY_WHEN_STATE_CHANGE
 import com.squareup.workflow1.RuntimeConfigOptions.STABLE_EVENT_HANDLERS
 import com.squareup.workflow1.WorkflowInterceptor.RenderPassesComplete
 import com.squareup.workflow1.WorkflowInterceptor.RuntimeLoopOutcome
-import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/workflow-runtime-android/src/androidTest/java/com/squareup/workflow1/AndroidRenderWorkflowInTest.kt
+++ b/workflow-runtime-android/src/androidTest/java/com/squareup/workflow1/AndroidRenderWorkflowInTest.kt
@@ -1,0 +1,122 @@
+package com.squareup.workflow1
+
+import com.squareup.workflow1.RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS
+import com.squareup.workflow1.WorkflowInterceptor.RenderPassesComplete
+import com.squareup.workflow1.WorkflowInterceptor.RuntimeLoopOutcome
+import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Ignore
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(WorkflowExperimentalRuntime::class, ExperimentalCoroutinesApi::class)
+class AndroidRenderWorkflowInTest {
+
+  @Ignore("#1311: Does not yet work with immediate dispatcher.")
+  @Test
+  fun with_conflate_we_conflate_stacked_actions_into_one_rendering() =
+    runTest(UnconfinedTestDispatcher()) {
+
+      var childHandlerActionExecuted = false
+      val trigger1 = Channel<String>(capacity = 1)
+      val trigger2 = Channel<String>(capacity = 1)
+      val emitted = mutableListOf<String>()
+      var renderingsPassed = 0
+      val countInterceptor = object : WorkflowInterceptor {
+        override fun onRuntimeLoopTick(outcome: RuntimeLoopOutcome) {
+          if (outcome is RenderPassesComplete<*>) {
+            renderingsPassed++
+          }
+        }
+      }
+
+      val childWorkflow = Workflow.stateful<String, String, String>(
+        initialState = "unchanging state",
+        render = { renderState ->
+          runningWorker(
+            trigger1.receiveAsFlow().asWorker()
+          ) {
+            action("") {
+              state = it
+              setOutput(it)
+            }
+          }
+          renderState
+        }
+      )
+      val workflow = Workflow.stateful<String, String, String>(
+        initialState = "unchanging state",
+        render = { renderState ->
+          renderChild(childWorkflow) { childOutput ->
+            action("childHandler") {
+              childHandlerActionExecuted = true
+              state = childOutput
+            }
+          }
+          runningWorker(
+            trigger2.receiveAsFlow().asWorker()
+          ) {
+            action("") {
+              // Update the rendering in order to show conflation.
+              state = "$it+update"
+              setOutput(state)
+            }
+          }
+          renderState
+        }
+      )
+      val props = MutableStateFlow(Unit)
+      // Render this on the Main.immediate dispatcher from Android.
+      val renderings = renderWorkflowIn(
+        workflow = workflow,
+        scope = backgroundScope +
+          Dispatchers.Main.immediate,
+        props = props,
+        runtimeConfig = setOf(CONFLATE_STALE_RENDERINGS),
+        workflowTracer = null,
+        interceptors = listOf(countInterceptor)
+      ) { }
+
+      val renderedMutex = Mutex(locked = true)
+
+      val collectionJob = launch(context = Dispatchers.Main.immediate, start = UNDISPATCHED) {
+        // Collect this unconfined so we can get all the renderings faster than actions can
+        // be processed.
+        renderings.collect {
+          emitted += it.rendering
+          if (it.rendering == "changed state 2+update") {
+            renderedMutex.unlock()
+          }
+        }
+      }
+
+      launch(context = Dispatchers.Main.immediate, start = UNDISPATCHED) {
+        trigger1.trySend("changed state 1")
+        trigger2.trySend("changed state 2")
+      }.join()
+
+      renderedMutex.lock()
+
+      collectionJob.cancel()
+
+      // 2 renderings (initial and then the update.) Not *3* renderings.
+      assertEquals(2, emitted.size, "Expected only 2 renderings when conflating actions.")
+      assertEquals(
+        2,
+        renderingsPassed,
+        "Expected only 2 renderings passed when conflating actions."
+      )
+      assertEquals("changed state 2+update", emitted.last())
+      assertTrue(childHandlerActionExecuted)
+    }
+}

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
@@ -2,6 +2,7 @@ package com.squareup.workflow1.internal
 
 import com.squareup.workflow1.ActionApplied
 import com.squareup.workflow1.ActionProcessingResult
+import com.squareup.workflow1.ActionsExhausted
 import com.squareup.workflow1.NoopWorkflowInterceptor
 import com.squareup.workflow1.RuntimeConfig
 import com.squareup.workflow1.TreeSnapshot
@@ -146,19 +147,26 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
   }
 
   /**
-   * Uses [selector] to invoke [WorkflowNode.onNextAction] for every running child workflow this instance
+   * Uses [selector] to invoke [WorkflowNode.selectNextAction] for every running child workflow this instance
    * is managing.
    *
-   * @return [Boolean] whether or not the children action queues are empty.
    */
-  fun onNextChildAction(selector: SelectBuilder<ActionProcessingResult>): Boolean {
-    var empty = true
+  fun selectNextChildAction(
+    selector: SelectBuilder<ActionProcessingResult>,
+  ) {
     children.forEachActive { child ->
-      // Do this separately so the compiler doesn't avoid it if empty is already false.
-      val childEmpty = child.workflowNode.onNextAction(selector)
-      empty = childEmpty && empty
+      child.workflowNode.selectNextAction(selector)
     }
-    return empty
+  }
+
+  fun applyNextAvailableChildAction(): ActionProcessingResult {
+    children.forEachActive { child ->
+      val result = child.workflowNode.applyNextAvailableAction()
+      if (result != ActionsExhausted) {
+        return result
+      }
+    }
+    return ActionsExhausted
   }
 
   fun createChildSnapshots(): Map<WorkflowNodeId, TreeSnapshot> {

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowRunner.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowRunner.kt
@@ -6,7 +6,6 @@ import com.squareup.workflow1.RenderingAndSnapshot
 import com.squareup.workflow1.RuntimeConfig
 import com.squareup.workflow1.TreeSnapshot
 import com.squareup.workflow1.Workflow
-import com.squareup.workflow1.WorkflowExperimentalRuntime
 import com.squareup.workflow1.WorkflowInterceptor
 import com.squareup.workflow1.WorkflowTracer
 import kotlinx.coroutines.CancellationException

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/SubtreeManagerTest.kt
@@ -305,7 +305,7 @@ internal class SubtreeManagerTest {
   @Suppress("UNCHECKED_CAST")
   private suspend fun <P, S, O : Any> SubtreeManager<P, S, O>.applyNextAction() =
     select<ActionProcessingResult?> {
-      onNextChildAction(this)
+      selectNextChildAction(this)
     } as ActionApplied<WorkflowAction<P, S, O>?>
 
   private fun <P, S, O : Any> subtreeManagerForTest(

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -190,7 +190,7 @@ internal class WorkflowNodeTest {
     runTest {
       val result = withTimeout(10) {
         select {
-          node.onNextAction(this)
+          node.selectNextAction(this)
         } as ActionApplied<String>
       }
       assertEquals("applyActionOutput:event", result.output!!.value)
@@ -236,7 +236,7 @@ internal class WorkflowNodeTest {
       val result = withTimeout(10) {
         List(2) {
           select {
-            node.onNextAction(this)
+            node.selectNextAction(this)
           } as ActionApplied<String>
         }
       }
@@ -340,7 +340,7 @@ internal class WorkflowNodeTest {
       // Result should be available instantly, any delay at all indicates something is broken.
       val result = withTimeout(1) {
         select {
-          node.onNextAction(this)
+          node.selectNextAction(this)
         } as ActionApplied<String>
       }
       assertEquals("result", result.output!!.value)
@@ -1198,7 +1198,7 @@ internal class WorkflowNodeTest {
     sink.send("hello")
 
     val result = select {
-      node.onNextAction(this)
+      node.selectNextAction(this)
     } as ActionApplied<String>
     assertNull(result.output)
     assertTrue(result.stateChanged)
@@ -1227,7 +1227,7 @@ internal class WorkflowNodeTest {
 
     runTest {
       val result = select {
-        node.onNextAction(this)
+        node.selectNextAction(this)
       } as ActionApplied<String>
       assertEquals("output:hello", result.output!!.value)
       assertFalse(result.stateChanged)
@@ -1252,7 +1252,7 @@ internal class WorkflowNodeTest {
 
     runTest {
       val result = select {
-        node.onNextAction(this)
+        node.selectNextAction(this)
       } as ActionApplied<String>
       assertNull(result.output!!.value)
       assertFalse(result.stateChanged)
@@ -1279,7 +1279,7 @@ internal class WorkflowNodeTest {
     node.render(workflow.asStatefulWorkflow(), Unit)
 
     select {
-      node.onNextAction(this)
+      node.selectNextAction(this)
     } as ActionApplied<String>
 
     val state = node.render(workflow.asStatefulWorkflow(), Unit)
@@ -1306,7 +1306,7 @@ internal class WorkflowNodeTest {
 
     runTest {
       val result = select {
-        node.onNextAction(this)
+        node.selectNextAction(this)
       } as ActionApplied<String>
       assertEquals("output:child:hello", result.output!!.value)
     }
@@ -1330,7 +1330,7 @@ internal class WorkflowNodeTest {
 
     runTest {
       val result = select {
-        node.onNextAction(this)
+        node.selectNextAction(this)
       } as ActionApplied<String>
       assertNull(result.output!!.value)
     }


### PR DESCRIPTION
First commits adds a failing Android test to demonstrate the problem reported in #1311 .

Second commit fixes this for `CONFLATE_STALE_RENDERINGS` by `yield()`ing _before_ applying the first action.

The issue with `yield()` in the middle of CSR's inner loop was that it breaks our workflow runtime stabilizing into two main thread messages (`yield()` always posts to the Handler). We want to keep the guarantee of each Workflow update in response to an event as happening within _1_ main thread message.

This solution satisfies that constraint by `yield()`ing _before_ we apply the first action. With these optimizations enabled, when `select` resumes with a deferrable action ready to be processed, we provide it to the runtime loop as a `Deferred` - then we `yield()` _before_ applying it. This allows any other possible collectors to go ahead and queue actions. We can then drain them manually without `select` in the inner loop for conflate (and later DEA).

Note: We add a field for `isDeferrable` on action. Worker actions are by default deferrable. This allows us to opt actions from UI handlers _out_ of this type of optimization.

We also add tests on `Main.immediate` that confirm that non-deferrable actions are handled in one main thread message from *the callback*. Otherwise they are handled in one main thread message *from the action application*.
 
This also adds new methods for fetching those available actions to apply without `select` (using `tryReceive`) to the `WorkflowRunner` and `WorkflowNode` as well as `WorkflowChildNode`.

Fixes #1311 