### PR TITLE
Use workflow-pr-fixer app for Token Auth on fixup commits

### DIFF
--- a/.github/actions/gradle-task-with-commit/action.yml
+++ b/.github/actions/gradle-task-with-commit/action.yml
@@ -17,6 +17,8 @@ inputs:
   commit-message:
     description: 'The commit message to use if changes are generated'
     default: ''
+  access-token:
+    description: 'The access token to use for checkouts.'
   restore-cache-key:
     description: 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
     default: 'null'
@@ -40,12 +42,14 @@ runs:
         fi
 
     # ensure that we have the actual branch checked out.  By default, actions/checkout is headless.
-    - name: check out with PAT
+    - name: check out with the generated app token
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       if: steps.can-push.outputs.can_push == 'true'
       with:
         ref: ${{ github.head_ref }}
         fetch-depth: 0
+        token: ${{ inputs.access-token }}
+        persist-credentials: false
 
     - name: Run ${{ inputs.fix-task }}
       if: steps.can-push.outputs.can_push == 'true'
@@ -70,7 +74,7 @@ runs:
 
     - name: commit ${{ inputs.fix-task }} changes
       if: steps.can-push.outputs.can_push == 'true'
-      uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # v5
+      uses: stefanzweifel/git-auto-commit-action@v6
       with:
         commit_message: ${{ steps.set-commit-message.outputs.commit-message }}
         commit_options: '--no-verify --signoff'

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -47,6 +47,14 @@ jobs :
     steps :
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
+      # to be triggered again.
+      - name: Generate App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name : check published artifacts
         uses : ./.github/actions/gradle-task-with-commit
@@ -54,6 +62,7 @@ jobs :
           check-task : connectedCheckShardMatrixYamlCheck checkVersionIsSnapshot
           fix-task : connectedCheckShardMatrixYamlUpdate checkVersionIsSnapshot
           write-cache-key : build-logic
+          access-token : ${{ steps.app-token.outputs.token }}
 
   artifacts-check :
     name : ArtifactsCheck
@@ -62,6 +71,14 @@ jobs :
     steps :
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
+      # to be triggered again.
+      - name: Generate App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name : check published artifacts
         uses : ./.github/actions/gradle-task-with-commit
@@ -69,6 +86,7 @@ jobs :
           check-task : artifactsCheck
           fix-task : artifactsDump
           write-cache-key : build-logic
+          access-token : ${{ steps.app-token.outputs.token }}
 
   dependency-guard :
     name : Dependency Guard
@@ -76,6 +94,14 @@ jobs :
     steps :
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
+      # to be triggered again.
+      - name: Generate App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       # If the PR was made by a maintainer or Renovate, automatically update baselines and push
       # so that no one has to check out the branch and update the baselines manually.
@@ -85,6 +111,7 @@ jobs :
           check-task : dependencyGuard --refresh-dependencies
           fix-task : dependencyGuardBaseline --refresh-dependencies
           write-cache-key : build-logic
+          access-token : ${{ steps.app-token.outputs.token }}
 
   ktlint :
     name : KtLint
@@ -92,6 +119,14 @@ jobs :
     steps :
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
+      # to be triggered again.
+      - name: Generate App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       # If the PR was made by a maintainer or Renovate, automatically format and push
       # so that no one has to check out the branch and do it manually.
@@ -101,6 +136,7 @@ jobs :
           check-task : ktLintCheck
           fix-task : ktLintFormat
           write-cache-key : build-logic
+          access-token : ${{ steps.app-token.outputs.token }}
 
   api-check :
     name : Api check
@@ -108,6 +144,14 @@ jobs :
     steps :
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
+      # to be triggered again.
+      - name: Generate App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       # If the PR was made by a maintainer or Renovate, automatically format and push
       # so that no one has to check out the branch and do it manually.
@@ -117,6 +161,7 @@ jobs :
           check-task : apiCheck
           fix-task : apiDump
           write-cache-key : build-logic
+          access-token : ${{ steps.app-token.outputs.token }}
 
   android-lint :
     name : Android Lint

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,8 +5,7 @@ on:
 
 jobs:
   publish-release:
-    # macos-latest is too slow. -14 will become latest in Q2 '24
-    runs-on: macos-14
+    runs-on: macos-latest
     if: github.repository == 'square/workflow-kotlin'
     timeout-minutes: 45
 

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -8,8 +8,7 @@ on:
 
 jobs:
   publish-snapshot:
-    # macos-latest is too slow. -14 will become latest in Q2 '24
-    runs-on: macos-14
+    runs-on: macos-latest
     if: github.repository == 'square/workflow-kotlin'
     timeout-minutes: 45
 


### PR DESCRIPTION
I added the `workflow-pr-fixer` github app as owned by `square` org, and installed against `square` org just for this repo. We use that github app to authentication and get a 'PAT' equivalent which will allow us to add fixup commits that will still trigger the workflow to run checks after they are done.
😅 