### PR TITLE
Refactor WorkflowNode into AbstractWorkflowNode <- StatefulWorkflowNode. [CLF-436]

### DIFF
--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/WorkflowInterceptor.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/WorkflowInterceptor.kt
@@ -1,6 +1,7 @@
 package com.squareup.workflow1
 
 import com.squareup.workflow1.WorkflowInterceptor.RenderContextInterceptor
+import com.squareup.workflow1.WorkflowInterceptor.RuntimeUpdate
 import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
@@ -189,6 +190,8 @@ public interface WorkflowInterceptor {
   /**
    * Information about the session of a workflow in the runtime that a [WorkflowInterceptor] method
    * is intercepting.
+   *
+   * Implementations should override [toString] to call [WorkflowSession.workflowSessionToString].
    */
   public interface WorkflowSession {
     /** The [WorkflowIdentifier] that represents the type of this workflow. */
@@ -400,6 +403,16 @@ internal fun <P, S, O, R> WorkflowInterceptor.intercept(
       override fun toString(): String = "InterceptedWorkflow($workflow, ${this@intercept})"
     }
   }
+
+internal fun WorkflowSession.workflowSessionToString(): String {
+  val parentDescription = parent?.let { "WorkflowInstance(…)" }
+  return "WorkflowInstance(" +
+    "identifier=$identifier, " +
+    "renderKey=$renderKey, " +
+    "instanceId=$sessionId, " +
+    "parent=$parentDescription" +
+    ")"
+}
 
 private class InterceptedRenderContext<P, S, O>(
   private val baseRenderContext: BaseRenderContext<P, S, O>,

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/AbstractWorkflowNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/AbstractWorkflowNode.kt
@@ -1,0 +1,121 @@
+package com.squareup.workflow1.internal
+
+import com.squareup.workflow1.ActionApplied
+import com.squareup.workflow1.ActionProcessingResult
+import com.squareup.workflow1.ActionsExhausted
+import com.squareup.workflow1.NoopWorkflowInterceptor
+import com.squareup.workflow1.RuntimeConfig
+import com.squareup.workflow1.RuntimeConfigOptions
+import com.squareup.workflow1.TreeSnapshot
+import com.squareup.workflow1.Workflow
+import com.squareup.workflow1.WorkflowInterceptor
+import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
+import com.squareup.workflow1.WorkflowTracer
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.selects.SelectBuilder
+
+internal fun <PropsT, OutputT, RenderingT> createWorkflowNode(
+  id: WorkflowNodeId,
+  workflow: Workflow<PropsT, OutputT, RenderingT>,
+  initialProps: PropsT,
+  snapshot: TreeSnapshot?,
+  baseContext: CoroutineContext,
+  // Providing default value so we don't need to specify in test.
+  runtimeConfig: RuntimeConfig = RuntimeConfigOptions.DEFAULT_CONFIG,
+  workflowTracer: WorkflowTracer? = null,
+  emitAppliedActionToParent: (ActionApplied<OutputT>) -> ActionProcessingResult = { it },
+  parent: WorkflowSession? = null,
+  interceptor: WorkflowInterceptor = NoopWorkflowInterceptor,
+  idCounter: IdCounter? = null,
+): AbstractWorkflowNode<PropsT, OutputT, RenderingT> =
+  StatefulWorkflowNode(
+    id = id,
+    workflow = workflow.asStatefulWorkflow(),
+    initialProps = initialProps,
+    snapshot = snapshot,
+    baseContext = baseContext,
+    runtimeConfig = runtimeConfig,
+    workflowTracer = workflowTracer,
+    emitAppliedActionToParent = emitAppliedActionToParent,
+    parent = parent,
+    interceptor = interceptor,
+    idCounter = idCounter,
+  )
+
+internal abstract class AbstractWorkflowNode<PropsT, OutputT, RenderingT>(
+  val id: WorkflowNodeId,
+  protected val interceptor: WorkflowInterceptor,
+  protected val emitAppliedActionToParent: (ActionApplied<OutputT>) -> ActionProcessingResult,
+  baseContext: CoroutineContext,
+) {
+
+  /**
+   * Scope that has a job that will live as long as this node and be cancelled when [cancel] is
+   * called. Also adds a debug name to this coroutine based on its ID.
+   */
+  protected val scope: CoroutineScope =
+    CoroutineScope(baseContext + Job(parent = baseContext[Job]) + CoroutineName(id.toString()))
+
+  /** The [WorkflowSession] that represents this node to [WorkflowInterceptor]s. */
+  abstract val session: WorkflowSession
+
+  /**
+   * Walk the tree of workflows, rendering each one and using
+   * [RenderContext][com.squareup.workflow1.BaseRenderContext] to give its children a chance to
+   * render themselves and aggregate those child renderings.
+   *
+   * @param workflow The "template" workflow instance used in the current render pass. This isn't
+   *   necessarily the same _instance_ every call, but will be the same _type_.
+   */
+  abstract fun render(workflow: Workflow<PropsT, OutputT, RenderingT>, input: PropsT): RenderingT
+
+  /**
+   * Walk the tree of state machines again, this time gathering snapshots and aggregating them
+   * automatically.
+   */
+  abstract fun snapshot(): TreeSnapshot
+
+  /**
+   * Register select clauses for the next [result][ActionProcessingResult] from the state machine.
+   *
+   * Walk the tree of state machines, asking each one to wait for its next event. If something
+   * happens that results in an output, that output is returned. Null means something happened that
+   * requires a re-render, e.g. my state changed or a child state changed.
+   *
+   * It is an error to call this method after calling [cancel].
+   *
+   * Contrast this to [applyNextAvailableTreeAction], which is used to check for an action that is
+   * already available without waiting, and then _immediately_ apply it.
+   */
+  abstract fun registerTreeActionSelectors(selector: SelectBuilder<ActionProcessingResult>)
+
+  /**
+   * Will try to apply any immediately available actions in this action queue or any of our
+   * children's.
+   *
+   * Contrast this to [registerTreeActionSelectors] which will add select clauses that will await
+   * the next action.
+   *
+   * @param skipDirtyNodes Whether or not this should skip over any workflow nodes that are already
+   *   'dirty' - that is, they had their own state changed as the result of a previous action before
+   *   the next render pass.
+   * @return [ActionProcessingResult] of the action processed, or [ActionsExhausted] if there were
+   *   none immediately available.
+   */
+  abstract fun applyNextAvailableTreeAction(skipDirtyNodes: Boolean = false): ActionProcessingResult
+
+  /**
+   * Cancels this state machine host, and any coroutines started as children of it.
+   *
+   * This must be called when the caller will no longer call [registerTreeActionSelectors]. It is an
+   * error to call [registerTreeActionSelectors] after calling this method.
+   */
+  open fun cancel(cause: CancellationException? = null) {
+    scope.cancel(cause)
+  }
+}

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/StatefulWorkflowNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/StatefulWorkflowNode.kt
@@ -65,7 +65,7 @@ internal class StatefulWorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   interceptor: WorkflowInterceptor = NoopWorkflowInterceptor,
   idCounter: IdCounter? = null,
 ) :
-  AbstractWorkflowNode<PropsT, OutputT, RenderingT>(
+  WorkflowNode<PropsT, OutputT, RenderingT>(
     id = id,
     baseContext = baseContext,
     interceptor = interceptor,

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/StatefulWorkflowNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/StatefulWorkflowNode.kt
@@ -1,5 +1,6 @@
 package com.squareup.workflow1.internal
 
+import androidx.annotation.RestrictTo
 import com.squareup.workflow1.ActionApplied
 import com.squareup.workflow1.ActionProcessingResult
 import com.squareup.workflow1.ActionsExhausted
@@ -25,6 +26,7 @@ import com.squareup.workflow1.intercept
 import com.squareup.workflow1.internal.RealRenderContext.RememberStore
 import com.squareup.workflow1.internal.RealRenderContext.SideEffectRunner
 import com.squareup.workflow1.trace
+import com.squareup.workflow1.workflowSessionToString
 import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.KType
 import kotlinx.coroutines.CancellationException
@@ -32,7 +34,6 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart.LAZY
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.launch
@@ -50,8 +51,8 @@ import kotlinx.coroutines.selects.SelectBuilder
  *   violate structured concurrency).
  */
 @OptIn(WorkflowExperimentalApi::class, WorkflowExperimentalRuntime::class)
-internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
-  val id: WorkflowNodeId,
+internal class StatefulWorkflowNode<PropsT, StateT, OutputT, RenderingT>(
+  id: WorkflowNodeId,
   workflow: StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>,
   initialProps: PropsT,
   snapshot: TreeSnapshot?,
@@ -59,24 +60,29 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   // Providing default value so we don't need to specify in test.
   override val runtimeConfig: RuntimeConfig = RuntimeConfigOptions.DEFAULT_CONFIG,
   override val workflowTracer: WorkflowTracer? = null,
-  private val emitAppliedActionToParent: (ActionApplied<OutputT>) -> ActionProcessingResult = {
-    it
-  },
+  emitAppliedActionToParent: (ActionApplied<OutputT>) -> ActionProcessingResult = { it },
   override val parent: WorkflowSession? = null,
-  private val interceptor: WorkflowInterceptor = NoopWorkflowInterceptor,
+  interceptor: WorkflowInterceptor = NoopWorkflowInterceptor,
   idCounter: IdCounter? = null,
-) : CoroutineScope, SideEffectRunner, RememberStore, WorkflowSession {
+) :
+  AbstractWorkflowNode<PropsT, OutputT, RenderingT>(
+    id = id,
+    baseContext = baseContext,
+    interceptor = interceptor,
+    emitAppliedActionToParent = emitAppliedActionToParent,
+  ),
+  SideEffectRunner,
+  RememberStore,
+  WorkflowSession {
 
-  /**
-   * Context that has a job that will live as long as this node. Also adds a debug name to this
-   * coroutine based on its ID.
-   */
-  override val coroutineContext = baseContext + Job(baseContext[Job]) + CoroutineName(id.toString())
+  internal val coroutineContextForTest: CoroutineContext
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    get() = scope.coroutineContext
 
   override val runtimeContext: CoroutineContext
-    get() = coroutineContext
+    get() = scope.coroutineContext
 
-  // WorkflowInstance properties
+  // WorkflowSession properties
   override val identifier: WorkflowIdentifier
     get() = id.identifier
 
@@ -87,10 +93,13 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   private var cachedWorkflowInstance: StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>
   private var interceptedWorkflowInstance: StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>
 
+  override val session: WorkflowSession
+    get() = this
+
   private val subtreeManager =
     SubtreeManager(
       snapshotCache = snapshot?.childTreeSnapshots,
-      contextForChildren = coroutineContext,
+      contextForChildren = scope.coroutineContext,
       emitActionToParent = ::applyAction,
       runtimeConfig = runtimeConfig,
       workflowTracer = workflowTracer,
@@ -106,7 +115,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
           { it.key }
         } else {
           null
-        }
+        },
     )
   private val remembered =
     ActiveStagingList<RememberedNode<*>>(
@@ -115,7 +124,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
           { RememberIdentity(it.key, it.resultType, it.inputs) }
         } else {
           null
-        }
+        },
     )
   private var lastProps: PropsT = initialProps
   private var lastRendering: NullableInitBox<RenderingT> = NullableInitBox()
@@ -141,22 +150,20 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   private val context = RenderContext(baseRenderContext, workflow)
 
   init {
-    interceptor.onSessionStarted(this, this)
+    interceptor.onSessionStarted(workflowScope = scope, session = this)
 
     cachedWorkflowInstance = workflow
-    interceptedWorkflowInstance = interceptor.intercept(cachedWorkflowInstance, this)
-    state = interceptedWorkflowInstance.initialState(initialProps, snapshot?.workflowSnapshot, this)
+    interceptedWorkflowInstance =
+      interceptor.intercept(workflow = cachedWorkflowInstance, workflowSession = this)
+    state =
+      interceptedWorkflowInstance.initialState(
+        props = initialProps,
+        snapshot = snapshot?.workflowSnapshot,
+        workflowScope = scope,
+      )
   }
 
-  override fun toString(): String {
-    val parentDescription = parent?.let { "WorkflowInstance(…)" }
-    return "WorkflowInstance(" +
-      "identifier=$identifier, " +
-      "renderKey=$renderKey, " +
-      "instanceId=$sessionId, " +
-      "parent=$parentDescription" +
-      ")"
-  }
+  override fun toString(): String = workflowSessionToString()
 
   /**
    * Walk the tree of workflows, rendering each one and using
@@ -164,22 +171,20 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
    * render themselves and aggregate those child renderings.
    */
   @Suppress("UNCHECKED_CAST")
-  fun render(
-    workflow: StatefulWorkflow<PropsT, *, OutputT, RenderingT>,
-    input: PropsT,
-  ): RenderingT =
-    renderWithStateType(workflow as StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>, input)
+  override fun render(workflow: Workflow<PropsT, OutputT, RenderingT>, input: PropsT): RenderingT =
+    renderWithStateType(
+      workflow =
+        workflow.asStatefulWorkflow() as StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>,
+      props = input,
+    )
 
   /**
    * Walk the tree of state machines again, this time gathering snapshots and aggregating them
    * automatically.
    */
-  fun snapshot(workflow: StatefulWorkflow<*, *, *, *>): TreeSnapshot {
-    @Suppress("UNCHECKED_CAST")
-    val typedWorkflow = workflow as StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>
-    maybeUpdateCachedWorkflowInstance(typedWorkflow)
+  override fun snapshot(): TreeSnapshot {
     return interceptor.onSnapshotStateWithChildren(
-      {
+      proceed = {
         val childSnapshots = subtreeManager.createChildSnapshots()
         val rootSnapshot = interceptedWorkflowInstance.snapshotState(state)
         TreeSnapshot(
@@ -188,7 +193,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
           childTreeSnapshots = { childSnapshots },
         )
       },
-      this,
+      session = this,
     )
   }
 
@@ -277,20 +282,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
     }
   }
 
-  /**
-   * Register select clauses for the next [result][ActionProcessingResult] from the state machine.
-   *
-   * Walk the tree of state machines, asking each one to wait for its next event. If something
-   * happen that results in an output, that output is returned. Null means something happened that
-   * requires a re-render, e.g. my state changed or a child state changed.
-   *
-   * It is an error to call this method after calling [cancel].
-   *
-   * Contrast this to [applyNextAvailableTreeAction], which is used to check for an action that is
-   * already available without waiting, and then _immediately_ apply it. The select clauses added
-   * here also call [applyAction] when one of them is selected.
-   */
-  fun registerTreeActionSelectors(selector: SelectBuilder<ActionProcessingResult>) {
+  override fun registerTreeActionSelectors(selector: SelectBuilder<ActionProcessingResult>) {
     // Listen for any child workflow updates.
     subtreeManager.registerChildActionSelectors(selector)
 
@@ -302,21 +294,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
     }
   }
 
-  /**
-   * Will try to apply any immediately available actions in this action queue or any of our
-   * children's.
-   *
-   * Contrast this to [registerTreeActionSelectors] which will add select clauses that will await
-   * the next action. That will also end up with [applyAction] being called when the clauses is
-   * selected.
-   *
-   * @param skipDirtyNodes Whether or not this should skip over any workflow nodes that are already
-   *   'dirty' - that is, they had their own state changed as the result of a previous action before
-   *   the next render pass.
-   * @return [ActionProcessingResult] of the action processed, or [ActionsExhausted] if there were
-   *   none immediately available.
-   */
-  fun applyNextAvailableTreeAction(skipDirtyNodes: Boolean = false): ActionProcessingResult {
+  override fun applyNextAvailableTreeAction(skipDirtyNodes: Boolean): ActionProcessingResult {
     if (skipDirtyNodes && selfStateDirty) return ActionsExhausted
 
     val result = subtreeManager.applyNextAvailableChildAction(skipDirtyNodes)
@@ -334,7 +312,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
    * This must be called when the caller will no longer call [registerTreeActionSelectors]. It is an
    * error to call [registerTreeActionSelectors] after calling this method.
    */
-  fun cancel(cause: CancellationException? = null) {
+  override fun cancel(cause: CancellationException?) {
     val hangingActions = mutableListOf<WorkflowAction<PropsT, StateT, OutputT>>()
     // This will only be non-null if there is an action buffered and ready.
     var nextAction = eventActionsChannel.tryReceive().getOrNull()
@@ -343,7 +321,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
       nextAction = eventActionsChannel.tryReceive().getOrNull()
     }
     interceptor.onSessionCancelled(cause = cause, droppedActions = hangingActions, session = this)
-    coroutineContext.cancel(cause)
+    super.cancel(cause)
     lastRendering = NullableInitBox()
   }
 
@@ -373,8 +351,8 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
 
     if (
       !runtimeConfig.contains(PARTIAL_TREE_RENDERING) ||
-        !lastRendering.isInitialized ||
-        subtreeStateDirty
+      !lastRendering.isInitialized ||
+      subtreeStateDirty
     ) {
       // If we haven't already updated the cached instance, better do it now!
       maybeUpdateCachedWorkflowInstance(workflow)
@@ -437,7 +415,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
     val aggregateActionApplied =
       actionApplied.copy(
         // Changing state is sticky, we pass it up if it ever changed.
-        stateChanged = actionApplied.stateChanged || (childResult?.stateChanged ?: false)
+        stateChanged = actionApplied.stateChanged || (childResult?.stateChanged ?: false),
       )
     // Our state changed.
     selfStateDirty = selfStateDirty || actionApplied.stateChanged
@@ -465,7 +443,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT, RenderingT>(
     sideEffect: suspend CoroutineScope.() -> Unit,
   ): SideEffectNode {
     return workflowTracer.trace("CreateSideEffectNode") {
-      val scope = this + CoroutineName("sideEffect[$key] for $id")
+      val scope = scope + CoroutineName("sideEffect[$key] for $id")
       val job = scope.launch(start = LAZY, block = sideEffect)
       SideEffectNode(key, job)
     }

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/StatefulWorkflowNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/StatefulWorkflowNode.kt
@@ -76,8 +76,7 @@ internal class StatefulWorkflowNode<PropsT, StateT, OutputT, RenderingT>(
   WorkflowSession {
 
   internal val coroutineContextForTest: CoroutineContext
-    @RestrictTo(RestrictTo.Scope.TESTS)
-    get() = scope.coroutineContext
+    @RestrictTo(RestrictTo.Scope.TESTS) get() = scope.coroutineContext
 
   override val runtimeContext: CoroutineContext
     get() = scope.coroutineContext
@@ -115,7 +114,7 @@ internal class StatefulWorkflowNode<PropsT, StateT, OutputT, RenderingT>(
           { it.key }
         } else {
           null
-        },
+        }
     )
   private val remembered =
     ActiveStagingList<RememberedNode<*>>(
@@ -124,7 +123,7 @@ internal class StatefulWorkflowNode<PropsT, StateT, OutputT, RenderingT>(
           { RememberIdentity(it.key, it.resultType, it.inputs) }
         } else {
           null
-        },
+        }
     )
   private var lastProps: PropsT = initialProps
   private var lastRendering: NullableInitBox<RenderingT> = NullableInitBox()
@@ -351,8 +350,8 @@ internal class StatefulWorkflowNode<PropsT, StateT, OutputT, RenderingT>(
 
     if (
       !runtimeConfig.contains(PARTIAL_TREE_RENDERING) ||
-      !lastRendering.isInitialized ||
-      subtreeStateDirty
+        !lastRendering.isInitialized ||
+        subtreeStateDirty
     ) {
       // If we haven't already updated the cached instance, better do it now!
       maybeUpdateCachedWorkflowInstance(workflow)
@@ -415,7 +414,7 @@ internal class StatefulWorkflowNode<PropsT, StateT, OutputT, RenderingT>(
     val aggregateActionApplied =
       actionApplied.copy(
         // Changing state is sticky, we pass it up if it ever changed.
-        stateChanged = actionApplied.stateChanged || (childResult?.stateChanged ?: false),
+        stateChanged = actionApplied.stateChanged || (childResult?.stateChanged ?: false)
       )
     // Our state changed.
     selfStateDirty = selfStateDirty || actionApplied.stateChanged

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
@@ -22,8 +22,8 @@ import kotlinx.coroutines.selects.SelectBuilder
  * Responsible for tracking child workflows, starting them and tearing them down when necessary.
  * Also manages restoring children from snapshots.
  *
- * Child workflows are stored in [WorkflowChildNode]s, which associate the child's
- * [AbstractWorkflowNode] with its output handler.
+ * Child workflows are stored in [WorkflowChildNode]s, which associate the child's [WorkflowNode]
+ * with its output handler.
  *
  * ## Rendering
  *
@@ -184,8 +184,8 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
   }
 
   /**
-   * Uses [selector] to invoke [AbstractWorkflowNode.registerTreeActionSelectors] for every running
-   * child workflow this instance is managing.
+   * Uses [selector] to invoke [WorkflowNode.registerTreeActionSelectors] for every running child
+   * workflow this instance is managing.
    */
   fun registerChildActionSelectors(selector: SelectBuilder<ActionProcessingResult>) {
     children.forEachActive { child -> child.workflowNode.registerTreeActionSelectors(selector) }

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/SubtreeManager.kt
@@ -22,14 +22,14 @@ import kotlinx.coroutines.selects.SelectBuilder
  * Responsible for tracking child workflows, starting them and tearing them down when necessary.
  * Also manages restoring children from snapshots.
  *
- * Child workflows are stored in [WorkflowChildNode]s, which associate the child's [WorkflowNode]
- * with its output handler.
+ * Child workflows are stored in [WorkflowChildNode]s, which associate the child's
+ * [AbstractWorkflowNode] with its output handler.
  *
  * ## Rendering
  *
- * This class implements [RealRenderContext.Renderer], and [WorkflowNode] will pass its instance of
- * this class to the [RealRenderContext] on each render pass to render children. That means that
- * when a workflow renders a child, this class does the actual work.
+ * This class implements [RealRenderContext.Renderer], and [StatefulWorkflowNode] will pass its
+ * instance of this class to the [RealRenderContext] on each render pass to render children. That
+ * means that when a workflow renders a child, this class does the actual work.
  *
  * This class keeps two lists:
  * 1. Active list: All the children from the last render pass that have not yet been rendered in the
@@ -60,8 +60,8 @@ import kotlinx.coroutines.selects.SelectBuilder
  *      active:  [bar]
  *      staging: [foo, baz]
  *      ```
- * 4. When the workflow's render method returns, the [WorkflowNode] calls [commitRenderedChildren],
- *    which:
+ * 4. When the workflow's render method returns, the [StatefulWorkflowNode] calls
+ *    [commitRenderedChildren], which:
  *     1. Tears down all the children remaining in the active list
  *
  *           ```
@@ -180,12 +180,12 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
         }
       }
     stagedChild.setHandler(handler)
-    return stagedChild.render(child.asStatefulWorkflow(), props)
+    return stagedChild.render(child, props)
   }
 
   /**
-   * Uses [selector] to invoke [WorkflowNode.registerTreeActionSelectors] for every running child
-   * workflow this instance is managing.
+   * Uses [selector] to invoke [AbstractWorkflowNode.registerTreeActionSelectors] for every running
+   * child workflow this instance is managing.
    */
   fun registerChildActionSelectors(selector: SelectBuilder<ActionProcessingResult>) {
     children.forEachActive { child -> child.workflowNode.registerTreeActionSelectors(selector) }
@@ -212,10 +212,7 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
 
   fun createChildSnapshots(): Map<WorkflowNodeId, TreeSnapshot> {
     val snapshots = mutableMapOf<WorkflowNodeId, TreeSnapshot>()
-    children.forEachActive { child ->
-      val childWorkflow = child.workflow.asStatefulWorkflow()
-      snapshots[child.id] = child.workflowNode.snapshot(childWorkflow)
-    }
+    children.forEachActive { child -> snapshots[child.id] = child.workflowNode.snapshot() }
     return snapshots
   }
 
@@ -240,9 +237,9 @@ internal class SubtreeManager<PropsT, StateT, OutputT>(
     val childTreeSnapshots = snapshotCache?.get(id)
 
     val workflowNode =
-      WorkflowNode(
+      createWorkflowNode(
         id = id,
-        workflow = child.asStatefulWorkflow(),
+        workflow = child,
         initialProps = initialProps,
         snapshot = childTreeSnapshots,
         baseContext = contextForChildren,

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowChildNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowChildNode.kt
@@ -9,8 +9,8 @@ import com.squareup.workflow1.trace
 /**
  * Representation of a child workflow that has been rendered by another workflow.
  *
- * Associates the child's [AbstractWorkflowNode] (which includes the key passed to `renderChild`)
- * with the output handler function that was passed to `renderChild`.
+ * Associates the child's [WorkflowNode] (which includes the key passed to `renderChild`) with the
+ * output handler function that was passed to `renderChild`.
  */
 internal class WorkflowChildNode<
   ChildPropsT,
@@ -21,11 +21,11 @@ internal class WorkflowChildNode<
 >(
   val workflow: Workflow<*, ChildOutputT, *>,
   private var handler: (ChildOutputT) -> WorkflowAction<ParentPropsT, ParentStateT, ParentOutputT>,
-  val workflowNode: AbstractWorkflowNode<ChildPropsT, ChildOutputT, *>,
+  val workflowNode: WorkflowNode<ChildPropsT, ChildOutputT, *>,
 ) : InlineListNode<WorkflowChildNode<*, *, *, *, *>> {
   override var nextListNode: WorkflowChildNode<*, *, *, *, *>? = null
 
-  /** The [AbstractWorkflowNode]'s [WorkflowNodeId]. */
+  /** The [WorkflowNode]'s [WorkflowNodeId]. */
   val id
     get() = workflowNode.id
 
@@ -43,7 +43,7 @@ internal class WorkflowChildNode<
       newHandler as (ChildOutputT) -> WorkflowAction<ParentPropsT, ParentStateT, ParentOutputT>
   }
 
-  /** Wrapper around [AbstractWorkflowNode.render] that allows calling it with erased types. */
+  /** Wrapper around [WorkflowNode.render] that allows calling it with erased types. */
   fun <R> render(workflow: Workflow<*, *, *>, props: Any?): R {
     @Suppress("UNCHECKED_CAST")
     return workflowNode.render(

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowChildNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowChildNode.kt
@@ -1,6 +1,5 @@
 package com.squareup.workflow1.internal
 
-import com.squareup.workflow1.StatefulWorkflow
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowAction
 import com.squareup.workflow1.WorkflowTracer
@@ -10,8 +9,8 @@ import com.squareup.workflow1.trace
 /**
  * Representation of a child workflow that has been rendered by another workflow.
  *
- * Associates the child's [WorkflowNode] (which includes the key passed to `renderChild`) with the
- * output handler function that was passed to `renderChild`.
+ * Associates the child's [AbstractWorkflowNode] (which includes the key passed to `renderChild`)
+ * with the output handler function that was passed to `renderChild`.
  */
 internal class WorkflowChildNode<
   ChildPropsT,
@@ -22,11 +21,11 @@ internal class WorkflowChildNode<
 >(
   val workflow: Workflow<*, ChildOutputT, *>,
   private var handler: (ChildOutputT) -> WorkflowAction<ParentPropsT, ParentStateT, ParentOutputT>,
-  val workflowNode: WorkflowNode<ChildPropsT, *, ChildOutputT, *>,
+  val workflowNode: AbstractWorkflowNode<ChildPropsT, ChildOutputT, *>,
 ) : InlineListNode<WorkflowChildNode<*, *, *, *, *>> {
   override var nextListNode: WorkflowChildNode<*, *, *, *, *>? = null
 
-  /** The [WorkflowNode]'s [WorkflowNodeId]. */
+  /** The [AbstractWorkflowNode]'s [WorkflowNodeId]. */
   val id
     get() = workflowNode.id
 
@@ -44,11 +43,11 @@ internal class WorkflowChildNode<
       newHandler as (ChildOutputT) -> WorkflowAction<ParentPropsT, ParentStateT, ParentOutputT>
   }
 
-  /** Wrapper around [WorkflowNode.render] that allows calling it with erased types. */
-  fun <R> render(workflow: StatefulWorkflow<*, *, *, *>, props: Any?): R {
+  /** Wrapper around [AbstractWorkflowNode.render] that allows calling it with erased types. */
+  fun <R> render(workflow: Workflow<*, *, *>, props: Any?): R {
     @Suppress("UNCHECKED_CAST")
     return workflowNode.render(
-      workflow as StatefulWorkflow<ChildPropsT, *, ChildOutputT, Nothing>,
+      workflow as Workflow<ChildPropsT, ChildOutputT, Nothing>,
       props as ChildPropsT,
     ) as R
   }

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowNode.kt
@@ -32,7 +32,7 @@ internal fun <PropsT, OutputT, RenderingT> createWorkflowNode(
   parent: WorkflowSession? = null,
   interceptor: WorkflowInterceptor = NoopWorkflowInterceptor,
   idCounter: IdCounter? = null,
-): AbstractWorkflowNode<PropsT, OutputT, RenderingT> =
+): WorkflowNode<PropsT, OutputT, RenderingT> =
   StatefulWorkflowNode(
     id = id,
     workflow = workflow.asStatefulWorkflow(),
@@ -47,7 +47,7 @@ internal fun <PropsT, OutputT, RenderingT> createWorkflowNode(
     idCounter = idCounter,
   )
 
-internal abstract class AbstractWorkflowNode<PropsT, OutputT, RenderingT>(
+internal abstract class WorkflowNode<PropsT, OutputT, RenderingT>(
   val id: WorkflowNodeId,
   protected val interceptor: WorkflowInterceptor,
   protected val emitAppliedActionToParent: (ActionApplied<OutputT>) -> ActionProcessingResult,

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowRunner.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/internal/WorkflowRunner.kt
@@ -47,7 +47,7 @@ internal class WorkflowRunner<PropsT, OutputT, RenderingT>(
   private val propsChannel = props.dropWhile { it == currentProps }.produceIn(scope)
 
   private val rootNode =
-    WorkflowNode(
+    createWorkflowNode(
       id = workflow.id(),
       workflow = workflow,
       initialProps = currentProps,
@@ -67,13 +67,13 @@ internal class WorkflowRunner<PropsT, OutputT, RenderingT>(
    */
   fun nextRendering(): RenderingAndSnapshot<RenderingT> {
     return interceptor.onRenderAndSnapshot(
-      currentProps,
-      { props ->
+      renderProps = currentProps,
+      proceed = { props ->
         val rendering = rootNode.render(workflow, props)
-        val snapshot = rootNode.snapshot(workflow)
+        val snapshot = rootNode.snapshot()
         RenderingAndSnapshot(rendering, snapshot)
       },
-      rootNode,
+      session = rootNode.session,
     )
   }
 

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/StatefulWorkflowNodeTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/StatefulWorkflowNodeTest.kt
@@ -506,10 +506,10 @@ internal class StatefulWorkflowNodeTest {
 
     val workflow =
       Workflow.stateless<Int, Nothing, Unit> { props ->
-        if (props in 0..2) runningSideEffect("one", recordingSideEffect(events1))
-        if (props == 1) runningSideEffect("two", recordingSideEffect(events2))
-        if (props == 2) runningSideEffect("three", recordingSideEffect(events3))
-      }
+          if (props in 0..2) runningSideEffect("one", recordingSideEffect(events1))
+          if (props == 1) runningSideEffect("two", recordingSideEffect(events2))
+          if (props == 2) runningSideEffect("three", recordingSideEffect(events3))
+        }
         .asStatefulWorkflow()
     val node =
       StatefulWorkflowNode(

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/StatefulWorkflowNodeTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/StatefulWorkflowNodeTest.kt
@@ -57,7 +57,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 
 @Suppress("UNCHECKED_CAST")
-internal class WorkflowNodeTest {
+internal class StatefulWorkflowNodeTest {
 
   abstract class StringWorkflow : StatefulWorkflow<String, String, String, String>() {
     override fun snapshotState(state: String): Snapshot = fail("not expected")
@@ -107,7 +107,7 @@ internal class WorkflowNodeTest {
       oldAndNewProps += old to new
       return@PropsRenderingWorkflow state
     }
-    val node = WorkflowNode(workflow.id(), workflow, "old", null, context)
+    val node = StatefulWorkflowNode(workflow.id(), workflow, "old", null, context)
 
     node.render(workflow, "new")
 
@@ -121,7 +121,7 @@ internal class WorkflowNodeTest {
       oldAndNewProps += old to new
       return@PropsRenderingWorkflow state
     }
-    val node = WorkflowNode(workflow.id(), workflow, "old", null, context)
+    val node = StatefulWorkflowNode(workflow.id(), workflow, "old", null, context)
 
     node.render(workflow, "old")
 
@@ -131,7 +131,7 @@ internal class WorkflowNodeTest {
   @Test
   fun props_are_rendered() {
     val workflow = PropsRenderingWorkflow { old, new, _ -> "$old->$new" }
-    val node = WorkflowNode(workflow.id(), workflow, "foo", null, context)
+    val node = StatefulWorkflowNode(workflow.id(), workflow, "foo", null, context)
 
     val rendering = node.render(workflow, "foo2")
 
@@ -174,7 +174,7 @@ internal class WorkflowNodeTest {
         }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow,
         "",
@@ -213,7 +213,7 @@ internal class WorkflowNodeTest {
         }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow,
         "",
@@ -259,7 +259,7 @@ internal class WorkflowNodeTest {
           return ""
         }
       }
-    val node = WorkflowNode(workflow.id(), workflow, "", null, context)
+    val node = StatefulWorkflowNode(workflow.id(), workflow, "", null, context)
 
     node.render(workflow, "")
     sink.send(action("") { setOutput("event") })
@@ -277,7 +277,7 @@ internal class WorkflowNodeTest {
         assertFalse(started)
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -299,7 +299,7 @@ internal class WorkflowNodeTest {
         runningSideEffect("the key") { contextFromWorker = coroutineContext }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -308,7 +308,10 @@ internal class WorkflowNodeTest {
       )
 
     node.render(workflow.asStatefulWorkflow(), Unit)
-    assertEquals(WorkflowNodeId(workflow).toString(), node.coroutineContext[CoroutineName]!!.name)
+    assertEquals(
+      WorkflowNodeId(workflow).toString(),
+      node.coroutineContextForTest[CoroutineName]!!.name,
+    )
     assertEquals(
       "sideEffect[the key] for ${WorkflowNodeId(workflow)}",
       contextFromWorker!![CoroutineName]!!.name,
@@ -322,7 +325,7 @@ internal class WorkflowNodeTest {
         runningSideEffect("key") { actionSink.send(action("") { setOutput("result") }) }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -356,7 +359,7 @@ internal class WorkflowNodeTest {
         }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = true,
@@ -388,7 +391,7 @@ internal class WorkflowNodeTest {
         }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -420,7 +423,7 @@ internal class WorkflowNodeTest {
         }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = 0,
@@ -449,7 +452,7 @@ internal class WorkflowNodeTest {
         runningSideEffect("") { seenProps += props }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = 0,
@@ -476,7 +479,7 @@ internal class WorkflowNodeTest {
         runningSideEffect("same") { fail() }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -503,13 +506,13 @@ internal class WorkflowNodeTest {
 
     val workflow =
       Workflow.stateless<Int, Nothing, Unit> { props ->
-          if (props in 0..2) runningSideEffect("one", recordingSideEffect(events1))
-          if (props == 1) runningSideEffect("two", recordingSideEffect(events2))
-          if (props == 2) runningSideEffect("three", recordingSideEffect(events3))
-        }
+        if (props in 0..2) runningSideEffect("one", recordingSideEffect(events1))
+        if (props == 1) runningSideEffect("two", recordingSideEffect(events2))
+        if (props == 2) runningSideEffect("three", recordingSideEffect(events3))
+      }
         .asStatefulWorkflow()
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow,
         initialProps = 0,
@@ -548,7 +551,7 @@ internal class WorkflowNodeTest {
         runningSideEffect("two") { started2 = true }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -574,7 +577,7 @@ internal class WorkflowNodeTest {
         snapshot = { state -> Snapshot.write { it.writeUtf8WithLength("state:$state") } },
       )
     val originalNode =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow,
         initialProps = "initial props",
@@ -583,11 +586,11 @@ internal class WorkflowNodeTest {
       )
 
     assertEquals("initial props", originalNode.render(workflow, "foo"))
-    val snapshot = originalNode.snapshot(workflow)
+    val snapshot = originalNode.snapshot()
     assertNotEquals(0, snapshot.toByteString().size)
 
     val restoredNode =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow,
         // These props should be ignored, since snapshot is non-null.
@@ -607,7 +610,7 @@ internal class WorkflowNodeTest {
         snapshot = { Snapshot.of("restored") },
       )
     val originalNode =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow,
         initialProps = "initial props",
@@ -616,11 +619,11 @@ internal class WorkflowNodeTest {
       )
 
     assertEquals("initial props", originalNode.render(workflow, "foo"))
-    val snapshot = originalNode.snapshot(workflow)
+    val snapshot = originalNode.snapshot()
     assertNotEquals(0, snapshot.toByteString().size)
 
     val restoredNode =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow,
         // These props should be ignored, since snapshot is non-null.
@@ -661,7 +664,7 @@ internal class WorkflowNodeTest {
       )
 
     val originalNode =
-      WorkflowNode(
+      StatefulWorkflowNode(
         parentWorkflow.id(),
         parentWorkflow,
         initialProps = "initial props",
@@ -670,11 +673,11 @@ internal class WorkflowNodeTest {
       )
 
     assertEquals("initial props|child props", originalNode.render(parentWorkflow, "foo"))
-    val snapshot = originalNode.snapshot(parentWorkflow)
+    val snapshot = originalNode.snapshot()
     assertNotEquals(0, snapshot.toByteString().size)
 
     val restoredNode =
-      WorkflowNode(
+      StatefulWorkflowNode(
         parentWorkflow.id(),
         parentWorkflow,
         // These props should be ignored, since snapshot is non-null.
@@ -707,13 +710,13 @@ internal class WorkflowNodeTest {
           }
         },
       )
-    val node = WorkflowNode(workflow.id(), workflow, Unit, null, Unconfined)
+    val node = StatefulWorkflowNode(workflow.id(), workflow, Unit, null, Unconfined)
 
     assertEquals(0, snapshotCalls)
     assertEquals(0, snapshotWrites)
     assertEquals(0, restoreCalls)
 
-    val snapshot = node.snapshot(workflow)
+    val snapshot = node.snapshot()
 
     assertEquals(1, snapshotCalls)
     assertEquals(0, snapshotWrites)
@@ -725,7 +728,7 @@ internal class WorkflowNodeTest {
     assertEquals(1, snapshotWrites)
     assertEquals(0, restoreCalls)
 
-    WorkflowNode(workflow.id(), workflow, Unit, snapshot, Unconfined)
+    StatefulWorkflowNode(workflow.id(), workflow, Unit, snapshot, Unconfined)
 
     assertEquals(1, snapshotCalls)
     assertEquals(1, snapshotWrites)
@@ -747,7 +750,7 @@ internal class WorkflowNodeTest {
         snapshot = { state -> Snapshot.write { it.writeUtf8WithLength(state) } },
       )
     val originalNode =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow,
         initialProps = "initial props",
@@ -756,11 +759,11 @@ internal class WorkflowNodeTest {
       )
 
     assertEquals("initial props", originalNode.render(workflow, "foo"))
-    val snapshot = originalNode.snapshot(workflow)
+    val snapshot = originalNode.snapshot()
     assertNotEquals(0, snapshot.toByteString().size)
 
     val restoredNode =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow,
         initialProps = "new props",
@@ -774,7 +777,7 @@ internal class WorkflowNodeTest {
   fun toString_formats_as_WorkflowInstance_without_parent() {
     val workflow = Workflow.rendering<Nothing, Unit>(Unit)
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -794,7 +797,7 @@ internal class WorkflowNodeTest {
   fun toString_formats_as_WorkflowInstance_with_parent() {
     val workflow = Workflow.rendering<Nothing, Unit>(Unit)
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -832,7 +835,7 @@ internal class WorkflowNodeTest {
       }
     val workflow = Workflow.rendering<Nothing, Unit>(Unit)
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -842,7 +845,7 @@ internal class WorkflowNodeTest {
         parent = TestSession(42),
       )
 
-    assertSame(node.coroutineContext, interceptedScope.coroutineContext)
+    assertSame(node.coroutineContextForTest, interceptedScope.coroutineContext)
     assertEquals(workflow.identifier, interceptedSession.identifier)
     assertEquals(0, interceptedSession.sessionId)
     assertEquals("foo", interceptedSession.renderKey)
@@ -877,7 +880,7 @@ internal class WorkflowNodeTest {
       }
     val workflow = Workflow.rendering<Nothing, Unit>(Unit)
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -888,7 +891,7 @@ internal class WorkflowNodeTest {
         parent = TestSession(42),
       )
 
-    assertSame(node.coroutineContext, interceptedScope.coroutineContext)
+    assertSame(node.coroutineContextForTest, interceptedScope.coroutineContext)
     assertEquals(workflow.identifier, interceptedSession.identifier)
     assertEquals(0, interceptedSession.sessionId)
     assertEquals("foo", interceptedSession.renderKey)
@@ -926,7 +929,7 @@ internal class WorkflowNodeTest {
         initialState = { props -> "state($props)" },
         render = { _, _ -> fail() },
       )
-    WorkflowNode(
+    StatefulWorkflowNode(
       id = workflow.id(key = "foo"),
       workflow = workflow.asStatefulWorkflow(),
       initialProps = "props",
@@ -975,7 +978,7 @@ internal class WorkflowNodeTest {
         render = { _, state -> state },
       )
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = "old",
@@ -1026,7 +1029,7 @@ internal class WorkflowNodeTest {
         render = { props, state -> "render($props, $state)" },
       )
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = "props",
@@ -1071,7 +1074,7 @@ internal class WorkflowNodeTest {
         snapshot = { state -> Snapshot.of("snapshot($state)") },
       )
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = "old",
@@ -1080,7 +1083,7 @@ internal class WorkflowNodeTest {
         baseContext = Unconfined,
         parent = TestSession(42),
       )
-    val snapshot = node.snapshot(workflow)
+    val snapshot = node.snapshot()
 
     assertEquals("state", interceptedState)
     assertEquals(Snapshot.of("snapshot(state)"), interceptedSnapshot)
@@ -1115,7 +1118,7 @@ internal class WorkflowNodeTest {
         snapshot = { null },
       )
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(key = "foo"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = "old",
@@ -1124,7 +1127,7 @@ internal class WorkflowNodeTest {
         baseContext = Unconfined,
         parent = TestSession(42),
       )
-    val snapshot = node.snapshot(workflow)
+    val snapshot = node.snapshot()
 
     assertEquals("state", interceptedState)
     assertNull(interceptedSnapshot)
@@ -1159,7 +1162,7 @@ internal class WorkflowNodeTest {
         render = { props, _ -> "root(${renderChild(leafWorkflow, props)})" },
       )
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = rootWorkflow.id(key = "foo"),
         workflow = rootWorkflow.asStatefulWorkflow(),
         initialProps = "props",
@@ -1182,7 +1185,7 @@ internal class WorkflowNodeTest {
         sink()
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1213,7 +1216,7 @@ internal class WorkflowNodeTest {
 
     val workflow = Workflow.stateless { actionSink.send(TestAction()) }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1242,7 +1245,7 @@ internal class WorkflowNodeTest {
         },
       )
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1268,7 +1271,7 @@ internal class WorkflowNodeTest {
         actionSink.contraMap { action("") { setOutput(it) } }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1296,7 +1299,7 @@ internal class WorkflowNodeTest {
         actionSink.contraMap { action("") { setOutput(null) } }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1326,7 +1329,7 @@ internal class WorkflowNodeTest {
         },
       )
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1348,7 +1351,7 @@ internal class WorkflowNodeTest {
         runningSideEffect("test") { actionSink.send(action("") { setOutput("child:hello") }) }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1373,7 +1376,7 @@ internal class WorkflowNodeTest {
         runningSideEffect("test") { actionSink.send(action("") { setOutput(null) }) }
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1399,7 +1402,7 @@ internal class WorkflowNodeTest {
     val stateful = workflow.asStatefulWorkflow()
 
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         stateful,
         initialProps = "",
@@ -1426,7 +1429,7 @@ internal class WorkflowNodeTest {
       }
     val stateful = workflow.asStatefulWorkflow()
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         stateful,
         initialProps = "",
@@ -1455,7 +1458,7 @@ internal class WorkflowNodeTest {
       }
     val stateful = workflow.asStatefulWorkflow()
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         stateful,
         initialProps = "" to ("" as Any),
@@ -1483,7 +1486,7 @@ internal class WorkflowNodeTest {
       }
     val stateful = workflow.asStatefulWorkflow()
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         workflow.id(),
         stateful,
         initialProps = Unit,
@@ -1517,7 +1520,7 @@ internal class WorkflowNodeTest {
       }
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {}
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1557,7 +1560,7 @@ internal class WorkflowNodeTest {
         sink
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1598,7 +1601,7 @@ internal class WorkflowNodeTest {
         sink
       }
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1650,7 +1653,7 @@ internal class WorkflowNodeTest {
         },
       )
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1685,7 +1688,7 @@ internal class WorkflowNodeTest {
       }
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {}
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1715,7 +1718,7 @@ internal class WorkflowNodeTest {
       }
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {}
     val node =
-      WorkflowNode(
+      StatefulWorkflowNode(
         id = workflow.id(key = "test-key"),
         workflow = workflow.asStatefulWorkflow(),
         initialProps = Unit,
@@ -1758,7 +1761,8 @@ internal class WorkflowNodeTest {
           return context.eventHandler("handler") { event -> setOutput(event) }
         }
       }
-    val node = WorkflowNode(workflow.id(), workflow, "", null, context, interceptor = interceptor)
+    val node =
+      StatefulWorkflowNode(workflow.id(), workflow, "", null, context, interceptor = interceptor)
 
     val eventSink = node.render(workflow, "")
     eventSink("event1")


### PR DESCRIPTION
This is to prepare for go/compose-based-workflows.

This is two commits to make git diff recognize the extracted abstract class as the new file instead of the `WorkflowNode -> StatefulWorkflowNode` rename. However, github doesn't get this and shows `StatefulWorkflowNode` as a net new file, so it's must easier to review if you only look at the first commit. 