### PR TITLE
Need to increase release timeout

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,7 +7,7 @@ jobs:
   publish-release:
     runs-on: macos-latest
     if: github.repository == 'square/workflow-kotlin'
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
Because github runners just keep getting slower and slower 😢 

<img width="671" height="185" alt="image" src="https://github.com/user-attachments/assets/c9147cb9-871f-487a-8049-66ad483464d6" />
