### PR TITLE
Add Runtime Update Lines for Dropped Actions

### DIFF
--- a/workflow-tracing/api/workflow-tracing.api
+++ b/workflow-tracing/api/workflow-tracing.api
@@ -20,6 +20,12 @@ public final class com/squareup/workflow1/tracing/ActionAppliedLogLine$WorkflowA
 	public static fun values ()[Lcom/squareup/workflow1/tracing/ActionAppliedLogLine$WorkflowActionLogType;
 }
 
+public final class com/squareup/workflow1/tracing/ActionDroppedLogLine : com/squareup/workflow1/tracing/RuntimeUpdateLogLine {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getActionName ()Ljava/lang/String;
+	public fun log (Ljava/lang/StringBuilder;)V
+}
+
 public final class com/squareup/workflow1/tracing/ChainedWorkflowRuntimeTracerKt {
 	public static final fun wrap (Lcom/squareup/workflow1/WorkflowInterceptor$RenderContextInterceptor;Lcom/squareup/workflow1/WorkflowInterceptor$RenderContextInterceptor;)Lcom/squareup/workflow1/WorkflowInterceptor$RenderContextInterceptor;
 }

--- a/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/RuntimeUpdateLogLine.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/RuntimeUpdateLogLine.kt
@@ -59,6 +59,18 @@ public data object SkipLogLine : RuntimeUpdateLogLine {
 }
 
 /**
+ * An action that was queued but got dropped because the Workflow session ended.
+ */
+public class ActionDroppedLogLine(
+  val actionName: String,
+) : RuntimeUpdateLogLine {
+  override fun log(builder: StringBuilder) {
+    builder.append("DROPPED: $actionName")
+      .append('\n')
+  }
+}
+
+/**
  * The Workflow runtime has applied an action.
  */
 public class ActionAppliedLogLine(

--- a/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/WorkflowRuntimeMonitor.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/WorkflowRuntimeMonitor.kt
@@ -91,6 +91,13 @@ public class WorkflowRuntimeMonitor(
     droppedActions: List<WorkflowAction<P, S, O>>,
     session: WorkflowSession
   ) {
+    droppedActions.forEach { droppedAction ->
+      runtimeUpdates.logUpdate(
+        updateLine = ActionDroppedLogLine(
+          actionName = droppedAction.toLoggingShortName()
+        )
+      )
+    }
     onWorkflowStopped(session.sessionId)
     chainedWorkflowRuntimeTracer.onWorkflowSessionStopped(session.sessionId)
   }
@@ -349,7 +356,7 @@ public class WorkflowRuntimeMonitor(
      * but we specify it as a [CascadeAction] as this is an action that is applied synchronously
      * as part of an action cascade that originated with a [QueuedAction].
      *
-     * Note that for every [com.squareup.workflow1.Worker] a child workflow is created and rendered,
+     * Note that for every [Worker] a child workflow is created and rendered,
      * so this will be part of the callstack for that. In that case the output of the handler will
      * contain the worker action signature. We can detect that with
      * [Worker.WORKER_OUTPUT_ACTION_NAME].


### PR DESCRIPTION
Add a `RuntimeUpdateLogLine` - `ActionDroppedLogLine` that simply logs:

```
DROPPED: <actionName>
```

This helps debug differences between runtime and dispatch changes, but should be limited enough so as not to create too much spam.