### PR TITLE
Updated ComposeScreen idioms in samples.

### DIFF
--- a/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/preview/PreviewTest.kt
+++ b/samples/compose-samples/src/androidTest/java/com/squareup/sample/compose/preview/PreviewTest.kt
@@ -24,9 +24,9 @@ class PreviewTest {
     .around(IdlingDispatcherRule)
 
   @Test fun showsPreviewRendering() {
-    composeRule.onNodeWithText(ContactDetailsRendering::class.java.simpleName, substring = true)
+    composeRule.onNodeWithText(ContactDetailsScreen::class.java.simpleName, substring = true)
       .assertIsDisplayed()
-      .assertTextContains(previewContactRendering.details.phoneNumber, substring = true)
-      .assertTextContains(previewContactRendering.details.address, substring = true)
+      .assertTextContains(previewContactScreen.details.phoneNumber, substring = true)
+      .assertTextContains(previewContactScreen.details.address, substring = true)
   }
 }

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/HelloComposeScreen.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/hellocompose/HelloComposeScreen.kt
@@ -16,14 +16,31 @@ data class HelloComposeScreen(
   val onClick: () -> Unit
 ) : ComposeScreen {
   @Composable override fun Content() {
-    Text(
-      message,
-      modifier = Modifier
-        .clickable(onClick = onClick)
-        .fillMaxSize()
-        .wrapContentSize(Alignment.Center)
-    )
+    // It is best to keep this method as empty as possible to avoid
+    // capturing state from stale ComposeScreen instances,
+    // and to keep from interfering with Compose's stability checks.
+    // https://developer.android.com/develop/ui/compose/performance/stability
+    Hello(this)
   }
+}
+
+/**
+ * @param modifier even though we use the default [Modifier] when calling
+ * from [HelloComposeScreen.Content], a habit of accepting this param from the
+ * Composable itself is handy for screenshot tests and previews.
+ */
+@Composable
+private fun Hello(
+  screen: HelloComposeScreen,
+  modifier: Modifier = Modifier
+) {
+  Text(
+    screen.message,
+    modifier = modifier
+      .clickable(onClick = screen.onClick)
+      .fillMaxSize()
+      .wrapContentSize(Alignment.Center)
+  )
 }
 
 @Preview(heightDp = 150, showBackground = true)

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingActivity.kt
@@ -20,7 +20,8 @@ import com.squareup.workflow1.ui.workflowContentView
 import kotlinx.coroutines.flow.StateFlow
 
 /**
- * A workflow that returns an anonymous `ComposeRendering`.
+ * A workflow that returns an anonymous
+ * [ComposeScreen][com.squareup.workflow1.ui.compose.ComposeScreen].
  */
 class InlineRenderingActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/inlinerendering/InlineRenderingWorkflow.kt
@@ -39,18 +39,26 @@ object InlineRenderingWorkflow : StatefulWorkflow<Unit, Int, Nothing, Screen>() 
   ): ComposeScreen {
     val onClick = context.eventHandler("increment") { state += 1 }
     return ComposeScreen {
-      Box {
-        Button(onClick = onClick) {
-          Text("Counter: ")
-          AnimatedCounter(renderState) { counterValue ->
-            Text(counterValue.toString())
-          }
-        }
-      }
+      Content(renderState, onClick)
     }
   }
 
   override fun snapshotState(state: Int): Snapshot = Snapshot.of(state)
+}
+
+@Composable
+private fun Content(
+  count: Int,
+  onClick: () -> Unit
+) {
+  Box {
+    Button(onClick = onClick) {
+      Text("Counter: ")
+      AnimatedCounter(count) { counterValue ->
+        Text(counterValue.toString())
+      }
+    }
+  }
 }
 
 @Composable

--- a/samples/compose-samples/src/main/java/com/squareup/sample/compose/preview/PreviewActivity.kt
+++ b/samples/compose-samples/src/main/java/com/squareup/sample/compose/preview/PreviewActivity.kt
@@ -33,9 +33,9 @@ class PreviewActivity : AppCompatActivity() {
   }
 }
 
-val previewContactRendering = ContactRendering(
+val previewContactScreen = ContactScreen(
   name = "Dim Tonnelly",
-  details = ContactDetailsRendering(
+  details = ContactDetailsScreen(
     phoneNumber = "555-555-5555",
     address = "1234 Apgar Lane"
   )
@@ -46,27 +46,30 @@ val previewContactRendering = ContactRendering(
 fun PreviewApp() {
   MaterialTheme {
     Surface {
-      previewContactRendering.Preview()
+      previewContactScreen.Preview()
     }
   }
 }
 
-data class ContactRendering(
+data class ContactScreen(
   val name: String,
-  val details: ContactDetailsRendering
+  val details: ContactDetailsScreen
 ) : ComposeScreen {
   @Composable override fun Content() {
-    ContactDetails(this)
+    Contact(this)
   }
 }
 
-data class ContactDetailsRendering(
+// Note, not a ComposeScreen and has no view binding of any kind,
+// which would normally be a runtime error. We're demonstrating that
+// the preview is able to stub out the WorkflowRendering call below.
+data class ContactDetailsScreen(
   val phoneNumber: String,
   val address: String
 ) : Screen
 
 @Composable
-private fun ContactDetails(rendering: ContactRendering) {
+private fun Contact(screen: ContactScreen) {
   Card(
     modifier = Modifier
       .padding(8.dp)
@@ -76,9 +79,9 @@ private fun ContactDetails(rendering: ContactRendering) {
       modifier = Modifier.padding(16.dp),
       verticalArrangement = spacedBy(8.dp),
     ) {
-      Text(rendering.name, style = MaterialTheme.typography.body1)
+      Text(screen.name, style = MaterialTheme.typography.body1)
       WorkflowRendering(
-        rendering = rendering.details,
+        rendering = screen.details,
         modifier = Modifier
           .aspectRatio(1f)
           .border(0.dp, Color.LightGray)

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeScreen.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ComposeScreen.kt
@@ -24,6 +24,9 @@ import com.squareup.workflow1.ui.ViewRegistry
  *
  * Note that unlike most workflow view functions, [Content] does not take the rendering as a
  * parameter. Instead, the rendering is the receiver, i.e. the current value of `this`.
+ * Despite this (perhaps unfortunate) convenience, it is best to keep your `Content()`
+ * function as lean as possible to avoid interfering with Composes
+ * [stability calculations](https://developer.android.com/develop/ui/compose/performance/stability).
  *
  * Example:
  *
@@ -31,17 +34,29 @@ import com.squareup.workflow1.ui.ViewRegistry
  *       val message: String,
  *       val onClick: () -> Unit
  *     ) : ComposeScreen {
- *
- *       @Composable override fun Content(viewEnvironment: ViewEnvironment) {
- *         Button(onClick) {
- *           Text(message)
- *         }
+ *       @Composable override fun Content() {
+ *         Hello(this)
  *       }
  *     }
  *
- * This is the simplest way to bridge the gap between your workflows and the UI, but using it
- * requires your workflows code to reside in Android modules and depend upon the Compose runtime,
- * instead of being pure Kotlin. If this is a problem, or you need more flexibility for any other
+ *     @Composable
+ *     private fun Hello(
+ *       screen: HelloScreen,
+ *       modifier: Modifier = Modifier
+ *     ) {
+ *         Button(screen.onClick, modifier) {
+ *           Text(screen.message)
+ *         }
+ *     }
+ *
+ * (Note that the example includes a `modifier` parameter that is not used by
+ * the `HelloScreen` itself. We recommend this approach to simplify
+ * previews and snapshot tests.)
+ *
+ * [ComposeScreen] is the simplest way to bridge the gap between your workflows and the UI,
+ * but using it requires your workflows code to reside in Android modules
+ * and depend upon the Compose runtime, instead of being pure Kotlin.
+ * If this is a problem, or you need more flexibility for any other
  * reason, you can use [ViewRegistry] to bind your renderings to [ScreenComposableFactory]
  * implementations at runtime.
  *


### PR DESCRIPTION
Demonstrates and documents the preferred pattern of keeping Composable functions as static as possible, and fixes a few stray doc spots where `WorkflowRendering` was still being called with its `ViewEnvironment` parameter.