### PR TITLE
1311: Dispatcher Tests for RenderWorkflowIn on Android

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
 
   compileOnly(gradleApi())
 
+  implementation(libs.burst.plugin)
   implementation(libs.android.gradle.plugin)
   implementation(libs.kgx)
   implementation(libs.dokka.gradle.plugin)

--- a/dependencies/classpath.txt
+++ b/dependencies/classpath.txt
@@ -1,5 +1,9 @@
 androidx.databinding:databinding-common:8.8.0
 androidx.databinding:databinding-compiler-common:8.8.0
+app.cash.burst:burst-gradle-plugin:2.1.0
+app.cash.burst:burst-jvm:2.1.0
+app.cash.burst:burst-kotlin-plugin:2.1.0
+app.cash.burst:burst:2.1.0
 com.android.databinding:baseLibrary:8.8.0
 com.android.tools.analytics-library:crash:31.8.0
 com.android.tools.analytics-library:protos:31.8.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,8 @@ androidx-tracing = "1.2.0"
 androidx-transition = "1.5.1"
 androidx-viewbinding = "8.1.2"
 
+burst = "2.1.0"
+
 detekt = "1.19.0"
 dokka = "2.0.0"
 dependencyGuard = "0.5.0"
@@ -83,6 +85,7 @@ squareup-moshi = "1.15.0"
 squareup-moshi-kotlin = "1.15.2"
 squareup-okhttp = "4.9.1"
 squareup-okio = "3.3.0"
+squareup-papa = "0.30"
 squareup-radiography = "2.4.1"
 squareup-retrofit = "2.9.0"
 squareup-seismic = "1.0.3"
@@ -184,6 +187,8 @@ androidx-transition = { module = "androidx.transition:transition", version.ref =
 
 androidx-viewbinding = { module = "androidx.databinding:viewbinding", version.ref = "androidx-viewbinding" }
 
+burst-plugin = { module = "app.cash.burst:burst-gradle-plugin", version.ref = "burst" }
+
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 
 dropbox-dependencyGuard = { module = "com.dropbox.dependency-guard:dependency-guard", version.ref = "dependencyGuard" }
@@ -257,6 +262,8 @@ squareup-moshi-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", v
 squareup-moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "squareup-moshi-kotlin" }
 
 squareup-okio = { module = "com.squareup.okio:okio", version.ref = "squareup-okio" }
+
+squareup-papa = { module = "com.squareup.papa:papa", version.ref = "squareup-papa"}
 
 squareup-radiography = { module = "com.squareup.radiography:radiography", version.ref = "squareup-radiography" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -64,6 +64,7 @@ include(
   ":workflow-config:config-jvm",
   ":workflow-core",
   ":workflow-runtime",
+  ":workflow-runtime-android",
   ":workflow-rx2",
   ":workflow-testing",
   ":workflow-tracing",

--- a/workflow-runtime-android/README.md
+++ b/workflow-runtime-android/README.md
@@ -1,0 +1,4 @@
+# Module Workflow Runtime Android
+
+This module is an Android library that is used to test the Workflow Runtime with Android specific
+coroutine dispatchers. These are headless android-tests that run on device without UI.

--- a/workflow-runtime-android/build.gradle.kts
+++ b/workflow-runtime-android/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+  id("com.android.library")
+  id("kotlin-android")
+  id("android-defaults")
+  id("android-ui-tests")
+  id("app.cash.burst")
+}
+
+android {
+  namespace = "com.squareup.workflow1.android"
+  testNamespace = "$namespace.test"
+}
+
+dependencies {
+  api(project(":workflow-runtime"))
+  implementation(project(":workflow-core"))
+
+  androidTestImplementation(libs.androidx.test.core)
+  androidTestImplementation(libs.androidx.test.truth)
+  androidTestImplementation(libs.kotlin.test.core)
+  androidTestImplementation(libs.kotlin.test.jdk)
+  androidTestImplementation(libs.kotlinx.coroutines.android)
+  androidTestImplementation(libs.kotlinx.coroutines.core)
+  androidTestImplementation(libs.kotlinx.coroutines.test)
+  androidTestImplementation(libs.squareup.papa)
+  androidTestImplementation(libs.turbine)
+}

--- a/workflow-runtime-android/gradle.properties
+++ b/workflow-runtime-android/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=workflow-runtime-android
+POM_NAME=Workflow Runtime Android
+POM_PACKAGING=aar

--- a/workflow-runtime-android/src/androidTest/AndroidManifest.xml
+++ b/workflow-runtime-android/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <application>
+    <activity android:name="androidx.activity.ComponentActivity"/>
+  </application>
+</manifest>

--- a/workflow-runtime-android/src/androidTest/java/com/squareup/workflow1/android/AndroidDispatchersRenderWorkflowInTest.kt
+++ b/workflow-runtime-android/src/androidTest/java/com/squareup/workflow1/android/AndroidDispatchersRenderWorkflowInTest.kt
@@ -1,0 +1,424 @@
+@file:OptIn(WorkflowExperimentalRuntime::class)
+@file:Suppress("JUnitMalformedDeclaration")
+
+package com.squareup.workflow1.android
+
+import app.cash.burst.Burst
+import com.squareup.workflow1.RuntimeConfig
+import com.squareup.workflow1.RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS
+import com.squareup.workflow1.RuntimeConfigOptions.Companion.RENDER_PER_ACTION
+import com.squareup.workflow1.RuntimeConfigOptions.PARTIAL_TREE_RENDERING
+import com.squareup.workflow1.RuntimeConfigOptions.RENDER_ONLY_WHEN_STATE_CHANGES
+import com.squareup.workflow1.RuntimeConfigOptions.STABLE_EVENT_HANDLERS
+import com.squareup.workflow1.Workflow
+import com.squareup.workflow1.WorkflowExperimentalRuntime
+import com.squareup.workflow1.WorkflowInterceptor
+import com.squareup.workflow1.WorkflowInterceptor.RenderPassesComplete
+import com.squareup.workflow1.WorkflowInterceptor.RuntimeLoopOutcome
+import com.squareup.workflow1.action
+import com.squareup.workflow1.asWorker
+import com.squareup.workflow1.renderChild
+import com.squareup.workflow1.runningWorker
+import com.squareup.workflow1.stateful
+import com.squareup.workflow1.ui.renderWorkflowIn
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import papa.Choreographers
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+
+@OptIn(WorkflowExperimentalRuntime::class)
+@Burst
+class AndroidDispatchersRenderWorkflowInTest(
+  private val runtime: RuntimeOptions = RuntimeOptions.DEFAULT
+) {
+
+  @Before
+  fun setup() {
+    resetOrderCounter()
+  }
+
+  @Ignore("See https://github.com/square/workflow-kotlin/issues/1311")
+  @Test
+  fun conflate_renderings_for_multiple_worker_actions_same_trigger() =
+    runTest {
+
+      val trigger = MutableStateFlow("unchanged state")
+      val emitted = mutableListOf<String>()
+      var renderingsPassed = 0
+      val countInterceptor = object : WorkflowInterceptor {
+        override fun onRuntimeLoopTick(outcome: RuntimeLoopOutcome) {
+          if (outcome is RenderPassesComplete<*>) {
+            renderingsPassed++
+          }
+        }
+      }
+
+      val childWorkflow = Workflow.stateful<String, String, String>(
+        initialState = "unchanged state",
+        render = { renderState ->
+          runningWorker(
+            worker = trigger.drop(1).asWorker(),
+            key = "Worker1"
+          ) {
+            action("") {
+              val newState = "$it+u1"
+              state = newState
+              setOutput(newState)
+            }
+          }
+          renderState
+        }
+      )
+      val workflow = Workflow.stateful<String, String, String>(
+        initialState = "unchanged state",
+        render = { renderState ->
+          renderChild(childWorkflow) { childOutput ->
+            action("childHandler") {
+              state = childOutput
+            }
+          }
+          runningWorker(
+            worker = trigger.drop(1).asWorker(),
+            key = "Worker2"
+          ) {
+            action("") {
+              // Update the state in order to show conflation.
+              state = "$state+u2"
+            }
+          }
+          runningWorker(
+            worker = trigger.drop(1).asWorker(),
+            key = "Worker3"
+          ) {
+            action("") {
+              // Update the state in order to show conflation.
+              state = "$state+u3"
+            }
+          }
+          runningWorker(
+            worker = trigger.drop(1).asWorker(),
+            key = "Worker4"
+          ) {
+            action("") {
+              // Update the state in order to show conflation.
+              state = "$state+u4"
+              // Output only on the last one!
+              setOutput(state)
+            }
+          }
+          renderState
+        }
+      )
+      val props = MutableStateFlow(Unit)
+      val renderings = renderWorkflowIn(
+        workflow = workflow,
+        scope = backgroundScope +
+          ANDROID_WORKFLOW_RUNTIME_DISPATCHER,
+        props = props,
+        runtimeConfig = setOf(CONFLATE_STALE_RENDERINGS),
+        workflowTracer = null,
+        interceptors = listOf(countInterceptor)
+      ) { }
+
+      val renderedMutex = Mutex(locked = true)
+
+      val collectionJob = launch {
+        renderings.collect {
+          emitted += it
+          if (it == "state change+u1+u2+u3+u4") {
+            renderedMutex.unlock()
+          }
+        }
+      }
+
+      testScheduler.advanceUntilIdle()
+
+      launch {
+        trigger.value = "state change"
+      }
+
+      testScheduler.advanceUntilIdle()
+
+      renderedMutex.lock()
+
+      collectionJob.cancel()
+
+      // 2 renderings (initial and then the update.) Not *5* renderings.
+      assertEquals(2, emitted.size, "Expected only 2 emitted renderings when conflating actions.")
+      assertEquals(
+        2,
+        renderingsPassed,
+        "Expected only 2 renderings passed to interceptor when conflating actions."
+      )
+      assertEquals("state change+u1+u2+u3+u4", emitted.last())
+    }
+
+  @Ignore("See https://github.com/square/workflow-kotlin/issues/1311")
+  @Test
+  fun conflate_renderings_for_multiple_side_effect_actions() =
+    runTest {
+
+      val trigger = MutableStateFlow("unchanged state")
+      val emitted = mutableListOf<String>()
+      var renderingsPassed = 0
+      val countInterceptor = object : WorkflowInterceptor {
+        override fun onRuntimeLoopTick(outcome: RuntimeLoopOutcome) {
+          if (outcome is RenderPassesComplete<*>) {
+            renderingsPassed++
+          }
+        }
+      }
+
+      val childWorkflow = Workflow.stateful<String, String, String>(
+        initialState = "unchanged state",
+        render = { renderState ->
+          runningSideEffect("childSideEffect") {
+            trigger.drop(1).collect {
+              actionSink.send(
+                action(
+                  name = "handleChildSideEffectAction",
+                ) {
+                  val newState = "$it+u1"
+                  state = newState
+                  setOutput(newState)
+                }
+              )
+            }
+          }
+          renderState
+        }
+      )
+      val workflow = Workflow.stateful<String, String, String>(
+        initialState = "unchanged state",
+        render = { renderState ->
+          renderChild(childWorkflow) { childOutput ->
+            action("childHandler") {
+              state = childOutput
+            }
+          }
+          runningSideEffect("parentSideEffect") {
+            trigger.drop(1).collect {
+              actionSink.send(
+                action(
+                  name = "handleParentSideEffectAction",
+                ) {
+                  state = "$state+u2"
+                }
+              )
+            }
+          }
+          renderState
+        }
+      )
+      val props = MutableStateFlow(Unit)
+      val renderings = renderWorkflowIn(
+        workflow = workflow,
+        scope = backgroundScope +
+          ANDROID_WORKFLOW_RUNTIME_DISPATCHER,
+        props = props,
+        runtimeConfig = setOf(CONFLATE_STALE_RENDERINGS),
+        workflowTracer = null,
+        interceptors = listOf(countInterceptor)
+      ) { }
+
+      val renderedMutex = Mutex(locked = true)
+
+      val collectionJob = launch {
+        renderings.collect {
+          emitted += it
+          if (it == "state change+u1+u2") {
+            renderedMutex.unlock()
+          }
+        }
+      }
+
+      testScheduler.advanceUntilIdle()
+
+      launch {
+        trigger.value = "state change"
+      }
+
+      testScheduler.advanceUntilIdle()
+
+      renderedMutex.lock()
+
+      collectionJob.cancel()
+
+      // 2 renderings (initial and then the update.) Not *3* renderings.
+      assertEquals(2, emitted.size, "Expected only 2 emitted renderings when conflating actions.")
+      assertEquals(
+        2,
+        renderingsPassed,
+        "Expected only 2 renderings passed to interceptor when conflating actions."
+      )
+      assertEquals("state change+u1+u2", emitted.last())
+    }
+
+  @Test
+  fun all_runtimes_handle_side_effect_actions_before_the_next_frame() =
+    runTest {
+      val completedMutex = Mutex(locked = true)
+      val trigger = MutableSharedFlow<String>()
+
+      val workflow = Workflow.stateful<String, String, String>(
+        initialState = "unchanged state",
+        render = { renderState ->
+          runningSideEffect("only1") {
+            trigger.collect {
+              actionSink.send(action(name = "triggerCollect") { state = it })
+            }
+          }
+          renderState
+        }
+      )
+
+      val renderings = renderWorkflowIn(
+        workflow = workflow,
+        scope = backgroundScope +
+          ANDROID_WORKFLOW_RUNTIME_DISPATCHER,
+        props = MutableStateFlow(Unit).asStateFlow(),
+        runtimeConfig = runtime.runtimeConfig,
+        workflowTracer = null,
+        interceptors = emptyList()
+      ) {}
+
+      val collectionJob = launch(Dispatchers.Main.immediate) {
+        renderings.collect {
+          if (it == "changed state") {
+            // The rendering we were looking for!
+            expectInOrder(1)
+            completedMutex.unlock()
+          } else {
+            expectInOrder(0)
+            Choreographers.postOnFrameRendered {
+              // We are expecting this to happen last, after we get the rendering!
+              expectInOrder(2)
+            }
+            trigger.emit("changed state")
+          }
+        }
+      }
+
+      completedMutex.lock()
+      collectionJob.cancel()
+    }
+
+  @Test
+  fun all_runtimes_handle_rendering_events_before_next_frame() = runTest {
+    val completedMutex = Mutex(locked = true)
+    val frameCompleteMutex = Mutex(locked = true)
+    val workflow = Workflow.stateful<String, String, SimpleScreen>(
+      initialState = "neverends",
+      render = { renderState ->
+        SimpleScreen(
+          name = renderState,
+          callback = {
+            actionSink.send(action(name = "handleInput") { state = "$state+$state" })
+          }
+        )
+      }
+    )
+
+    val renderings = renderWorkflowIn(
+      workflow = workflow,
+      scope = backgroundScope +
+        ANDROID_WORKFLOW_RUNTIME_DISPATCHER,
+      props = MutableStateFlow(Unit).asStateFlow(),
+      runtimeConfig = runtime.runtimeConfig,
+      workflowTracer = null,
+      interceptors = emptyList()
+    ) {}
+
+    val collectionJob = launch(Dispatchers.Main.immediate) {
+      renderings.collect {
+        if (it.name == "neverends+neverends") {
+          // The rendering we were looking for after the event!
+          expectInOrder(1)
+          completedMutex.unlock()
+        } else {
+          expectInOrder(0)
+          Choreographers.postOnFrameRendered {
+            // This should be happening last!
+            expectInOrder(2)
+            frameCompleteMutex.unlock()
+          }
+          // First rendering, lets call it.
+          it.callback()
+        }
+      }
+    }
+
+    completedMutex.lock()
+    frameCompleteMutex.lock()
+    expectInOrder(3)
+    collectionJob.cancel()
+  }
+
+  private class SimpleScreen(
+    val name: String = "Empty",
+    val callback: () -> Unit,
+  )
+
+  private val orderIndex = AtomicInteger(0)
+
+  private fun resetOrderCounter() {
+    orderIndex.set(0)
+  }
+
+  private fun expectInOrder(
+    expected: Int,
+    prefix: String = ""
+  ) {
+    val localActual = orderIndex.getAndIncrement()
+    assertEquals(
+      expected,
+      localActual,
+      "$prefix: This should have happened" +
+        " in a different order position:"
+    )
+  }
+
+  companion object {
+    val ANDROID_WORKFLOW_RUNTIME_DISPATCHER: CoroutineDispatcher = Dispatchers.Main.immediate
+  }
+}
+
+enum class RuntimeOptions(
+  val runtimeConfig: RuntimeConfig
+) {
+  DEFAULT(RENDER_PER_ACTION),
+  RENDER_ONLY(setOf(RENDER_ONLY_WHEN_STATE_CHANGES)),
+  CONFLATE(setOf(CONFLATE_STALE_RENDERINGS)),
+  STABLE(setOf(STABLE_EVENT_HANDLERS)),
+  RENDER_ONLY_CONFLATE(setOf(CONFLATE_STALE_RENDERINGS, RENDER_ONLY_WHEN_STATE_CHANGES)),
+  RENDER_ONLY_PARTIAL(setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING)),
+  RENDER_ONLY_CONFLATE_STABLE(
+    setOf(CONFLATE_STALE_RENDERINGS, RENDER_ONLY_WHEN_STATE_CHANGES, STABLE_EVENT_HANDLERS)
+  ),
+  RENDER_ONLY_PARTIAL_STABLE(
+    setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING, STABLE_EVENT_HANDLERS)
+  ),
+  RENDER_ONLY_CONFLATE_PARTIAL(
+    setOf(CONFLATE_STALE_RENDERINGS, RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING)
+  ),
+  RENDER_ONLY_CONFLATE_PARTIAL_STABLE(
+    setOf(
+      CONFLATE_STALE_RENDERINGS,
+      RENDER_ONLY_WHEN_STATE_CHANGES,
+      PARTIAL_TREE_RENDERING,
+      STABLE_EVENT_HANDLERS
+    )
+  )
+}


### PR DESCRIPTION
A set of tests for using `renderWorkflowIn` with particular dispatchers on Android. These are used in two ways:

1. To ensure we are satisfying the guarantee we want to keep: Updates from the runtime in response to an event are processed before the next Choreographer frame on Android.
2. We are effectively conflating renderings on Android when using a particular dispatcher (e.g., in this case the `Main.immediate` dispatcher). Now, this 2nd category is currently failing! That's part of the fix that needs to happen for #1311 . So we merge these red tests first.