### PR TITLE
DRAIN_EXCLUSIVE_ACTIONS implementation

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -1,50 +1,50 @@
-name : Kotlin CI
+name: Kotlin CI
 
-on :
-  pull_request :
-  merge_group :
+on:
+  pull_request:
+  merge_group:
 
 env:
   ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: 720 # 12 minutes; default is 20s
 
 # If CI is already running for a branch when that branch is updated, cancel the older jobs.
-concurrency :
-  group : ci-${{ github.ref }}-${{ github.head_ref }}
-  cancel-in-progress : true
+concurrency:
+  group: ci-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
-jobs :
+jobs:
 
-  build-all :
-    name : Build all
-    runs-on : workflow-kotlin-test-runner-ubuntu-4core
-    steps :
+  build-all:
+    name: Build all
+    runs-on: workflow-kotlin-test-runner-ubuntu-4core
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name : main build
-        uses : ./.github/actions/gradle-task
-        with :
-          task : compileKotlin assembleDebug
-          write-cache-key : main-build-artifacts
+      - name: main build
+        uses: ./.github/actions/gradle-task
+        with:
+          task: compileKotlin assembleDebug
+          write-cache-key: main-build-artifacts
 
-  dokka :
-    name : Dokka
-    runs-on : ubuntu-latest
-    needs : build-all
-    steps :
+  dokka:
+    name: Dokka
+    runs-on: ubuntu-latest
+    needs: build-all
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name : Run dokka to validate kdoc
-        uses : ./.github/actions/gradle-task
-        with :
-          task : siteDokka
-          write-cache-key : main-build-artifacts
+      - name: Run dokka to validate kdoc
+        uses: ./.github/actions/gradle-task
+        with:
+          task: siteDokka
+          write-cache-key: main-build-artifacts
 
-  shards-and-version :
-    name : Shard Matrix Yaml
-    runs-on : workflow-kotlin-test-runner-ubuntu-4core
-    steps :
+  shards-and-version:
+    name: Shard Matrix Yaml
+    runs-on: workflow-kotlin-test-runner-ubuntu-4core
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
@@ -56,19 +56,19 @@ jobs :
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name : check published artifacts
-        uses : ./.github/actions/gradle-task-with-commit
-        with :
-          check-task : connectedCheckShardMatrixYamlCheck checkVersionIsSnapshot
-          fix-task : connectedCheckShardMatrixYamlUpdate checkVersionIsSnapshot
-          write-cache-key : build-logic
-          access-token : ${{ steps.app-token.outputs.token }}
+      - name: check published artifacts
+        uses: ./.github/actions/gradle-task-with-commit
+        with:
+          check-task: connectedCheckShardMatrixYamlCheck checkVersionIsSnapshot
+          fix-task: connectedCheckShardMatrixYamlUpdate checkVersionIsSnapshot
+          write-cache-key: build-logic
+          access-token: ${{ steps.app-token.outputs.token }}
 
-  artifacts-check :
-    name : ArtifactsCheck
+  artifacts-check:
+    name: ArtifactsCheck
     # the `artifactsCheck` task has to run on macOS in order to see the iOS KMP artifacts
-    runs-on : macos-latest
-    steps :
+    runs-on: macos-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
@@ -80,18 +80,18 @@ jobs :
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name : check published artifacts
-        uses : ./.github/actions/gradle-task-with-commit
-        with :
-          check-task : artifactsCheck
-          fix-task : artifactsDump
-          write-cache-key : build-logic
-          access-token : ${{ steps.app-token.outputs.token }}
+      - name: check published artifacts
+        uses: ./.github/actions/gradle-task-with-commit
+        with:
+          check-task: artifactsCheck
+          fix-task: artifactsDump
+          write-cache-key: build-logic
+          access-token: ${{ steps.app-token.outputs.token }}
 
-  dependency-guard :
-    name : Dependency Guard
-    runs-on : ubuntu-latest
-    steps :
+  dependency-guard:
+    name: Dependency Guard
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
@@ -105,18 +105,18 @@ jobs :
 
       # If the PR was made by a maintainer or Renovate, automatically update baselines and push
       # so that no one has to check out the branch and update the baselines manually.
-      - name : dependency-guard
-        uses : ./.github/actions/gradle-task-with-commit
-        with :
-          check-task : dependencyGuard --refresh-dependencies
-          fix-task : dependencyGuardBaseline --refresh-dependencies
-          write-cache-key : build-logic
-          access-token : ${{ steps.app-token.outputs.token }}
+      - name: dependency-guard
+        uses: ./.github/actions/gradle-task-with-commit
+        with:
+          check-task: dependencyGuard --refresh-dependencies
+          fix-task: dependencyGuardBaseline --refresh-dependencies
+          write-cache-key: build-logic
+          access-token: ${{ steps.app-token.outputs.token }}
 
-  ktlint :
-    name : KtLint
-    runs-on : ubuntu-latest
-    steps :
+  ktlint:
+    name: KtLint
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
@@ -130,18 +130,18 @@ jobs :
 
       # If the PR was made by a maintainer or Renovate, automatically format and push
       # so that no one has to check out the branch and do it manually.
-      - name : KtLint
-        uses : ./.github/actions/gradle-task-with-commit
-        with :
-          check-task : ktLintCheck
-          fix-task : ktLintFormat
-          write-cache-key : build-logic
-          access-token : ${{ steps.app-token.outputs.token }}
+      - name: KtLint
+        uses: ./.github/actions/gradle-task-with-commit
+        with:
+          check-task: ktLintCheck
+          fix-task: ktLintFormat
+          write-cache-key: build-logic
+          access-token: ${{ steps.app-token.outputs.token }}
 
-  api-check :
-    name : Api check
-    runs-on : ubuntu-latest
-    steps :
+  api-check:
+    name: Api check
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
@@ -155,115 +155,136 @@ jobs :
 
       # If the PR was made by a maintainer or Renovate, automatically format and push
       # so that no one has to check out the branch and do it manually.
-      - name : binary compatibility
-        uses : ./.github/actions/gradle-task-with-commit
-        with :
-          check-task : apiCheck
-          fix-task : apiDump
-          write-cache-key : build-logic
-          access-token : ${{ steps.app-token.outputs.token }}
+      - name: binary compatibility
+        uses: ./.github/actions/gradle-task-with-commit
+        with:
+          check-task: apiCheck
+          fix-task: apiDump
+          write-cache-key: build-logic
+          access-token: ${{ steps.app-token.outputs.token }}
 
-  android-lint :
-    name : Android Lint
-    runs-on : ubuntu-latest
-    needs : build-all
-    timeout-minutes : 20
-    steps :
+  android-lint:
+    name: Android Lint
+    runs-on: ubuntu-latest
+    needs: build-all
+    timeout-minutes: 20
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name : Check with Gradle
-        uses : ./.github/actions/gradle-task
-        with :
-          task : lint
-          write-cache-key : main-build-artifacts
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: lint
+          write-cache-key: main-build-artifacts
 
-  check :
-    name : Check
-    runs-on : macos-latest
-    needs : build-all
-    timeout-minutes : 20
-    steps :
+  check:
+    name: Check
+    runs-on: macos-latest
+    needs: build-all
+    timeout-minutes: 20
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name : Check with Gradle
-        uses : ./.github/actions/gradle-task
-        with :
-          task : |
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: |
             allTests
             test
             --continue
-          restore-cache-key : build-logic
-          write-cache-key : main-build-artifacts
+          restore-cache-key: build-logic
+          write-cache-key: main-build-artifacts
 
       # Report as GitHub Pull Request Check.
-      - name : Publish Test Report
-        uses : mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
-        if : always() # always run even if the previous step fails
-        with :
-          report_paths : '**/build/test-results/test/TEST-*.xml'
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
 
-  tutorials :
-    name : Build Tutorials
-    runs-on : ubuntu-latest
-    timeout-minutes : 15
-    steps :
+  tutorials:
+    name: Build Tutorials
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
       # These setup steps should be common across all jobs in this workflow.
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name : build tutorials
-        uses : ./.github/actions/gradle-task
-        with :
-          task : build
-          build-root-directory : samples/tutorial
-          restore-cache-key : main-build-artifacts
+      - name: build tutorials
+        uses: ./.github/actions/gradle-task
+        with:
+          task: build
+          build-root-directory: samples/tutorial
+          restore-cache-key: main-build-artifacts
 
-  jvm-conflate-runtime-test :
-    name : Conflate Stale Renderings Runtime JVM Tests
-    runs-on : ubuntu-latest
-    timeout-minutes : 20
-    steps :
+  jvm-drainExclusive-runtime-test:
+    name: DEA JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name : Check with Gradle
-        uses : ./.github/actions/gradle-task
-        with :
-          task : jvmTest --continue -Pworkflow.runtime=conflate
-          restore-cache-key : main-build-artifacts
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=drainExclusive
+          restore-cache-key: main-build-artifacts
 
       # Report as GitHub Pull Request Check.
-      - name : Publish Test Report
-        uses : mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
-        if : always() # always run even if the previous step fails
-        with :
-          report_paths : '**/build/test-results/test/TEST-*.xml'
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
 
-  jvm-stateChange-runtime-test :
-    name : Render On State Change Only Runtime JVM Tests
-    runs-on : ubuntu-latest
-    timeout-minutes : 20
-    steps :
+  jvm-conflate-runtime-test:
+    name: CSR JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name : Check with Gradle
-        uses : ./.github/actions/gradle-task
-        with :
-          task : jvmTest --continue -Pworkflow.runtime=stateChange
-          restore-cache-key : main-build-artifacts
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=conflate
+          restore-cache-key: main-build-artifacts
 
       # Report as GitHub Pull Request Check.
-      - name : Publish Test Report
-        uses : mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
-        if : always() # always run even if the previous step fails
-        with :
-          report_paths : '**/build/test-results/test/TEST-*.xml'
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+  jvm-stateChange-runtime-test:
+    name: SCO JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=stateChange
+          restore-cache-key: main-build-artifacts
+
+      # Report as GitHub Pull Request Check.
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
 
   jvm-stable-handlers-test:
-    name: Stable Event Handlers Only Runtime JVM Tests
+    name: SEH JVM Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -284,7 +305,7 @@ jobs :
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
   jvm-partial-runtime-test:
-    name: Partial Tree Rendering Only Runtime JVM Tests
+    name: PTR JVM Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -304,29 +325,29 @@ jobs :
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
-  jvm-conflate-stateChange-runtime-test :
-    name : Render On State Change Only and Conflate Stale Runtime JVM Tests
-    runs-on : ubuntu-latest
-    timeout-minutes : 20
-    steps :
+  jvm-conflate-stateChange-runtime-test:
+    name: SCO, CSR JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name : Check with Gradle
-        uses : ./.github/actions/gradle-task
-        with :
-          task : jvmTest --continue -Pworkflow.runtime=conflate-stateChange
-          restore-cache-key : main-build-artifacts
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=conflate-stateChange
+          restore-cache-key: main-build-artifacts
 
       # Report as GitHub Pull Request Check.
-      - name : Publish Test Report
-        uses : mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
-        if : always() # always run even if the previous step fails
-        with :
-          report_paths : '**/build/test-results/test/TEST-*.xml'
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
 
   jvm-conflate-partial-runtime-test:
-    name: Render On State Change Only and Conflate Stale Runtime JVM Tests
+    name: CSR, PTR JVM Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -346,131 +367,236 @@ jobs :
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
-  ios-tests :
-    name : iOS Tests
-    runs-on : macos-latest
-    timeout-minutes : 30
-    steps :
+  jvm-conflate-drainExclusive-runtime-test:
+    name: CSR, DEA JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name : Check with Gradle
-        uses : ./.github/actions/gradle-task
-        with :
-          task : iosX64Test
-          restore-cache-key : main-build-artifacts
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=conflate-drainExclusive
+          restore-cache-key: main-build-artifacts
 
       # Report as GitHub Pull Request Check.
-      - name : Publish Test Report
-        uses : mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
-        if : always() # always run even if the previous step fails
-        with :
-          report_paths : '**/build/test-results/test/TEST-*.xml'
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
 
-  js-tests :
-    name : JS Tests
-    runs-on : macos-latest
-    timeout-minutes : 30
-    steps :
+  jvm-stateChange-drainExclusive-runtime-test:
+    name: SCO, DEA JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=stateChange-drainExclusive
+          restore-cache-key: main-build-artifacts
+
+      # Report as GitHub Pull Request Check.
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+  jvm-partial-drainExclusive-runtime-test:
+    name: PTR, DEA JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=partial-drainExclusive
+          restore-cache-key: main-build-artifacts
+
+      # Report as GitHub Pull Request Check.
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+  jvm-conflate-stateChange-drainExclusive-runtime-test:
+    name: SCO, CSR, DEA JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=conflate-stateChange-drainExclusive
+          restore-cache-key: main-build-artifacts
+
+      # Report as GitHub Pull Request Check.
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+  jvm-conflate-partial-drainExclusive-runtime-test:
+    name: CSR, PTR, DEA JVM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jvmTest --continue -Pworkflow.runtime=conflate-partial-drainExclusive
+          restore-cache-key: main-build-artifacts
+
+      # Report as GitHub Pull Request Check.
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+  ios-tests:
+    name: iOS Tests
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: iosX64Test
+          restore-cache-key: main-build-artifacts
+
+      # Report as GitHub Pull Request Check.
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+  js-tests:
+    name: JS Tests
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       ## JS Specific Tests (for KMP js actuals in core and runtime).
-      - name : Check with Gradle
-        uses : ./.github/actions/gradle-task
-        with :
-          task : jsTest
-          restore-cache-key : main-build-artifacts
+      - name: Check with Gradle
+        uses: ./.github/actions/gradle-task
+        with:
+          task: jsTest
+          restore-cache-key: main-build-artifacts
 
       # Report as GitHub Pull Request Check.
-      - name : Publish Test Report
-        uses : mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
-        if : always() # always run even if the previous step fails
-        with :
-          report_paths : '**/build/test-results/test/TEST-*.xml'
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@5f47764eec0e1c1f19f40c8e60a5ba47e47015c5 # v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
 
-  performance-tests :
-    name : Performance tests
-    runs-on : workflow-kotlin-test-runner-ubuntu-4core
-    timeout-minutes : 45
-    strategy :
+  performance-tests:
+    name: Performance tests
+    runs-on: workflow-kotlin-test-runner-ubuntu-4core
+    timeout-minutes: 45
+    strategy:
       # Allow tests to continue on other devices if they fail on one device.
-      fail-fast : false
-      matrix :
-        api-level :
+      fail-fast: false
+      matrix:
+        api-level:
           - 31
-    steps :
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name : Instrumented tests
-        uses : ./.github/actions/gradle-tasks-with-emulator
-        with :
-          tests-name : perf-tests-results
-          api-level : ${{ matrix.api-level }}
-          prepare-task : :benchmarks:performance-poetry:complex-poetry:prepareDebugAndroidTestArtifacts
-          test-task : :benchmarks:performance-poetry:complex-poetry:connectedCheck --continue
-          restore-cache-key : androidTest-build-artifacts
+      - name: Instrumented tests
+        uses: ./.github/actions/gradle-tasks-with-emulator
+        with:
+          tests-name: perf-tests-results
+          api-level: ${{ matrix.api-level }}
+          prepare-task: :benchmarks:performance-poetry:complex-poetry:prepareDebugAndroidTestArtifacts
+          test-task: :benchmarks:performance-poetry:complex-poetry:connectedCheck --continue
+          restore-cache-key: androidTest-build-artifacts
 
-  instrumentation-tests :
-    name : Instrumentation tests
-    runs-on : workflow-kotlin-test-runner-ubuntu-4core
-    timeout-minutes : 60
-    strategy :
+  instrumentation-tests:
+    name: Instrumentation tests
+    runs-on: workflow-kotlin-test-runner-ubuntu-4core
+    timeout-minutes: 60
+    strategy:
       # Allow tests to continue on other devices if they fail on one device.
-      fail-fast : false
-      matrix :
-        api-level :
-          - 31
-        ### <start-connected-check-shards>
-        shardNum: [ 1, 2, 3 ]
-        ### <end-connected-check-shards>
-    steps :
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - name : Instrumented tests
-        uses : ./.github/actions/gradle-tasks-with-emulator
-        with :
-          tests-name : core-tests-results-${{matrix.shardNum}}
-          api-level : ${{ matrix.api-level }}
-          prepare-task : prepareConnectedCheckShard${{matrix.shardNum}}
-          test-task : connectedCheckShard${{matrix.shardNum}} -x :benchmarks:dungeon-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-poetry:connectedCheck
-          write-cache-key : androidTest-build-artifacts-${{matrix.shardNum}}
-          restore-cache-key : main-build-artifacts
-
-  runtime-instrumentation-tests :
-    name : Alternate Runtime Instrumentation tests
-    runs-on : workflow-kotlin-test-runner-ubuntu-4core
-    timeout-minutes : 60
-    strategy :
-      # Allow tests to continue on other devices if they fail on one device.
-      fail-fast : false
-      matrix :
-        api-level :
+      fail-fast: false
+      matrix:
+        api-level:
           - 31
         ### <start-connected-check-shards>
         shardNum: [ 1, 2, 3 ]
         ### <end-connected-check-shards>
-        runtime : [ conflate, stateChange, conflate-stateChange, partial, conflate-partial, stable ]
-    steps :
+    steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name : Instrumented tests
-        uses : ./.github/actions/gradle-tasks-with-emulator
-        with :
-          tests-name : alt-runtime-tests-results-${{matrix.runtime}}-${{matrix.shardNum}}
-          api-level : ${{ matrix.api-level }}
-          prepare-task : prepareConnectedCheckShard${{matrix.shardNum}} -Pworkflow.runtime=${{matrix.runtime}}
-          test-task : connectedCheckShard${{matrix.shardNum}} -Pworkflow.runtime=${{matrix.runtime}} -x :benchmarks:dungeon-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-poetry:connectedCheck
-          write-cache-key : androidTest-build-artifacts-${{matrix.shardNum}}-${{matrix.runtime}}
-          restore-cache-key : main-build-artifacts
+      - name: Instrumented tests
+        uses: ./.github/actions/gradle-tasks-with-emulator
+        with:
+          tests-name: core-tests-results-${{matrix.shardNum}}
+          api-level: ${{ matrix.api-level }}
+          prepare-task: prepareConnectedCheckShard${{matrix.shardNum}}
+          test-task: connectedCheckShard${{matrix.shardNum}} -x :benchmarks:dungeon-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-poetry:connectedCheck
+          write-cache-key: androidTest-build-artifacts-${{matrix.shardNum}}
+          restore-cache-key: main-build-artifacts
 
-  all-green :
-    if : always()
-    runs-on : ubuntu-latest
-    needs :
+  runtime-instrumentation-tests:
+    name: Alternate Runtime Instrumentation tests
+    runs-on: workflow-kotlin-test-runner-ubuntu-4core
+    timeout-minutes: 60
+    strategy:
+      # Allow tests to continue on other devices if they fail on one device.
+      fail-fast: false
+      matrix:
+        api-level:
+          - 31
+        ### <start-connected-check-shards>
+        shardNum: [ 1, 2, 3 ]
+        ### <end-connected-check-shards>
+        runtime: [ conflate, stateChange, drainExclusive, conflate-stateChange, partial, conflate-partial, stable, conflate-drainExclusive, stateChange-drainExclusive, partial-drainExclusive, conflate-partial-drainExclusive ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Instrumented tests
+        uses: ./.github/actions/gradle-tasks-with-emulator
+        with:
+          tests-name: alt-runtime-tests-results-${{matrix.runtime}}-${{matrix.shardNum}}
+          api-level: ${{ matrix.api-level }}
+          prepare-task: prepareConnectedCheckShard${{matrix.shardNum}} -Pworkflow.runtime=${{matrix.runtime}}
+          test-task: connectedCheckShard${{matrix.shardNum}} -Pworkflow.runtime=${{matrix.runtime}} -x :benchmarks:dungeon-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-poetry:connectedCheck
+          write-cache-key: androidTest-build-artifacts-${{matrix.shardNum}}-${{matrix.runtime}}
+          restore-cache-key: main-build-artifacts
+
+  all-green:
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
       - android-lint
       - api-check
       - artifacts-check
@@ -480,20 +606,26 @@ jobs :
       - instrumentation-tests
       - ios-tests
       - js-tests
+      - jvm-drainExclusive-runtime-test
       - jvm-conflate-runtime-test
       - jvm-stateChange-runtime-test
       - jvm-stable-handlers-test
       - jvm-partial-runtime-test
       - jvm-conflate-stateChange-runtime-test
       - jvm-conflate-partial-runtime-test
+      - jvm-conflate-drainExclusive-runtime-test
+      - jvm-stateChange-drainExclusive-runtime-test
+      - jvm-partial-drainExclusive-runtime-test
+      - jvm-conflate-stateChange-drainExclusive-runtime-test
+      - jvm-conflate-partial-drainExclusive-runtime-test
       - ktlint
       - performance-tests
       - runtime-instrumentation-tests
       - shards-and-version
       - tutorials
 
-    steps :
-      - name : require that all other jobs have passed
-        uses : re-actors/alls-green@release/v1
-        with :
-          jobs : ${{ toJSON(needs) }}
+    steps:
+      - name: require that all other jobs have passed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/workflow-config/config-android/src/main/java/com/squareup/workflow1/config/AndroidRuntimeConfigTools.kt
+++ b/workflow-config/config-android/src/main/java/com/squareup/workflow1/config/AndroidRuntimeConfigTools.kt
@@ -3,6 +3,7 @@ package com.squareup.workflow1.config
 import com.squareup.workflow1.RuntimeConfig
 import com.squareup.workflow1.RuntimeConfigOptions
 import com.squareup.workflow1.RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS
+import com.squareup.workflow1.RuntimeConfigOptions.DRAIN_EXCLUSIVE_ACTIONS
 import com.squareup.workflow1.RuntimeConfigOptions.PARTIAL_TREE_RENDERING
 import com.squareup.workflow1.RuntimeConfigOptions.RENDER_ONLY_WHEN_STATE_CHANGES
 import com.squareup.workflow1.RuntimeConfigOptions.STABLE_EVENT_HANDLERS
@@ -33,6 +34,10 @@ public class AndroidRuntimeConfigTools {
      *
      * - `stable` Enables stable event handlers (changes the default value of the `remember`
      *    parameter of `RenderContext.eventHandler` functions from `false` to `true`)
+     *
+     * - `drainExclusive` Enables draining exclusive actions. If we have more actions to process
+     *    that are queued on nodes not affected by the last action application, then we will
+     *    continue to process those actions before another render pass.
      */
     @WorkflowExperimentalRuntime
     public fun getAppWorkflowRuntimeConfig(): RuntimeConfig {
@@ -48,6 +53,7 @@ public class AndroidRuntimeConfigTools {
           "stateChange" -> config.add(RENDER_ONLY_WHEN_STATE_CHANGES)
           "partial" -> config.addAll(setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING))
           "stable" -> config.add(STABLE_EVENT_HANDLERS)
+          "drainExclusive" -> config.add(DRAIN_EXCLUSIVE_ACTIONS)
           else -> throw IllegalArgumentException("Unrecognized runtime config option \"$it\"")
         }
       }

--- a/workflow-config/config-jvm/src/main/java/com/squareup/workflow1/config/JvmTestRuntimeConfigTools.kt
+++ b/workflow-config/config-jvm/src/main/java/com/squareup/workflow1/config/JvmTestRuntimeConfigTools.kt
@@ -3,6 +3,7 @@ package com.squareup.workflow1.config
 import com.squareup.workflow1.RuntimeConfig
 import com.squareup.workflow1.RuntimeConfigOptions
 import com.squareup.workflow1.RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS
+import com.squareup.workflow1.RuntimeConfigOptions.DRAIN_EXCLUSIVE_ACTIONS
 import com.squareup.workflow1.RuntimeConfigOptions.PARTIAL_TREE_RENDERING
 import com.squareup.workflow1.RuntimeConfigOptions.RENDER_ONLY_WHEN_STATE_CHANGES
 import com.squareup.workflow1.RuntimeConfigOptions.STABLE_EVENT_HANDLERS
@@ -35,6 +36,10 @@ public class JvmTestRuntimeConfigTools {
      *
      * - `stable` Enables stable event handlers (changes the default value of the `remember`
      *    parameter of `RenderContext.eventHandler` functions from `false` to `true`)
+     *
+     * - `drainExclusive` Enables draining exclusive actions. If we have more actions to process
+     *    that are queued on nodes not affected by the last action application, then we will
+     *    continue to process those actions before another render pass.
      */
     @OptIn(WorkflowExperimentalRuntime::class)
     public fun getTestRuntimeConfig(): RuntimeConfig {
@@ -50,6 +55,7 @@ public class JvmTestRuntimeConfigTools {
           "stateChange" -> config.add(RENDER_ONLY_WHEN_STATE_CHANGES)
           "partial" -> config.addAll(setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING))
           "stable" -> config.add(STABLE_EVENT_HANDLERS)
+          "drainExclusive" -> config.add(DRAIN_EXCLUSIVE_ACTIONS)
           else -> throw IllegalArgumentException("Unrecognized runtime config option \"$it\"")
         }
       }

--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -164,6 +164,7 @@ public final class com/squareup/workflow1/PropsUpdated : com/squareup/workflow1/
 public final class com/squareup/workflow1/RuntimeConfigOptions : java/lang/Enum {
 	public static final field CONFLATE_STALE_RENDERINGS Lcom/squareup/workflow1/RuntimeConfigOptions;
 	public static final field Companion Lcom/squareup/workflow1/RuntimeConfigOptions$Companion;
+	public static final field DRAIN_EXCLUSIVE_ACTIONS Lcom/squareup/workflow1/RuntimeConfigOptions;
 	public static final field PARTIAL_TREE_RENDERING Lcom/squareup/workflow1/RuntimeConfigOptions;
 	public static final field RENDER_ONLY_WHEN_STATE_CHANGES Lcom/squareup/workflow1/RuntimeConfigOptions;
 	public static final field STABLE_EVENT_HANDLERS Lcom/squareup/workflow1/RuntimeConfigOptions;
@@ -180,14 +181,22 @@ public final class com/squareup/workflow1/RuntimeConfigOptions$Companion {
 
 public final class com/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions : java/lang/Enum {
 	public static final field CONFLATE Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
+	public static final field DEA Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
 	public static final field DEFAULT Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
 	public static final field RENDER_ONLY Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
 	public static final field RENDER_ONLY_CONFLATE Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
+	public static final field RENDER_ONLY_CONFLATE_DEA Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
 	public static final field RENDER_ONLY_CONFLATE_PARTIAL Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
+	public static final field RENDER_ONLY_CONFLATE_PARTIAL_DEA Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
 	public static final field RENDER_ONLY_CONFLATE_PARTIAL_STABLE Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
+	public static final field RENDER_ONLY_CONFLATE_PARTIAL_STABLE_DEA Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
 	public static final field RENDER_ONLY_CONFLATE_STABLE Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
+	public static final field RENDER_ONLY_DEA Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
+	public static final field RENDER_ONLY_DEA_STABLE Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
 	public static final field RENDER_ONLY_PARTIAL Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
+	public static final field RENDER_ONLY_PARTIAL_DEA Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
 	public static final field RENDER_ONLY_PARTIAL_STABLE Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
+	public static final field RENDER_ONLY_PARTIAL_STABLE_DEA Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
 	public static final field STABLE Lcom/squareup/workflow1/RuntimeConfigOptions$Companion$RuntimeOptions;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getRuntimeConfig ()Ljava/util/Set;

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/RuntimeConfig.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/RuntimeConfig.kt
@@ -67,13 +67,13 @@ public enum class RuntimeConfigOptions {
   @WorkflowExperimentalRuntime
   STABLE_EVENT_HANDLERS,
 
-  // /**
-  //  * If we have more actions to process that are queued on nodes not affected by the last
-  //  * action application, then we will continue to process those actions before another render
-  //  * pass.
-  //  */
-  // @WorkflowExperimentalRuntime
-  // DRAIN_EXCLUSIVE_ACTIONS,
+  /**
+   * If we have more actions to process that are queued on nodes not affected by the last
+   * action application, then we will continue to process those actions before another render
+   * pass.
+   */
+  @WorkflowExperimentalRuntime
+  DRAIN_EXCLUSIVE_ACTIONS,
   ;
 
   public companion object {
@@ -103,11 +103,11 @@ public enum class RuntimeConfigOptions {
       CONFLATE(setOf(CONFLATE_STALE_RENDERINGS)),
       STABLE(setOf(STABLE_EVENT_HANDLERS)),
 
-      // DEA(setOf(DRAIN_EXCLUSIVE_ACTIONS)),
+      DEA(setOf(DRAIN_EXCLUSIVE_ACTIONS)),
       RENDER_ONLY_CONFLATE(setOf(RENDER_ONLY_WHEN_STATE_CHANGES, CONFLATE_STALE_RENDERINGS)),
       RENDER_ONLY_PARTIAL(setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING)),
 
-      // RENDER_ONLY_DEA(setOf(RENDER_ONLY_WHEN_STATE_CHANGES, DRAIN_EXCLUSIVE_ACTIONS)),
+      RENDER_ONLY_DEA(setOf(RENDER_ONLY_WHEN_STATE_CHANGES, DRAIN_EXCLUSIVE_ACTIONS)),
       RENDER_ONLY_CONFLATE_STABLE(
         setOf(RENDER_ONLY_WHEN_STATE_CHANGES, CONFLATE_STALE_RENDERINGS, STABLE_EVENT_HANDLERS)
       ),
@@ -115,19 +115,19 @@ public enum class RuntimeConfigOptions {
         setOf(RENDER_ONLY_WHEN_STATE_CHANGES, CONFLATE_STALE_RENDERINGS, PARTIAL_TREE_RENDERING)
       ),
 
-      // RENDER_ONLY_CONFLATE_DEA(
-      //   setOf(RENDER_ONLY_WHEN_STATE_CHANGES, CONFLATE_STALE_RENDERINGS, DRAIN_EXCLUSIVE_ACTIONS)
-      // ),
+      RENDER_ONLY_CONFLATE_DEA(
+        setOf(RENDER_ONLY_WHEN_STATE_CHANGES, CONFLATE_STALE_RENDERINGS, DRAIN_EXCLUSIVE_ACTIONS)
+      ),
       RENDER_ONLY_PARTIAL_STABLE(
         setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING, STABLE_EVENT_HANDLERS)
       ),
 
-      // RENDER_ONLY_PARTIAL_DEA(
-      //   setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING, DRAIN_EXCLUSIVE_ACTIONS)
-      // ),
-      // RENDER_ONLY_DEA_STABLE(
-      //   setOf(RENDER_ONLY_WHEN_STATE_CHANGES, DRAIN_EXCLUSIVE_ACTIONS, STABLE_EVENT_HANDLERS)
-      // ),
+      RENDER_ONLY_PARTIAL_DEA(
+        setOf(RENDER_ONLY_WHEN_STATE_CHANGES, PARTIAL_TREE_RENDERING, DRAIN_EXCLUSIVE_ACTIONS)
+      ),
+      RENDER_ONLY_DEA_STABLE(
+        setOf(RENDER_ONLY_WHEN_STATE_CHANGES, DRAIN_EXCLUSIVE_ACTIONS, STABLE_EVENT_HANDLERS)
+      ),
       RENDER_ONLY_CONFLATE_PARTIAL_STABLE(
         setOf(
           RENDER_ONLY_WHEN_STATE_CHANGES,
@@ -136,31 +136,31 @@ public enum class RuntimeConfigOptions {
           STABLE_EVENT_HANDLERS,
         )
       ),
-      // RENDER_ONLY_CONFLATE_PARTIAL_DEA(
-      //   setOf(
-      //     RENDER_ONLY_WHEN_STATE_CHANGES,
-      //     CONFLATE_STALE_RENDERINGS,
-      //     PARTIAL_TREE_RENDERING,
-      //     DRAIN_EXCLUSIVE_ACTIONS,
-      //   )
-      // ),
-      // RENDER_ONLY_PARTIAL_STABLE_DEA(
-      //   setOf(
-      //     RENDER_ONLY_WHEN_STATE_CHANGES,
-      //     PARTIAL_TREE_RENDERING,
-      //     STABLE_EVENT_HANDLERS,
-      //     DRAIN_EXCLUSIVE_ACTIONS,
-      //   )
-      // ),
-      // RENDER_ONLY_CONFLATE_PARTIAL_STABLE_DEA(
-      //   setOf(
-      //     RENDER_ONLY_WHEN_STATE_CHANGES,
-      //     CONFLATE_STALE_RENDERINGS,
-      //     PARTIAL_TREE_RENDERING,
-      //     STABLE_EVENT_HANDLERS,
-      //     DRAIN_EXCLUSIVE_ACTIONS,
-      //   )
-      // ),
+      RENDER_ONLY_CONFLATE_PARTIAL_DEA(
+        setOf(
+          RENDER_ONLY_WHEN_STATE_CHANGES,
+          CONFLATE_STALE_RENDERINGS,
+          PARTIAL_TREE_RENDERING,
+          DRAIN_EXCLUSIVE_ACTIONS,
+        )
+      ),
+      RENDER_ONLY_PARTIAL_STABLE_DEA(
+        setOf(
+          RENDER_ONLY_WHEN_STATE_CHANGES,
+          PARTIAL_TREE_RENDERING,
+          STABLE_EVENT_HANDLERS,
+          DRAIN_EXCLUSIVE_ACTIONS,
+        )
+      ),
+      RENDER_ONLY_CONFLATE_PARTIAL_STABLE_DEA(
+        setOf(
+          RENDER_ONLY_WHEN_STATE_CHANGES,
+          CONFLATE_STALE_RENDERINGS,
+          PARTIAL_TREE_RENDERING,
+          STABLE_EVENT_HANDLERS,
+          DRAIN_EXCLUSIVE_ACTIONS,
+        )
+      ),
     }
   }
 }

--- a/workflow-runtime-android/src/main/java/com/squareup/workflow1/android/AndroidRenderWorkflow.kt
+++ b/workflow-runtime-android/src/main/java/com/squareup/workflow1/android/AndroidRenderWorkflow.kt
@@ -278,6 +278,7 @@ public fun <PropsT, OutputT, RenderingT> renderWorkflowIn(
  * A [StateFlow] of [RenderingT]s that will emit any time the root workflow creates a new
  * rendering.
  */
+@OptIn(ExperimentalStdlibApi::class)
 public fun <PropsT, OutputT, RenderingT> renderWorkflowIn(
   workflow: Workflow<PropsT, OutputT, RenderingT>,
   scope: CoroutineScope,

--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -4,7 +4,7 @@ public final class com/squareup/workflow1/NoopWorkflowInterceptor : com/squareup
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRenderAndSnapshot (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/RenderingAndSnapshot;
-	public fun onRuntimeLoopTick (Lcom/squareup/workflow1/WorkflowInterceptor$RuntimeLoopOutcome;)V
+	public fun onRuntimeUpdate (Lcom/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate;)V
 	public fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)V
 	public fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/Snapshot;
 	public fun onSnapshotStateWithChildren (Lkotlin/jvm/functions/Function0;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/TreeSnapshot;
@@ -33,7 +33,7 @@ public class com/squareup/workflow1/SimpleLoggingWorkflowInterceptor : com/squar
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRenderAndSnapshot (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/RenderingAndSnapshot;
-	public fun onRuntimeLoopTick (Lcom/squareup/workflow1/WorkflowInterceptor$RuntimeLoopOutcome;)V
+	public fun onRuntimeUpdate (Lcom/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate;)V
 	public fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)V
 	public fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/Snapshot;
 	public fun onSnapshotStateWithChildren (Lkotlin/jvm/functions/Function0;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/TreeSnapshot;
@@ -56,7 +56,7 @@ public abstract interface class com/squareup/workflow1/WorkflowInterceptor {
 	public abstract fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public abstract fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public abstract fun onRenderAndSnapshot (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/RenderingAndSnapshot;
-	public abstract fun onRuntimeLoopTick (Lcom/squareup/workflow1/WorkflowInterceptor$RuntimeLoopOutcome;)V
+	public abstract fun onRuntimeUpdate (Lcom/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate;)V
 	public abstract fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)V
 	public abstract fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/Snapshot;
 	public abstract fun onSnapshotStateWithChildren (Lkotlin/jvm/functions/Function0;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/TreeSnapshot;
@@ -67,7 +67,7 @@ public final class com/squareup/workflow1/WorkflowInterceptor$DefaultImpls {
 	public static fun onPropsChanged (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public static fun onRender (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public static fun onRenderAndSnapshot (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/RenderingAndSnapshot;
-	public static fun onRuntimeLoopTick (Lcom/squareup/workflow1/WorkflowInterceptor;Lcom/squareup/workflow1/WorkflowInterceptor$RuntimeLoopOutcome;)V
+	public static fun onRuntimeUpdate (Lcom/squareup/workflow1/WorkflowInterceptor;Lcom/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate;)V
 	public static fun onSessionStarted (Lcom/squareup/workflow1/WorkflowInterceptor;Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)V
 	public static fun onSnapshotState (Lcom/squareup/workflow1/WorkflowInterceptor;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/Snapshot;
 	public static fun onSnapshotStateWithChildren (Lcom/squareup/workflow1/WorkflowInterceptor;Lkotlin/jvm/functions/Function0;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/TreeSnapshot;
@@ -87,19 +87,29 @@ public final class com/squareup/workflow1/WorkflowInterceptor$RenderContextInter
 	public static fun onRunningSideEffect (Lcom/squareup/workflow1/WorkflowInterceptor$RenderContextInterceptor;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
 }
 
-public final class com/squareup/workflow1/WorkflowInterceptor$RenderPassSkipped : com/squareup/workflow1/WorkflowInterceptor$RuntimeLoopOutcome {
-	public fun <init> ()V
-	public fun <init> (Z)V
-	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getEndOfTick ()Z
+public final class com/squareup/workflow1/WorkflowInterceptor$RenderPassSkipped : com/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate {
+	public static final field INSTANCE Lcom/squareup/workflow1/WorkflowInterceptor$RenderPassSkipped;
 }
 
-public final class com/squareup/workflow1/WorkflowInterceptor$RenderPassesComplete : com/squareup/workflow1/WorkflowInterceptor$RuntimeLoopOutcome {
-	public fun <init> (Lcom/squareup/workflow1/RenderingAndSnapshot;)V
+public final class com/squareup/workflow1/WorkflowInterceptor$RenderingConflated : com/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate {
+	public static final field INSTANCE Lcom/squareup/workflow1/WorkflowInterceptor$RenderingConflated;
+}
+
+public final class com/squareup/workflow1/WorkflowInterceptor$RenderingProduced : com/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate {
+	public static final synthetic fun box-impl (Lcom/squareup/workflow1/RenderingAndSnapshot;)Lcom/squareup/workflow1/WorkflowInterceptor$RenderingProduced;
+	public static fun constructor-impl (Lcom/squareup/workflow1/RenderingAndSnapshot;)Lcom/squareup/workflow1/RenderingAndSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Lcom/squareup/workflow1/RenderingAndSnapshot;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Lcom/squareup/workflow1/RenderingAndSnapshot;Lcom/squareup/workflow1/RenderingAndSnapshot;)Z
 	public final fun getRenderingAndSnapshot ()Lcom/squareup/workflow1/RenderingAndSnapshot;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Lcom/squareup/workflow1/RenderingAndSnapshot;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Lcom/squareup/workflow1/RenderingAndSnapshot;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Lcom/squareup/workflow1/RenderingAndSnapshot;
 }
 
-public abstract interface class com/squareup/workflow1/WorkflowInterceptor$RuntimeLoopOutcome {
+public abstract interface class com/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate {
 }
 
 public abstract interface class com/squareup/workflow1/WorkflowInterceptor$WorkflowSession {

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/WorkflowInterceptor.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/WorkflowInterceptor.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
+import kotlin.jvm.JvmInline
 import kotlin.reflect.KType
 
 /**
@@ -34,9 +35,7 @@ import kotlin.reflect.KType
  *
  *  1. [onSessionStarted] - called when a new [WorkflowSession] is created the first time a
  *     workflow is rendered with the [CoroutineScope] for that session.
- *  1. [onRuntimeLoopTick] - Called to report the [RuntimeLoopOutcome] of each tick of the runtime
- *     loop. In the simplest case this is the application of one action and one render pass, but
- *     optimizations can change that. See [onRenderingUpdated] for more.
+ *  1. [onRuntimeUpdate] - Called to report [RuntimeUpdate]s from the event loop.
  *
  * ## On Profiling
  *
@@ -140,43 +139,57 @@ public interface WorkflowInterceptor {
   ): Snapshot? = proceed(state)
 
   /**
-   * Called to report the [outcome] of each tick of the runtime loop. In the simplest case
-   * this is the application of one action and one render pass, but optimizations can
-   * change that:
+   * Called to report the [update]s from the runtime as it executes its loop.
    *
-   *  - With the `RENDER_ONLY_WHEN_STATE_CHANGES` optimization, there may not be a render pass
-   *    at all, in which case [RenderPassSkipped] is the outcome.
-   *  - With the `CONFLATE_STALE_RENDERINGS` optimization, there could be multiple render passes.
-   *  - If there is at least one render pass, then [RenderPassesComplete] is passed as the outcome,
-   *    which includes the actual [RenderingAndSnapshot] returned from the runtime.
+   * There will be at least one [update] for every application of an action, as this is how the
+   * runtime is advancing the state machine.
    *
-   * @param outcome The [RuntimeLoopOutcome] of the tick of the runtime loop.
+   * The possible [update]s are:
+   *
+   * 1. [RenderingProduced]: The runtime produced a new rendering for the view code.
+   * 1. [RenderPassSkipped]: Optimizations were able to apply multiple actions and skip a render
+   * pass
+   * 1. [RenderingConflated]: The runtime detected that the rendering was stale, so it conflates
+   * this rendering with the next before producing it for the view code.
+   *
+   * In the simplest case, the [update] for an action may be just *one* [RenderingProduced] - in
+   * which case we know there was one action applied, and one render pass.
+   *
+   * If there are optimizations applied, then they will try to greedily apply actions. In this case,
+   * for each action that is applied without a corresponding render pass, the [RenderPassSkipped]
+   * [update] will be reported here, and for each rendering that was conflated before producing it
+   * for the view code, the [RenderingConflated] [update] is reported.
+   *
+   * @param update A [RuntimeUpdate] from the event loop.
    */
-  public fun onRuntimeLoopTick(
-    outcome: RuntimeLoopOutcome
+  public fun onRuntimeUpdate(
+    update: RuntimeUpdate
   ): Unit = Unit
 
-  public sealed interface RuntimeLoopOutcome
+  public sealed interface RuntimeUpdate
 
   /**
-   * @param endOfTick This is true if this skip was the end of the loop iteration (i.e. no update
-   *        was passed to the UI. It is false otherwise. An example of when it can be false is if
-   *        we have an action that causes a state change, but then we can process more while the
-   *        `CONFLATE_STALE_RENDERINGS` optimization is enabled. We may skip rendering based on
-   *        the subsequent action not changing state, but we will need to finish the loop and update
-   *        the UI from the previous action that changed state.
+   * A render pass has been skipped by an optimization, multiple actions are applied before
+   * the runtime produces a rendering.
    */
-  public class RenderPassSkipped(
-    public val endOfTick: Boolean = true
-  ) : RuntimeLoopOutcome
+  public object RenderPassSkipped : RuntimeUpdate
 
   /**
+   * The runtime skipped producing a rendering, conflating it to the next rendering after the next
+   * render pass.
+   */
+  public object RenderingConflated : RuntimeUpdate
+
+  /**
+   * This runtime has produced a new rendering after at least one render pass.
+   *
    * @param renderingAndSnapshot This is the rendering and snapshot that was passed out of the
    *        Workflow runtime.
    */
-  public class RenderPassesComplete<R>(
+  @JvmInline
+  public value class RenderingProduced<R>(
     public val renderingAndSnapshot: RenderingAndSnapshot<R>
-  ) : RuntimeLoopOutcome
+  ) : RuntimeUpdate
 
   /**
    * Information about the session of a workflow in the runtime that a [WorkflowInterceptor] method

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptor.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/ChainedWorkflowInterceptor.kt
@@ -9,7 +9,7 @@ import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
 import com.squareup.workflow1.WorkflowInterceptor
 import com.squareup.workflow1.WorkflowInterceptor.RenderContextInterceptor
-import com.squareup.workflow1.WorkflowInterceptor.RuntimeLoopOutcome
+import com.squareup.workflow1.WorkflowInterceptor.RuntimeUpdate
 import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
 import kotlinx.coroutines.CoroutineScope
 import kotlin.reflect.KType
@@ -124,9 +124,9 @@ internal class ChainedWorkflowInterceptor(
     return chainedProceed(state)
   }
 
-  override fun onRuntimeLoopTick(outcome: RuntimeLoopOutcome) {
+  override fun onRuntimeUpdate(update: RuntimeUpdate) {
     interceptors.forEach { interceptor ->
-      interceptor.onRuntimeLoopTick(outcome)
+      interceptor.onRuntimeUpdate(update)
     }
   }
 

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
@@ -159,12 +159,16 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
   /**
    * Will try to apply any actions immediately available in our children's actions queues.
    *
+   * @param skipDirtyNodes Whether or not this should skip over any workflow nodes that are already
+   * 'dirty' - that is, they had their own state changed as the result of a previous action before
+   * the next render pass.
+   *
    * @return [ActionProcessingResult] of the action processed, or [ActionsExhausted] if there were
    * none immediately available.
    */
-  fun applyNextAvailableChildAction(): ActionProcessingResult {
+  fun applyNextAvailableChildAction(skipDirtyNodes: Boolean = false): ActionProcessingResult {
     children.forEachActive { child ->
-      val result = child.workflowNode.applyNextAvailableTreeAction()
+      val result = child.workflowNode.applyNextAvailableTreeAction(skipDirtyNodes)
       if (result != ActionsExhausted) {
         return result
       }

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
@@ -95,7 +95,16 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   private val eventActionsChannel =
     Channel<WorkflowAction<PropsT, StateT, OutputT>>(capacity = UNLIMITED)
   private var state: StateT
-  private var subtreeStateDidChange: Boolean = true
+
+  /**
+   * The state of this node or that of one of our descendants changed since we last rendered.
+   */
+  private var subtreeStateDirty: Boolean = true
+
+  /**
+   * The state of this node changed since we last rendered.
+   */
+  private var selfStateDirty: Boolean = true
 
   private val baseRenderContext = RealRenderContext(
     renderer = subtreeManager,
@@ -230,11 +239,17 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
    * the next action. That will also end up with [applyAction] being called when the clauses is
    * selected.
    *
+   * @param skipDirtyNodes Whether or not this should skip over any workflow nodes that are already
+   * 'dirty' - that is, they had their own state changed as the result of a previous action before
+   * the next render pass.
+   *
    * @return [ActionProcessingResult] of the action processed, or [ActionsExhausted] if there were
    * none immediately available.
    */
-  fun applyNextAvailableTreeAction(): ActionProcessingResult {
-    val result = subtreeManager.applyNextAvailableChildAction()
+  fun applyNextAvailableTreeAction(skipDirtyNodes: Boolean = false): ActionProcessingResult {
+    if (skipDirtyNodes && selfStateDirty) return ActionsExhausted
+
+    val result = subtreeManager.applyNextAvailableChildAction(skipDirtyNodes)
 
     if (result == ActionsExhausted) {
       return eventActionsChannel.tryReceive().getOrNull()?.let { action ->
@@ -281,7 +296,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
 
     if (!runtimeConfig.contains(PARTIAL_TREE_RENDERING) ||
       !lastRendering.isInitialized ||
-      subtreeStateDidChange
+      subtreeStateDirty
     ) {
       // If we haven't already updated the cached instance, better do it now!
       maybeUpdateCachedWorkflowInstance(workflow)
@@ -301,7 +316,8 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
       }
       // After we have rendered this subtree, we need another action in order for us to be
       // considered dirty again.
-      subtreeStateDidChange = false
+      subtreeStateDirty = false
+      selfStateDirty = false
     }
 
     return lastRendering.getOrThrow()
@@ -310,7 +326,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   /**
    * Update props if they have changed. If that happens, then check to see if we need
    * to update the cached workflow instance, then call [StatefulWorkflow.onPropsChanged] and
-   * update the state from that. We consider any change to props as [subtreeStateDidChange] because
+   * update the state from that. We consider any change to props as dirty because
    * the props themselves are used in [StatefulWorkflow.render] (they are the 'external' part of
    * the state) so we must re-render.
    */
@@ -322,7 +338,8 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
       maybeUpdateCachedWorkflowInstance(workflow)
       val newState = interceptedWorkflowInstance.onPropsChanged(lastProps, newProps, state)
       state = newState
-      subtreeStateDidChange = true
+      subtreeStateDirty = true
+      selfStateDirty = true
     }
     lastProps = newProps
   }
@@ -344,8 +361,10 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
       // Changing state is sticky, we pass it up if it ever changed.
       stateChanged = actionApplied.stateChanged || (childResult?.stateChanged ?: false)
     )
+    // Our state changed.
+    selfStateDirty = selfStateDirty || actionApplied.stateChanged
     // Our state changed or one of our children's state changed.
-    subtreeStateDidChange = aggregateActionApplied.stateChanged
+    subtreeStateDirty = subtreeStateDirty || aggregateActionApplied.stateChanged
     return if (actionApplied.output != null ||
       runtimeConfig.contains(PARTIAL_TREE_RENDERING)
     ) {
@@ -358,7 +377,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
       //
       // However, the root and the path down to the changed nodes must always
       // re-render now, so this is the implementation detail of how we get
-      // subtreeStateDidChange = true on that entire path to the root.
+      // subtreeStateDirty = true on that entire path to the root.
       emitAppliedActionToParent(aggregateActionApplied)
     } else {
       aggregateActionApplied

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowRunner.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowRunner.kt
@@ -92,11 +92,15 @@ internal class WorkflowRunner<PropsT, OutputT, RenderingT>(
   /**
    * Will try to apply any immediately available actions for this runtime (no suspending).
    *
+   * @param skipDirtyNodes Whether or not this should skip over any workflow nodes that are already
+   * 'dirty' - that is, they had their own state changed as the result of a previous action before
+   * the next render pass.
+   *
    * @return [ActionProcessingResult] of the action processed, or [ActionsExhausted] if there were
    * none immediately available.
    */
-  fun applyNextAvailableTreeAction(): ActionProcessingResult {
-    return rootNode.applyNextAvailableTreeAction()
+  fun applyNextAvailableTreeAction(skipDirtyNodes: Boolean = false): ActionProcessingResult {
+    return rootNode.applyNextAvailableTreeAction(skipDirtyNodes)
   }
 
   @OptIn(DelicateCoroutinesApi::class)

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderWorkflowInTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderWorkflowInTest.kt
@@ -4,11 +4,12 @@ import app.cash.burst.Burst
 import com.squareup.workflow1.RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS
 import com.squareup.workflow1.RuntimeConfigOptions.Companion.RuntimeOptions
 import com.squareup.workflow1.RuntimeConfigOptions.Companion.RuntimeOptions.DEFAULT
+import com.squareup.workflow1.RuntimeConfigOptions.DRAIN_EXCLUSIVE_ACTIONS
 import com.squareup.workflow1.RuntimeConfigOptions.PARTIAL_TREE_RENDERING
 import com.squareup.workflow1.RuntimeConfigOptions.RENDER_ONLY_WHEN_STATE_CHANGES
 import com.squareup.workflow1.WorkflowInterceptor.RenderPassSkipped
-import com.squareup.workflow1.WorkflowInterceptor.RenderPassesComplete
-import com.squareup.workflow1.WorkflowInterceptor.RuntimeLoopOutcome
+import com.squareup.workflow1.WorkflowInterceptor.RenderingProduced
+import com.squareup.workflow1.WorkflowInterceptor.RuntimeUpdate
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -105,9 +106,9 @@ class RenderWorkflowInTest(
 
     val hasReportedRendering = Mutex(locked = true)
     val testInterceptor = object : WorkflowInterceptor {
-      override fun onRuntimeLoopTick(outcome: RuntimeLoopOutcome) {
-        if (outcome is RenderPassesComplete<*>) {
-          assertEquals("props: foo", outcome.renderingAndSnapshot.rendering)
+      override fun onRuntimeUpdate(update: RuntimeUpdate) {
+        if (update is RenderingProduced<*>) {
+          assertEquals("props: foo", update.renderingAndSnapshot.rendering)
           hasReportedRendering.unlock()
         }
       }
@@ -129,9 +130,9 @@ class RenderWorkflowInTest(
 
     val interceptedRenderings = mutableListOf<Any?>()
     val testInterceptor = object : WorkflowInterceptor {
-      override fun onRuntimeLoopTick(outcome: RuntimeLoopOutcome) {
-        if (outcome is RenderPassesComplete<*>) {
-          interceptedRenderings.add(outcome.renderingAndSnapshot.rendering)
+      override fun onRuntimeUpdate(update: RuntimeUpdate) {
+        if (update is RenderingProduced<*>) {
+          interceptedRenderings.add(update.renderingAndSnapshot.rendering)
         }
       }
     }
@@ -170,7 +171,7 @@ class RenderWorkflowInTest(
     }
 
   @Test
-  fun `side_effects_from_initial_rendering_in_root_workflow_are_never_started_when_scope_cancelled_before_start`() =
+  fun side_effects_from_initial_rendering_in_root_workflow_are_never_started_when_scope_cancelled_before_start() =
     runTest(dispatcherUsed) {
       var sideEffectWasRan = false
       val workflow = Workflow.stateless<Unit, Nothing, Unit> {
@@ -194,7 +195,7 @@ class RenderWorkflowInTest(
     }
 
   @Test
-  fun `side_effects_from_initial_rendering_in_non_root_workflow_are_never_started_when_scope_cancelled_before_start`() =
+  fun side_effects_from_initial_rendering_in_non_root_workflow_are_never_started_when_scope_cancelled_before_start() =
     runTest(dispatcherUsed) {
       var sideEffectWasRan = false
       val childWorkflow = Workflow.stateless<Unit, Nothing, Unit> {
@@ -246,9 +247,9 @@ class RenderWorkflowInTest(
 
     val interceptedRenderings = mutableListOf<Any?>()
     val testInterceptor = object : WorkflowInterceptor {
-      override fun onRuntimeLoopTick(outcome: RuntimeLoopOutcome) {
-        if (outcome is RenderPassesComplete<*>) {
-          interceptedRenderings.add(outcome.renderingAndSnapshot.rendering)
+      override fun onRuntimeUpdate(update: RuntimeUpdate) {
+        if (update is RenderingProduced<*>) {
+          interceptedRenderings.add(update.renderingAndSnapshot.rendering)
         }
       }
     }
@@ -656,7 +657,7 @@ class RenderWorkflowInTest(
     }
 
   @Test
-  fun `side_effects_from_initial_rendering_in_root_workflow_are_never_started_when_initial_render_of_root_workflow_fails`() =
+  fun side_effects_from_initial_rendering_in_root_workflow_are_never_started_when_initial_render_of_root_workflow_fails() =
     runTest(dispatcherUsed) {
       var sideEffectWasRan = false
       val workflow = Workflow.stateless<Unit, Nothing, Unit> {
@@ -679,7 +680,7 @@ class RenderWorkflowInTest(
     }
 
   @Test
-  fun `side_effects_from_initial_rendering_in_non_root_workflow_are_cancelled_when_initial_render_of_root_workflow_fails`() =
+  fun side_effects_from_initial_rendering_in_non_root_workflow_are_cancelled_when_initial_render_of_root_workflow_fails() =
     runTest(dispatcherUsed) {
       var sideEffectWasRan = false
       var cancellationException: Throwable? = null
@@ -717,7 +718,7 @@ class RenderWorkflowInTest(
     }
 
   @Test
-  fun `side_effects_from_initial_rendering_in_non_root_workflow_are_never_started_when_initial_render_of_non_root_workflow_fails`() =
+  fun side_effects_from_initial_rendering_in_non_root_workflow_are_never_started_when_initial_render_of_non_root_workflow_fails() =
     runTest(dispatcherUsed) {
       var sideEffectWasRan = false
       val childWorkflow = Workflow.stateless<Unit, Nothing, Unit> {
@@ -1116,10 +1117,10 @@ class RenderWorkflowInTest(
         val interceptedRenderings = mutableListOf<Any?>()
         var skippedRenderings = 0
         val testInterceptor = object : WorkflowInterceptor {
-          override fun onRuntimeLoopTick(outcome: RuntimeLoopOutcome) {
-            if (outcome is RenderPassesComplete<*>) {
-              interceptedRenderings.add(outcome.renderingAndSnapshot.rendering)
-            } else if (outcome is RenderPassSkipped) {
+          override fun onRuntimeUpdate(update: RuntimeUpdate) {
+            if (update is RenderingProduced<*>) {
+              interceptedRenderings.add(update.renderingAndSnapshot.rendering)
+            } else if (update is RenderPassSkipped) {
               skippedRenderings++
             }
           }
@@ -1196,7 +1197,7 @@ class RenderWorkflowInTest(
   }
 
   @Test
-  fun `for_partial_tree_rendering_we_do_not_render_nodes_if_state_not_changed_even_in_render_pass`() {
+  fun for_partial_tree_rendering_we_do_not_render_nodes_if_state_not_changed_even_in_render_pass() {
     if (runtimeConfig.contains(PARTIAL_TREE_RENDERING)) {
       runTest(dispatcherUsed) {
         check(runtimeConfig.contains(PARTIAL_TREE_RENDERING))
@@ -1320,7 +1321,14 @@ class RenderWorkflowInTest(
         trigger.emit("state 1") // different value than the child starts with.
         advanceIfStandard()
 
-        assertEquals(3, parentRenderCount)
+        if (runtimeConfig.contains(DRAIN_EXCLUSIVE_ACTIONS) &&
+          dispatcherUsed == myStandardTestDispatcher
+        ) {
+          // With the unconfined dispatcher, the other actions don't get queued up in time to drain.
+          assertEquals(2, parentRenderCount)
+        } else {
+          assertEquals(3, parentRenderCount)
+        }
         // Parent needs to be rendered 3x, but child only 2x as the 3rd time its the same.
         assertEquals(2, childRenderCount)
       }
@@ -1734,6 +1742,302 @@ class RenderWorkflowInTest(
         // Only 2 times rendered, the initial + the update (not 3).
         assertEquals(2, renderCount)
         assertTrue(childHandlerActionExecuted)
+      }
+    }
+  }
+
+  @Test
+  fun for_drain_exclusive_we_handle_multiple_actions_in_one_render_or_not() = runTest(
+    dispatcherUsed
+  ) {
+
+    var childActionAppliedCount = 0
+    var parentRenderCount = 0
+    val trigger = MutableSharedFlow<String>()
+
+    val childWorkflow = Workflow.stateful<String, String, String>(
+      initialState = "unchanged state",
+      render = { renderState ->
+        runningWorker(
+          trigger.asWorker()
+        ) {
+          action("") {
+            state = it
+            childActionAppliedCount++
+          }
+        }
+        renderState
+      }
+    )
+    val workflow = Workflow.stateful<String, String, String>(
+      initialState = "unchanging state",
+      render = { renderState ->
+        renderChild(childWorkflow, key = "key1") { _ ->
+          WorkflowAction.noAction()
+        }
+        renderChild(childWorkflow, key = "key2") { _ ->
+          WorkflowAction.noAction()
+        }
+        parentRenderCount++
+        renderState
+      }
+    )
+    val props = MutableStateFlow(Unit)
+    renderWorkflowIn(
+      workflow = workflow,
+      scope = backgroundScope,
+      props = props,
+      runtimeConfig = runtimeConfig,
+      workflowTracer = testTracer,
+    ) { }
+    advanceIfStandard()
+
+    launch {
+      trigger.emit("changed state")
+    }
+    advanceIfStandard()
+
+    // 2 child actions processed.
+    assertEquals(2, childActionAppliedCount, "Expecting 2 child actions to be applied.")
+    if (runtimeConfig.contains(DRAIN_EXCLUSIVE_ACTIONS)) {
+      //  and 2 parent renders - 1 initial (synchronous) and then 1 additional.
+      assertEquals(2, parentRenderCount, "Expecting only 2 total renders.")
+    } else {
+      //  and 3 parent renders - 1 initial (synchronous) and then 1 additional for each child.
+      assertEquals(3, parentRenderCount, "Expecting only 3 total renders.")
+    }
+  }
+
+  @Test
+  fun for_drain_exclusive_and_render_only_when_state_changes_we_handle_multiple_actions_in_one_render_but_do_not_render_if_no_state_change() {
+    if (runtimeConfig.contains(DRAIN_EXCLUSIVE_ACTIONS) &&
+      runtimeConfig.contains(RENDER_ONLY_WHEN_STATE_CHANGES)
+    ) {
+      runTest(dispatcherUsed) {
+        check(runtimeConfig.contains(DRAIN_EXCLUSIVE_ACTIONS))
+        check(runtimeConfig.contains(RENDER_ONLY_WHEN_STATE_CHANGES))
+
+        var childActionAppliedCount = 0
+        var parentRenderCount = 0
+        val trigger = MutableSharedFlow<String>()
+        val receivedOutputs = mutableListOf<String>()
+
+        val childWorkflow = Workflow.stateful<String, String, String>(
+          initialState = "unchanged state",
+          render = { renderState ->
+            runningWorker(
+              trigger.asWorker()
+            ) {
+              action("") {
+                // no state change!
+                childActionAppliedCount++
+                setOutput(it)
+              }
+            }
+            renderState
+          }
+        )
+        val workflow = Workflow.stateful<String, String, String>(
+          initialState = "unchanging state",
+          render = { renderState ->
+            renderChild(childWorkflow, key = "key1") { _ ->
+              WorkflowAction.noAction()
+            }
+            renderChild(childWorkflow, key = "key2") { childOutput ->
+              action(name = "Child2Handler") {
+                // Second one sets output to test that we still send the output!
+                setOutput(childOutput)
+              }
+            }
+            parentRenderCount++
+            renderState
+          }
+        )
+        val props = MutableStateFlow(Unit)
+        renderWorkflowIn(
+          workflow = workflow,
+          scope = backgroundScope,
+          props = props,
+          runtimeConfig = runtimeConfig,
+          workflowTracer = testTracer,
+        ) {
+          receivedOutputs.add(it)
+        }
+        advanceIfStandard()
+
+        launch {
+          trigger.emit("changed state")
+        }
+        advanceIfStandard()
+
+        // 2 child actions processed and 1 parent render - only the initial one.
+        assertEquals(2, childActionAppliedCount, "Expected each child action applied.")
+        assertEquals(1, parentRenderCount, "Expected parent only rendered once.")
+        assertEquals(1, receivedOutputs.size, "Expected one output.")
+        assertEquals("changed state", receivedOutputs[0])
+      }
+    }
+  }
+
+  @Test
+  fun for_drain_exclusive_and_render_only_when_state_changes_we_handle_multiple_actions_in_one_render_but_we_do_pass_rendering_if_state_changed_earlier() {
+    if (runtimeConfig.contains(DRAIN_EXCLUSIVE_ACTIONS) &&
+      runtimeConfig.contains(RENDER_ONLY_WHEN_STATE_CHANGES)
+    ) {
+      runTest(dispatcherUsed) {
+        check(runtimeConfig.contains(DRAIN_EXCLUSIVE_ACTIONS))
+        check(runtimeConfig.contains(RENDER_ONLY_WHEN_STATE_CHANGES))
+
+        var childActionAppliedCount = 0
+        var parentRenderCount = 0
+        val trigger = MutableSharedFlow<String>()
+        val receivedOutputs = mutableListOf<String>()
+        val emitted = mutableListOf<String>()
+
+        val childWorkflow = Workflow.stateful<String, String, String>(
+          initialState = "unchanged state",
+          render = { renderState ->
+            runningWorker(
+              trigger.asWorker()
+            ) {
+              action("") {
+                if (childActionAppliedCount == 0) {
+                  // change state on the first one.
+                  state = "$it+update"
+                } else {
+                  // no state change!
+                }
+                childActionAppliedCount++
+                setOutput(it)
+              }
+            }
+            renderState
+          }
+        )
+        val workflow = Workflow.stateful<String, String, String>(
+          initialState = "unchanging state",
+          render = { renderState ->
+            renderChild(childWorkflow, key = "key1") { _ ->
+              WorkflowAction.noAction()
+            }
+            renderChild(childWorkflow, key = "key2") { childOutput ->
+              action(name = "Child2Handler") {
+                // Second one sets output to test that we still send the output!
+                setOutput(childOutput)
+              }
+            }
+            parentRenderCount++
+            renderState
+          }
+        )
+        val props = MutableStateFlow(Unit)
+        val renderings = renderWorkflowIn(
+          workflow = workflow,
+          scope = backgroundScope,
+          props = props,
+          runtimeConfig = runtimeConfig,
+          workflowTracer = testTracer,
+        ) {
+          receivedOutputs.add(it)
+        }
+        advanceIfStandard()
+
+        val collectionJob = launch {
+          // Collect this unconfined so we can get all the renderings faster than actions can
+          // be processed.
+          renderings.collect {
+            emitted += it.rendering
+          }
+        }
+        advanceIfStandard()
+
+        launch {
+          trigger.emit("changed state")
+        }
+        advanceIfStandard()
+
+        collectionJob.cancel()
+
+        // 2 renderings received always as the state on child changes!
+        assertEquals(2, emitted.size)
+        // 2 child actions processed and 1 (or 2) parent renders.
+        assertEquals(2, childActionAppliedCount, "Expected each child action applied.")
+        if (runtimeConfig.contains(PARTIAL_TREE_RENDERING) &&
+          !runtimeConfig.contains(DRAIN_EXCLUSIVE_ACTIONS)
+        ) {
+          // With DEA both actions get applied before the 2nd render pass, so there are fewer
+          // render passes but all nodes are dirty and need to be re-rendered.
+          assertEquals(1, parentRenderCount, "Expected parent only rendered once.")
+        } else {
+          assertEquals(2, parentRenderCount, "Expected parent rendered twice.")
+        }
+        assertEquals(1, receivedOutputs.size, "Expected one output.")
+        assertEquals("changed state", receivedOutputs[0])
+      }
+    }
+  }
+
+  @Test
+  fun for_drain_exclusive_we_do_not_handle_multiple_actions_in_one_render_if_not_exclusive() {
+    if (runtimeConfig.contains(DRAIN_EXCLUSIVE_ACTIONS)) {
+      runTest(dispatcherUsed) {
+        check(runtimeConfig.contains(DRAIN_EXCLUSIVE_ACTIONS))
+
+        var childActionAppliedCount = 0
+        var parentRenderCount = 0
+        val trigger = MutableSharedFlow<String>()
+
+        val childWorkflow = Workflow.stateful<String, String, String>(
+          initialState = "unchanged state",
+          render = { renderState ->
+            runningWorker(
+              trigger.asWorker()
+            ) {
+              action("") {
+                state = it
+                childActionAppliedCount++
+                // set the output to dirty the parent node.
+                setOutput(it)
+              }
+            }
+            renderState
+          }
+        )
+        val workflow = Workflow.stateful<String, String, String>(
+          initialState = "unchanging state",
+          render = { renderState ->
+            renderChild(childWorkflow, key = "key1") { childOutput ->
+              action("childHandler1") {
+                state = childOutput
+              }
+            }
+            renderChild(childWorkflow, key = "key2") { childOutput ->
+              action("childHandler2") {
+                state = childOutput
+              }
+            }
+            parentRenderCount++
+            renderState
+          }
+        )
+        val props = MutableStateFlow(Unit)
+        renderWorkflowIn(
+          workflow = workflow,
+          scope = backgroundScope,
+          props = props,
+          runtimeConfig = runtimeConfig,
+          workflowTracer = testTracer,
+        ) { }
+        advanceIfStandard()
+
+        launch {
+          trigger.emit("changed state")
+        }
+        advanceIfStandard()
+
+        // 2 child actions processed and 3 parent renders
+        assertEquals(2, childActionAppliedCount, "Expecting 2 child actions applied")
+        assertEquals(3, parentRenderCount, "Expecting 3 parent renders")
       }
     }
   }

--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -11,7 +11,7 @@ public final class com/squareup/workflow1/testing/RenderIdempotencyChecker : com
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRenderAndSnapshot (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/RenderingAndSnapshot;
-	public fun onRuntimeLoopTick (Lcom/squareup/workflow1/WorkflowInterceptor$RuntimeLoopOutcome;)V
+	public fun onRuntimeUpdate (Lcom/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate;)V
 	public fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)V
 	public fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/Snapshot;
 	public fun onSnapshotStateWithChildren (Lkotlin/jvm/functions/Function0;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/TreeSnapshot;

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowsLifecycleTests.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowsLifecycleTests.kt
@@ -6,6 +6,7 @@ import app.cash.burst.Burst
 import com.squareup.workflow1.RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS
 import com.squareup.workflow1.RuntimeConfigOptions.Companion.RuntimeOptions
 import com.squareup.workflow1.RuntimeConfigOptions.Companion.RuntimeOptions.DEFAULT
+import com.squareup.workflow1.RuntimeConfigOptions.DRAIN_EXCLUSIVE_ACTIONS
 import com.squareup.workflow1.testing.headlessIntegrationTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -149,7 +150,9 @@ class WorkflowsLifecycleTests(
       setState.invoke(1)
       setState.invoke(2)
       awaitNextRendering()
-      if (!runtimeConfig.contains(CONFLATE_STALE_RENDERINGS)) {
+      if (!runtimeConfig.contains(CONFLATE_STALE_RENDERINGS) &&
+        !runtimeConfig.contains(DRAIN_EXCLUSIVE_ACTIONS)
+      ) {
         // 2 rendering or 1 depending on runtime config.
         awaitNextRendering()
       }

--- a/workflow-tracing/api/workflow-tracing.api
+++ b/workflow-tracing/api/workflow-tracing.api
@@ -16,7 +16,7 @@ public final class com/squareup/workflow1/diagnostic/tracing/TracingWorkflowInte
 	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRender (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow1/BaseRenderContext;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
 	public fun onRenderAndSnapshot (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/RenderingAndSnapshot;
-	public fun onRuntimeLoopTick (Lcom/squareup/workflow1/WorkflowInterceptor$RuntimeLoopOutcome;)V
+	public fun onRuntimeUpdate (Lcom/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate;)V
 	public fun onSessionStarted (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)V
 	public fun onSnapshotState (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/Snapshot;
 	public fun onSnapshotStateWithChildren (Lkotlin/jvm/functions/Function0;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Lcom/squareup/workflow1/TreeSnapshot;


### PR DESCRIPTION
Add an option to get the next action that is mutually exclusive to the dirty nodes. Then we can apply as many of those actions as possible.

Add tests for this as well and ensure existing tests can run with this runtime config on.