### PR TITLE
Make RenderingProduced not a value class.

### DIFF
--- a/workflow-runtime/api/workflow-runtime.api
+++ b/workflow-runtime/api/workflow-runtime.api
@@ -89,24 +89,27 @@ public final class com/squareup/workflow1/WorkflowInterceptor$RenderContextInter
 
 public final class com/squareup/workflow1/WorkflowInterceptor$RenderPassSkipped : com/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate {
 	public static final field INSTANCE Lcom/squareup/workflow1/WorkflowInterceptor$RenderPassSkipped;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/squareup/workflow1/WorkflowInterceptor$RenderingConflated : com/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate {
 	public static final field INSTANCE Lcom/squareup/workflow1/WorkflowInterceptor$RenderingConflated;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/squareup/workflow1/WorkflowInterceptor$RenderingProduced : com/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate {
-	public static final synthetic fun box-impl (Lcom/squareup/workflow1/RenderingAndSnapshot;)Lcom/squareup/workflow1/WorkflowInterceptor$RenderingProduced;
-	public static fun constructor-impl (Lcom/squareup/workflow1/RenderingAndSnapshot;)Lcom/squareup/workflow1/RenderingAndSnapshot;
+	public fun <init> (Lcom/squareup/workflow1/RenderingAndSnapshot;)V
+	public final fun component1 ()Lcom/squareup/workflow1/RenderingAndSnapshot;
+	public final fun copy (Lcom/squareup/workflow1/RenderingAndSnapshot;)Lcom/squareup/workflow1/WorkflowInterceptor$RenderingProduced;
+	public static synthetic fun copy$default (Lcom/squareup/workflow1/WorkflowInterceptor$RenderingProduced;Lcom/squareup/workflow1/RenderingAndSnapshot;ILjava/lang/Object;)Lcom/squareup/workflow1/WorkflowInterceptor$RenderingProduced;
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lcom/squareup/workflow1/RenderingAndSnapshot;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lcom/squareup/workflow1/RenderingAndSnapshot;Lcom/squareup/workflow1/RenderingAndSnapshot;)Z
 	public final fun getRenderingAndSnapshot ()Lcom/squareup/workflow1/RenderingAndSnapshot;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Lcom/squareup/workflow1/RenderingAndSnapshot;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lcom/squareup/workflow1/RenderingAndSnapshot;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lcom/squareup/workflow1/RenderingAndSnapshot;
 }
 
 public abstract interface class com/squareup/workflow1/WorkflowInterceptor$RuntimeUpdate {

--- a/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/WorkflowInterceptor.kt
+++ b/workflow-runtime/src/commonMain/kotlin/com/squareup/workflow1/WorkflowInterceptor.kt
@@ -172,13 +172,13 @@ public interface WorkflowInterceptor {
    * A render pass has been skipped by an optimization, multiple actions are applied before
    * the runtime produces a rendering.
    */
-  public object RenderPassSkipped : RuntimeUpdate
+  public data object RenderPassSkipped : RuntimeUpdate
 
   /**
    * The runtime skipped producing a rendering, conflating it to the next rendering after the next
    * render pass.
    */
-  public object RenderingConflated : RuntimeUpdate
+  public data object RenderingConflated : RuntimeUpdate
 
   /**
    * This runtime has produced a new rendering after at least one render pass.
@@ -186,8 +186,7 @@ public interface WorkflowInterceptor {
    * @param renderingAndSnapshot This is the rendering and snapshot that was passed out of the
    *        Workflow runtime.
    */
-  @JvmInline
-  public value class RenderingProduced<R>(
+  public data class RenderingProduced<R>(
     public val renderingAndSnapshot: RenderingAndSnapshot<R>
   ) : RuntimeUpdate
 


### PR DESCRIPTION
Value classes get boxed as soon as they're used as a supertype, so it's basically pointless to make sealed class children value classes. I made it a data class instead.

This change is required to move `:workflow-runtime-android` into `:workflow-runtime`, or we get a compiler crash.

I also made the object siblings data objects to fix a compiler suggestion and get better `toString` methods.