### PR TITLE
Rename headlessIntegrationTest -> renderForTest and deprecate launchForTestingFrom*

### DIFF
--- a/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
+++ b/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.squareup.sample.timemachine
 
 import com.google.common.truth.Truth.assertThat

--- a/samples/tictactoe/common/src/test/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflowTest.kt
+++ b/samples/tictactoe/common/src/test/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflowTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.squareup.sample.gameworkflow
 
 import com.google.common.truth.Truth.assertThat

--- a/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/TicTacToeWorkflowTest.kt
+++ b/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/TicTacToeWorkflowTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.squareup.sample.mainworkflow
 
 import com.google.common.truth.Truth.assertThat

--- a/workflow-rx2/src/test/java/com/squareup/workflow1/rx2/PublisherWorkerTest.kt
+++ b/workflow-rx2/src/test/java/com/squareup/workflow1/rx2/PublisherWorkerTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow1.rx2
 
 import com.squareup.workflow1.Worker

--- a/workflow-testing/api/workflow-testing.api
+++ b/workflow-testing/api/workflow-testing.api
@@ -1,10 +1,3 @@
-public final class com/squareup/workflow1/testing/HeadlessIntegrationTestKt {
-	public static final fun headlessIntegrationTest (Lcom/squareup/workflow1/Workflow;Lkotlin/coroutines/CoroutineContext;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function2;JLkotlin/jvm/functions/Function2;)V
-	public static final fun headlessIntegrationTest (Lcom/squareup/workflow1/Workflow;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/coroutines/CoroutineContext;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function2;JLkotlin/jvm/functions/Function2;)V
-	public static synthetic fun headlessIntegrationTest$default (Lcom/squareup/workflow1/Workflow;Lkotlin/coroutines/CoroutineContext;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function2;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public static synthetic fun headlessIntegrationTest$default (Lcom/squareup/workflow1/Workflow;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/coroutines/CoroutineContext;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function2;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-}
-
 public final class com/squareup/workflow1/testing/RenderIdempotencyChecker : com/squareup/workflow1/WorkflowInterceptor {
 	public static final field INSTANCE Lcom/squareup/workflow1/testing/RenderIdempotencyChecker;
 	public fun onInitialState (Ljava/lang/Object;Lcom/squareup/workflow1/Snapshot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function3;Lcom/squareup/workflow1/WorkflowInterceptor$WorkflowSession;)Ljava/lang/Object;
@@ -210,5 +203,12 @@ public final class com/squareup/workflow1/testing/WorkflowTurbine {
 }
 
 public final class com/squareup/workflow1/testing/WorkflowTurbine$Companion {
+}
+
+public final class com/squareup/workflow1/testing/WorkflowTurbineKt {
+	public static final fun renderForTest (Lcom/squareup/workflow1/Workflow;Lkotlin/coroutines/CoroutineContext;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function2;JLkotlin/jvm/functions/Function2;)V
+	public static final fun renderForTest (Lcom/squareup/workflow1/Workflow;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/coroutines/CoroutineContext;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function2;JLkotlin/jvm/functions/Function2;)V
+	public static synthetic fun renderForTest$default (Lcom/squareup/workflow1/Workflow;Lkotlin/coroutines/CoroutineContext;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function2;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun renderForTest$default (Lcom/squareup/workflow1/Workflow;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/coroutines/CoroutineContext;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function2;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 }
 

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderTester.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/RenderTester.kt
@@ -112,6 +112,14 @@ public fun <PropsT, StateT, OutputT, RenderingT>
  * - It is a test failure if no workflow or worker emitted an output, no rendering event was
  *   invoked, and any of the action verification methods on [RenderTestResult] is called.
  *
+ * ## Testing Application
+ *
+ * Note that by providing the values for all child workflows, workers, and side effects, the test
+ * is extremely focused on the logic of the `render()` method. Everything else is essentially
+ * 'mocked'. If you do not have complex logic within `render()` that needs to be directly unit
+ * tested, then you may be better served by using a [WorkflowTurbine] and [renderForResult] as this
+ * will actually run your workflow (and any children, fake or not) in the runtime.
+ *
  * ## Examples
  *
  * ### Worker output

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTestRuntime.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTestRuntime.kt
@@ -1,5 +1,5 @@
 @file:OptIn(ExperimentalCoroutinesApi::class)
-@file:Suppress("ktlint:standard:indent")
+@file:Suppress("ktlint:standard:indent", "DEPRECATION")
 
 package com.squareup.workflow1.testing
 
@@ -53,6 +53,7 @@ import kotlin.coroutines.EmptyCoroutineContext
  *  - [sendProps]
  *    - Send a new [PropsT] to the root workflow.
  */
+@Deprecated("Use renderForTest and WorkflowTurbine instead.")
 public class WorkflowTestRuntime<PropsT, OutputT, RenderingT> @TestOnly internal constructor(
   private val props: MutableStateFlow<PropsT>,
   private val renderingsAndSnapshotsFlow: Flow<RenderingAndSnapshot<RenderingT>>,
@@ -173,6 +174,7 @@ public class WorkflowTestRuntime<PropsT, OutputT, RenderingT> @TestOnly internal
  *
  * All workflow-related coroutines are cancelled when the block exits.
  */
+@Deprecated("Use renderForTest and WorkflowTurbine instead.")
 @TestOnly
 public fun <T, PropsT, OutputT, RenderingT>
   Workflow<PropsT, OutputT, RenderingT>.launchForTestingFromStartWith(
@@ -187,6 +189,7 @@ public fun <T, PropsT, OutputT, RenderingT>
  *
  * All workflow-related coroutines are cancelled when the block exits.
  */
+@Deprecated("Use renderForTest and WorkflowTurbine instead.")
 @TestOnly
 public fun <T, OutputT, RenderingT>
   Workflow<Unit, OutputT, RenderingT>.launchForTestingFromStartWith(
@@ -202,6 +205,7 @@ public fun <T, OutputT, RenderingT>
  *
  * All workflow-related coroutines are cancelled when the block exits.
  */
+@Deprecated("Use renderForTest and WorkflowTurbine instead.")
 @TestOnly
 public fun <T, PropsT, StateT, OutputT, RenderingT>
   StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.launchForTestingFromStateWith(
@@ -223,6 +227,7 @@ public fun <T, PropsT, StateT, OutputT, RenderingT>
  *
  * All workflow-related coroutines are cancelled when the block exits.
  */
+@Deprecated("Use renderForTest and WorkflowTurbine instead.")
 @TestOnly
 public fun <StateT, OutputT, RenderingT>
   StatefulWorkflow<Unit, StateT, OutputT, RenderingT>.launchForTestingFromStateWith(
@@ -236,6 +241,7 @@ public fun <StateT, OutputT, RenderingT>
  *
  * All workflow-related coroutines are cancelled when the block exits.
  */
+@Deprecated("Use renderForTest and WorkflowTurbine instead.")
 @TestOnly
 public fun <T, PropsT, StateT, OutputT, RenderingT>
   StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.launchForTestingWith(

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTurbine.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTurbine.kt
@@ -3,9 +3,9 @@ package com.squareup.workflow1.testing
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import com.squareup.workflow1.RuntimeConfig
-import com.squareup.workflow1.RuntimeConfigOptions
 import com.squareup.workflow1.Workflow
 import com.squareup.workflow1.WorkflowInterceptor
+import com.squareup.workflow1.config.JvmTestRuntimeConfigTools
 import com.squareup.workflow1.renderWorkflowIn
 import com.squareup.workflow1.testing.WorkflowTurbine.Companion.WORKFLOW_TEST_DEFAULT_TIMEOUT_MS
 import kotlinx.coroutines.CoroutineScope
@@ -22,8 +22,8 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
- * This is a test harness to run integration tests for a Workflow tree. The parameters passed here are
- * the same as those to start a Workflow runtime with [renderWorkflowIn] except for ignoring
+ * This is a test harness to run turbine like tests for a Workflow tree. The parameters passed here
+ * are the same as those to start a Workflow runtime with [renderWorkflowIn] except for ignoring
  * state persistence as that is not needed for this style of test.
  *
  * The [coroutineContext] rather than a [CoroutineScope] is passed so that this harness handles the
@@ -35,13 +35,15 @@ import kotlin.time.Duration.Companion.milliseconds
  * This will start the Workflow runtime (with params as passed) rooted at whatever Workflow
  * it is called on and then create a [WorkflowTurbine] for its renderings and run [testCase] on that.
  * [testCase] can thus drive the test scenario and assert against renderings.
+ *
+ * The default [RuntimeConfig] will be the one specified via [JvmTestRuntimeConfigTools].
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-public fun <PropsT, OutputT, RenderingT> Workflow<PropsT, OutputT, RenderingT>.headlessIntegrationTest(
+public fun <PropsT, OutputT, RenderingT> Workflow<PropsT, OutputT, RenderingT>.renderForTest(
   props: StateFlow<PropsT>,
   coroutineContext: CoroutineContext = UnconfinedTestDispatcher(),
   interceptors: List<WorkflowInterceptor> = emptyList(),
-  runtimeConfig: RuntimeConfig = RuntimeConfigOptions.DEFAULT_CONFIG,
+  runtimeConfig: RuntimeConfig = JvmTestRuntimeConfigTools.getTestRuntimeConfig(),
   onOutput: suspend (OutputT) -> Unit = {},
   testTimeout: Long = WORKFLOW_TEST_DEFAULT_TIMEOUT_MS,
   testCase: suspend WorkflowTurbine<RenderingT>.() -> Unit
@@ -82,18 +84,18 @@ public fun <PropsT, OutputT, RenderingT> Workflow<PropsT, OutputT, RenderingT>.h
 }
 
 /**
- * Version of [headlessIntegrationTest] that does not require props. For Workflows that have [Unit]
+ * Version of [renderForTest] that does not require props. For Workflows that have [Unit]
  * props type.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-public fun <OutputT, RenderingT> Workflow<Unit, OutputT, RenderingT>.headlessIntegrationTest(
+public fun <OutputT, RenderingT> Workflow<Unit, OutputT, RenderingT>.renderForTest(
   coroutineContext: CoroutineContext = UnconfinedTestDispatcher(),
   interceptors: List<WorkflowInterceptor> = emptyList(),
-  runtimeConfig: RuntimeConfig = RuntimeConfigOptions.DEFAULT_CONFIG,
+  runtimeConfig: RuntimeConfig = JvmTestRuntimeConfigTools.getTestRuntimeConfig(),
   onOutput: suspend (OutputT) -> Unit = {},
   testTimeout: Long = WORKFLOW_TEST_DEFAULT_TIMEOUT_MS,
   testCase: suspend WorkflowTurbine<RenderingT>.() -> Unit
-): Unit = headlessIntegrationTest(
+): Unit = renderForTest(
   props = MutableStateFlow(Unit).asStateFlow(),
   coroutineContext = coroutineContext,
   interceptors = interceptors,

--- a/workflow-testing/src/test/java/com/squareup/workflow1/SnapshottingIntegrationTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/SnapshottingIntegrationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow1
 
 import com.squareup.workflow1.WorkflowAction.Companion.noAction

--- a/workflow-testing/src/test/java/com/squareup/workflow1/StatefulWorkflowEventHandlerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/StatefulWorkflowEventHandlerTest.kt
@@ -1,4 +1,4 @@
-@file:Suppress("JUnitMalformedDeclaration")
+@file:Suppress("JUnitMalformedDeclaration", "DEPRECATION")
 
 package com.squareup.workflow1
 

--- a/workflow-testing/src/test/java/com/squareup/workflow1/StatefulWorkflowSafeEventHandlerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/StatefulWorkflowSafeEventHandlerTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow1
 
 import com.squareup.workflow1.StatefulWorkflowSafeEventHandlerTest.State.Able

--- a/workflow-testing/src/test/java/com/squareup/workflow1/StatelessWorkflowEventHandlerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/StatelessWorkflowEventHandlerTest.kt
@@ -1,4 +1,4 @@
-@file:Suppress("JUnitMalformedDeclaration")
+@file:Suppress("JUnitMalformedDeclaration", "DEPRECATION")
 
 package com.squareup.workflow1
 

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkerCompositionIntegrationTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkerCompositionIntegrationTest.kt
@@ -1,4 +1,4 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow1
 

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowCompositionIntegrationTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowCompositionIntegrationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow1
 
 import com.squareup.workflow1.testing.WorkerSink

--- a/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowsLifecycleTests.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/WorkflowsLifecycleTests.kt
@@ -7,7 +7,7 @@ import com.squareup.workflow1.RuntimeConfigOptions.CONFLATE_STALE_RENDERINGS
 import com.squareup.workflow1.RuntimeConfigOptions.Companion.RuntimeOptions
 import com.squareup.workflow1.RuntimeConfigOptions.Companion.RuntimeOptions.NONE
 import com.squareup.workflow1.RuntimeConfigOptions.DRAIN_EXCLUSIVE_ACTIONS
-import com.squareup.workflow1.testing.headlessIntegrationTest
+import com.squareup.workflow1.testing.renderForTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
@@ -84,7 +84,7 @@ class WorkflowsLifecycleTests(
   }
 
   @Test fun sideEffectsStartedWhenExpected() {
-    workflowWithSideEffects.headlessIntegrationTest(
+    workflowWithSideEffects.renderForTest(
       runtimeConfig = runtimeConfig
     ) {
       // One time starts but does not stop the side effect.
@@ -98,7 +98,7 @@ class WorkflowsLifecycleTests(
   }
 
   @Test fun sideEffectsStoppedWhenExpected() {
-    workflowWithSideEffects.headlessIntegrationTest(
+    workflowWithSideEffects.renderForTest(
       runtimeConfig = runtimeConfig
     ) {
       // Twice will start and stop the side effect.
@@ -112,7 +112,7 @@ class WorkflowsLifecycleTests(
   }
 
   @Test fun childSessionWorkflowStartedWhenExpected() {
-    workflowWithChildSession.headlessIntegrationTest(
+    workflowWithChildSession.renderForTest(
       runtimeConfig = runtimeConfig
     ) {
       // One time starts but does not stop the child session workflow.
@@ -139,7 +139,7 @@ class WorkflowsLifecycleTests(
   @Test
   fun sideEffectsStartAndStoppedWhenHandledSynchronously() {
     val dispatcher = UnconfinedTestDispatcher()
-    workflowWithSideEffects.headlessIntegrationTest(
+    workflowWithSideEffects.renderForTest(
       coroutineContext = dispatcher,
       runtimeConfig = runtimeConfig
     ) {
@@ -163,7 +163,7 @@ class WorkflowsLifecycleTests(
   }
 
   @Test fun childSessionWorkflowStoppedWhenExpected() {
-    workflowWithChildSession.headlessIntegrationTest(
+    workflowWithChildSession.renderForTest(
       runtimeConfig = runtimeConfig
     ) {
       // Twice will start and stop the child session workflow.
@@ -185,7 +185,7 @@ class WorkflowsLifecycleTests(
   @Test
   fun childSessionWorkflowStartAndStoppedWhenHandledSynchronously() {
     val dispatcher = UnconfinedTestDispatcher()
-    workflowWithChildSession.headlessIntegrationTest(
+    workflowWithChildSession.renderForTest(
       coroutineContext = dispatcher,
       runtimeConfig = runtimeConfig
     ) {

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/WorkflowTestRuntimeTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/WorkflowTestRuntimeTest.kt
@@ -1,4 +1,4 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow1.testing
 


### PR DESCRIPTION
This is based on the confusing overload of the two types of test harnesses that use the runtime directly.

`renderForTest` is a more accurate name since it is not strictly an 'integration' test (depending on how you define that). And the fact that it is `headless` is not really pertinent at this level of the API, that was an artifact of originally writing this API to run Android type tests that used Android dependencies but without having to render the UI (since the renderings just come out in the turbine).

We do not have _all_ the facilities of the `launchForTestingFrom*` methods (such as starting with a snapshot) - but those are not extensively used AFAIK. They are also trivial to add to `renderForTest` and forward along to `renderWorkflowIn`. So this is somewhat of a premature deprecation (a soft deprecation), but at least it shows the direction.

Closes #1411.

#1152 will remain because it has more specification of the further work required.