### PR TITLE
Increase Snapshot timeout to 90 minutes

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -10,7 +10,7 @@ jobs:
   publish-snapshot:
     runs-on: macos-latest
     if: github.repository == 'square/workflow-kotlin'
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
It was recently timing out at 45.