### PR TITLE
1413: Check for `APP_ID` conditionally

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -51,6 +51,7 @@ jobs:
       # to be triggered again.
       - name: Generate App Token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2
+        if: ${{ vars.APP_ID != '' }}
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -62,7 +63,7 @@ jobs:
           check-task: connectedCheckShardMatrixYamlCheck checkVersionIsSnapshot
           fix-task: connectedCheckShardMatrixYamlUpdate checkVersionIsSnapshot
           write-cache-key: build-logic
-          access-token: ${{ steps.app-token.outputs.token }}
+          access-token: ${{ steps.app-token.outputs.token || '' }}
 
   artifacts-check:
     name: ArtifactsCheck
@@ -75,6 +76,7 @@ jobs:
       # to be triggered again.
       - name: Generate App Token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2
+        if: ${{ vars.APP_ID != '' }}
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -86,7 +88,7 @@ jobs:
           check-task: artifactsCheck
           fix-task: artifactsDump
           write-cache-key: build-logic
-          access-token: ${{ steps.app-token.outputs.token }}
+          access-token: ${{ steps.app-token.outputs.token || '' }}
 
   dependency-guard:
     name: Dependency Guard
@@ -98,6 +100,7 @@ jobs:
       # to be triggered again.
       - name: Generate App Token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2
+        if: ${{ vars.APP_ID != '' }}
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -111,7 +114,7 @@ jobs:
           check-task: dependencyGuard --refresh-dependencies
           fix-task: dependencyGuardBaseline --refresh-dependencies
           write-cache-key: build-logic
-          access-token: ${{ steps.app-token.outputs.token }}
+          access-token: ${{ steps.app-token.outputs.token || '' }}
 
   ktlint:
     name: KtLint
@@ -123,6 +126,7 @@ jobs:
       # to be triggered again.
       - name: Generate App Token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2
+        if: ${{ vars.APP_ID != '' }}
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -136,7 +140,7 @@ jobs:
           check-task: ktLintCheck
           fix-task: ktLintFormat
           write-cache-key: build-logic
-          access-token: ${{ steps.app-token.outputs.token }}
+          access-token: ${{ steps.app-token.outputs.token || '' }}
 
   api-check:
     name: Api check
@@ -148,6 +152,7 @@ jobs:
       # to be triggered again.
       - name: Generate App Token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2
+        if: ${{ vars.APP_ID != '' }}
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -161,7 +166,7 @@ jobs:
           check-task: apiCheck
           fix-task: apiDump
           write-cache-key: build-logic
-          access-token: ${{ steps.app-token.outputs.token }}
+          access-token: ${{ steps.app-token.outputs.token || '' }}
 
   android-lint:
     name: Android Lint


### PR DESCRIPTION
Closes #1413.

As opposed to using `pull_request_target`, which has security concerns, just check if we have the `APP_ID` rather than fail when PRs are submitted from a user outside our org.

The `check with commit` action already checks for this and does not try the fix up commits if it does not have the key.

Avoids problems like: https://github.com/square/workflow-kotlin/actions/runs/17107227857/job/48525856231?pr=1412