### PR TITLE
Persist checkout credentials for push

### DIFF
--- a/.github/actions/gradle-task-with-commit/action.yml
+++ b/.github/actions/gradle-task-with-commit/action.yml
@@ -33,7 +33,9 @@ runs:
       id: can-push
       shell: bash
       run: |
-        if [[ "${{ env.GITHUB_REF_PROTECTED }}" == 'true' ]]; then
+        if [[ "${{ inputs.access-token }}" == '' ]]; then
+          echo "can_push=false" >> $GITHUB_OUTPUT
+        elif [[ "${{ env.GITHUB_REF_PROTECTED }}" == 'true' ]]; then
           echo "can_push=false" >> $GITHUB_OUTPUT
         elif [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
           echo "can_push=false" >> $GITHUB_OUTPUT
@@ -46,10 +48,9 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       if: steps.can-push.outputs.can_push == 'true'
       with:
+        token: ${{ inputs.access-token }}
         ref: ${{ github.head_ref }}
         fetch-depth: 0
-        token: ${{ inputs.access-token }}
-        persist-credentials: false
 
     - name: Run ${{ inputs.fix-task }}
       if: steps.can-push.outputs.can_push == 'true'


### PR DESCRIPTION
I'm getting authentication errors on the fixup commits - https://github.com/square/workflow-kotlin/actions/runs/15763150244/job/44434172257?pr=1350 and I believe it is because we did not persist the credentials from the `checkout` action to be available for the `git-auto-commit-action`.
I'm updating to remove that line.

Also adding back the check for `can-push` to check if there is an `access-token` specified as I forgot to do that when I added it back.