### PR TITLE
Update Upload path for Connected Tests

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -618,7 +618,7 @@ jobs:
           prepare-task: :benchmarks:performance-poetry:complex-poetry:prepareDebugAndroidTestArtifacts
           test-task: :benchmarks:performance-poetry:complex-poetry:connectedCheck --continue
           restore-cache-key: androidTest-build-artifacts
-          failure-path-upload: '**/build/reports/tests/*[tT]est'
+          failure-path-upload: '**/build/reports/androidTests/connected'
           failure-upload-name: 'perf-tests-report'
 
   instrumentation-tests:
@@ -647,7 +647,7 @@ jobs:
           test-task: connectedCheckShard${{matrix.shardNum}} -x :benchmarks:dungeon-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-poetry:connectedCheck
           write-cache-key: androidTest-build-artifacts-${{matrix.shardNum}}
           restore-cache-key: main-build-artifacts
-          failure-path-upload: '**/build/reports/tests/*[tT]est'
+          failure-path-upload: '**/build/reports/androidTests/connected'
           failure-upload-name: core-tests-report-${{matrix.shardNum}}
 
   runtime-instrumentation-tests:
@@ -677,7 +677,7 @@ jobs:
           test-task: connectedCheckShard${{matrix.shardNum}} -Pworkflow.runtime=${{matrix.runtime}} -x :benchmarks:dungeon-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-benchmark:connectedCheck -x :benchmarks:performance-poetry:complex-poetry:connectedCheck
           write-cache-key: androidTest-build-artifacts-${{matrix.shardNum}}-${{matrix.runtime}}
           restore-cache-key: main-build-artifacts
-          failure-path-upload: '**/build/reports/tests/*[tT]est'
+          failure-path-upload: '**/build/reports/androidTests/connected'
           failure-upload-name: core-tests-report-${{matrix.runtime}}-${{matrix.shardNum}}
 
   all-green:


### PR DESCRIPTION
The instrumentation test shards were still using the upload paths for unit tests. Update to androidTest.