### PR TITLE
Extend timeout for general unit tests to 60 min

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -203,7 +203,7 @@ jobs:
     name: General Unit Tests (not KMP)
     runs-on: macos-latest
     needs: build-all
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
The general unit tests job was timing out at 40 minutes. This change increases the timeout to 60 minutes to allow the test suite to complete successfully.

e.g. https://github.com/square/workflow-kotlin/actions/runs/19176422684/job/54823085604?pr=1429#logs