### PR TITLE
Fix PhoneWindow.superDispatchTouchEvent NullPointerException

### DIFF
--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/navigation/DialogSession.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/navigation/DialogSession.kt
@@ -38,13 +38,15 @@ internal class DialogSession(
       val was = field
       field = value
       holder.dialog.window?.takeIf { value != was }?.let { window ->
-        // https://stackoverflow.com/questions/2886407/dealing-with-rapid-tapping-on-buttons
-        // If any motion events were enqueued on the main thread, cancel them.
-        dispatchCancelEvent { window.superDispatchTouchEvent(it) }
-        // When we cancel, have to warn things like RecyclerView that handle streams
-        // of motion events and eventually dispatch input events (click, key pressed, etc.)
-        // based on them.
-        window.peekDecorView()?.cancelPendingInputEvents()
+        window.peekDecorView()?.let { decorView ->
+          // https://stackoverflow.com/questions/2886407/dealing-with-rapid-tapping-on-buttons
+          // If any motion events were enqueued on the main thread, cancel them.
+          dispatchCancelEvent { window.superDispatchTouchEvent(it) }
+          // When we cancel, have to warn things like RecyclerView that handle streams
+          // of motion events and eventually dispatch input events (click, key pressed, etc.)
+          // based on them.
+          decorView.cancelPendingInputEvents()
+        }
       }
     }
 


### PR DESCRIPTION
PhoneWindow.superDispatchTouchEvent will crash with NullPointerException if DecorView is null: https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/com/android/internal/policy/PhoneWindow.java;l=2021

We should only dispatch touch events if DecorView is non-null. Note that we already checking for non-null DecorView below. This commit just expands that check.