### PR TITLE
Update Action Versions; Increase Release Timeout

### DIFF
--- a/.github/actions/gradle-task-with-commit/action.yml
+++ b/.github/actions/gradle-task-with-commit/action.yml
@@ -45,7 +45,7 @@ runs:
 
     # ensure that we have the actual branch checked out.  By default, actions/checkout is headless.
     - name: check out with the generated app token
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      uses: actions/checkout@v6
       if: steps.can-push.outputs.can_push == 'true'
       with:
         token: ${{ inputs.access-token }}
@@ -75,7 +75,7 @@ runs:
 
     - name: commit ${{ inputs.fix-task }} changes
       if: steps.can-push.outputs.can_push == 'true'
-      uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
+      uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: ${{ steps.set-commit-message.outputs.commit-message }}
         commit_options: '--no-verify --signoff'

--- a/.github/actions/gradle-task/action.yml
+++ b/.github/actions/gradle-task/action.yml
@@ -39,7 +39,7 @@ runs:
       run: ./gradlew tasks
 
     - name: Set up JDK
-      uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+      uses: actions/setup-java@v5
       with:
         distribution: ${{inputs.distribution}}
         java-version: ${{inputs.java-version}}
@@ -49,10 +49,9 @@ runs:
       uses: ./.github/actions/gradle-args
 
     - name: Gradle build action
-      uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
+      uses: gradle/actions/setup-gradle@v5
       with:
         cache-read-only: false
-        gradle-home-cache-cleanup: true
 
     # Calculate all the hashes for keys just one time.
     # These should only be referenced before the actual task action, since that action
@@ -72,7 +71,7 @@ runs:
     - name: restore cache for ${{inputs.write-cache-key}}
       id: restore-write-cache
       if: inputs.write-cache-key != 'null'
-      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      uses: actions/cache/restore@v4
       with:
         path: |
           ~/.gradle/caches/build-cache-1
@@ -90,7 +89,7 @@ runs:
     # Skipped if the restore-cache-key wasn't set, or if the write-cache-key restore had an exact match.
     - name: restore cache for ${{inputs.restore-cache-key}}
       if: inputs.restore-cache-key != 'null' && steps.restore-write-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      uses: actions/cache/restore@v4
       with:
         path: |
           ~/.gradle/caches/build-cache-1
@@ -104,26 +103,25 @@ runs:
           ${{runner.os}}-${{inputs.restore-cache-key}}-${{steps.hashes.outputs.lib_versions}}
           ${{runner.os}}-${{inputs.restore-cache-key}}
 
-    - uses: gradle/actions/wrapper-validation@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
+    - uses: gradle/actions/wrapper-validation@v5
 
-    # Run the actual task.  Note that this still uses gradle-build-action for more fine-grained caching.
+    # Run the actual task.  Note that this still uses setup-gradle for more fine-grained caching.
     - name: Run ${{inputs.task}}
-      uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
+      uses: gradle/actions/setup-gradle@v5
       with:
+        working-directory: ${{inputs.build-root-directory}}
         # These arguments need to be on a single line. If they're defined with wrapping (using `|`),
         # something along the way to the actual CLI invocation gets confused and the jvmargs list
         # winds up getting parsed as a single argument.
-        arguments: ${{steps.gradle-args.outputs.gradle-property-args}} ${{inputs.task}} '-Dorg.gradle.jvmargs=${{steps.gradle-args.outputs.gradle-jvm-args}}'
+        run: ./gradlew ${{steps.gradle-args.outputs.gradle-property-args}} ${{inputs.task}} '-Dorg.gradle.jvmargs=${{steps.gradle-args.outputs.gradle-jvm-args}}'
         cache-read-only: false
-        build-root-directory: ${{inputs.build-root-directory}}
-        gradle-home-cache-cleanup: true
 
     # Save the build cache to `write-cache-key`.
     # Skip if we already had an exact match, or if the key is not set, or if this is a Windows runner.
     # Windows runners are welcome to *read* the cross-OS cache, but the directories get weird if
     # they try to write to it.
     - name: save the '${{inputs.write-cache-key}}' cache
-      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      uses: actions/cache/save@v4
       id: save-write-cache-key
       if: inputs.write-cache-key != 'null' && steps.restore-write-cache.outputs.cache-hit != 'true'
       with:
@@ -136,21 +134,21 @@ runs:
 
     - name: Upload Any Logs
       if: failure()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@v5
       with:
         name: log-upload
         path: ${{github.workspace}}/**/*.log
 
     - name: Upload Any Heap Dumps
       if: failure()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@v5
       with:
         name: hprof-upload
         path: ${{github.workspace}}/**/*.hprof
 
     - name: Upload Any Specified Files
       if: failure() && inputs.failure-path-upload != 'null'
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@v5
       with:
         name: ${{inputs.failure-upload-name}}
         path: ${{github.workspace}}/${{inputs.failure-path-upload}}

--- a/.github/actions/gradle-tasks-with-emulator/action.yml
+++ b/.github/actions/gradle-tasks-with-emulator/action.yml
@@ -56,7 +56,7 @@ runs:
 
     # Get the AVD if it's already cached.
     - name: AVD cache
-      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      uses: actions/cache/restore@v4
       id: restore-avd-cache
       with:
         path: |
@@ -67,7 +67,7 @@ runs:
     # If the AVD cache didn't exist, create an AVD
     - name: create AVD and generate snapshot for caching
       if: steps.restore-avd-cache.outputs.cache-hit != 'true'
-      uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2
+      uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ inputs.api-level }}
         arch: x86_64
@@ -83,7 +83,7 @@ runs:
     - name: cache new AVD before tests
       if: steps.restore-avd-cache.outputs.cache-hit != 'true'
       id: save-avd-cache
-      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      uses: actions/cache/save@v4
       with:
         path: |
           ~/.android/avd/*
@@ -93,7 +93,7 @@ runs:
     # Run the actual emulator tests.
     # At this point every task should be up-to-date and the AVD should be ready to go.
     - name: run tests
-      uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2
+      uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ inputs.api-level }}
         arch: x86_64
@@ -105,21 +105,21 @@ runs:
 
     - name: Upload Any Logs
       if: failure()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@v5
       with:
         name: log-upload
         path: ${{github.workspace}}/**/*.log
 
     - name: Upload Any Heap Dumps
       if: failure()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@v5
       with:
         name: hprof-upload
         path: ${{github.workspace}}/**/*.hprof
 
     - name: Upload Any Specified Files
       if: failure() && inputs.failure-path-upload != 'null'
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@v5
       with:
         name: specified-upload
         path: ${{github.workspace}}/${{inputs.failure-path-upload}}

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: workflow-kotlin-test-runner-ubuntu-4core
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: main build
         uses: ./.github/actions/gradle-task
@@ -33,7 +33,7 @@ jobs:
     needs: build-all
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Run dokka to validate kdoc
         uses: ./.github/actions/gradle-task
@@ -46,11 +46,11 @@ jobs:
     runs-on: workflow-kotlin-test-runner-ubuntu-4core
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
       # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
       # to be triggered again.
       - name: Generate App Token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2
+        uses: actions/create-github-app-token@v2
         if: ${{ vars.APP_ID != '' }}
         id: app-token
         with:
@@ -71,11 +71,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
       # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
       # to be triggered again.
       - name: Generate App Token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2
+        uses: actions/create-github-app-token@v2
         if: ${{ vars.APP_ID != '' }}
         id: app-token
         with:
@@ -95,11 +95,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
       # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
       # to be triggered again.
       - name: Generate App Token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2
+        uses: actions/create-github-app-token@v2
         if: ${{ vars.APP_ID != '' }}
         id: app-token
         with:
@@ -121,11 +121,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
       # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
       # to be triggered again.
       - name: Generate App Token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2
+        uses: actions/create-github-app-token@v2
         if: ${{ vars.APP_ID != '' }}
         id: app-token
         with:
@@ -147,11 +147,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
       # We use the workflow-pr-fixer app to authenticate and get a token that will cause the workflow
       # to be triggered again.
       - name: Generate App Token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2
+        uses: actions/create-github-app-token@v2
         if: ${{ vars.APP_ID != '' }}
         id: app-token
         with:
@@ -175,7 +175,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Lint via gradle
         uses: ./.github/actions/gradle-task
@@ -190,7 +190,7 @@ jobs:
     steps:
       # These setup steps should be common across all jobs in this workflow.
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: build tutorials
         uses: ./.github/actions/gradle-task
@@ -206,7 +206,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: allTests via gradle
         uses: ./.github/actions/gradle-task
@@ -233,7 +233,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: test via Gradle
         uses: ./.github/actions/gradle-task
@@ -256,7 +256,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: test via Gradle
         uses: ./.github/actions/gradle-task
@@ -279,7 +279,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: test via Gradle
         uses: ./.github/actions/gradle-task
@@ -302,7 +302,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Test with Gradle
         uses: ./.github/actions/gradle-task
@@ -325,7 +325,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Test with Gradle
         uses: ./.github/actions/gradle-task
@@ -348,7 +348,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Test with Gradle
         uses: ./.github/actions/gradle-task
@@ -371,7 +371,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Test with Gradle
         uses: ./.github/actions/gradle-task
@@ -394,7 +394,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Test with Gradle
         uses: ./.github/actions/gradle-task
@@ -417,7 +417,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Test with Gradle
         uses: ./.github/actions/gradle-task
@@ -440,7 +440,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Test with Gradle
         uses: ./.github/actions/gradle-task
@@ -463,7 +463,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Test with Gradle
         uses: ./.github/actions/gradle-task
@@ -486,7 +486,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Test with Gradle
         uses: ./.github/actions/gradle-task
@@ -509,7 +509,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Test with Gradle
         uses: ./.github/actions/gradle-task
@@ -532,7 +532,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Check with Gradle
         uses: ./.github/actions/gradle-task
@@ -555,7 +555,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Check with Gradle
         uses: ./.github/actions/gradle-task
@@ -578,7 +578,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       ## JS Specific Tests (for KMP js actuals in core and runtime).
       - name: Check with Gradle
@@ -608,7 +608,7 @@ jobs:
           - 31
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Instrumented tests
         uses: ./.github/actions/gradle-tasks-with-emulator
@@ -636,7 +636,7 @@ jobs:
         ### <end-connected-check-shards>
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Instrumented tests
         uses: ./.github/actions/gradle-tasks-with-emulator
@@ -666,7 +666,7 @@ jobs:
         runtime: [ conflate, stateChange, drainExclusive, conflate-stateChange, partial, conflate-partial, stable, conflate-drainExclusive, stateChange-drainExclusive, partial-drainExclusive, conflate-partial-drainExclusive, all ]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Instrumented tests
         uses: ./.github/actions/gradle-tasks-with-emulator

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,11 +7,11 @@ jobs:
   publish-release:
     runs-on: macos-latest
     if: github.repository == 'square/workflow-kotlin'
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: gradle/wrapper-validation-action@699bb18358f12c5b78b37bb0111d3a0e2276e0e2 # v2
+      - uses: actions/checkout@v6
+      - uses: gradle/actions/wrapper-validation@v5
 
       - name: Ensure this isn't a -SNAPSHOT version
         uses: ./.github/actions/gradle-task

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -13,8 +13,8 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: gradle/wrapper-validation-action@699bb18358f12c5b78b37bb0111d3a0e2276e0e2 # v2
+      - uses: actions/checkout@v6
+      - uses: gradle/actions/wrapper-validation@v5
 
       - name: Check for -SNAPSHOT version
         uses: ./.github/actions/gradle-task

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -12,7 +12,7 @@ jobs:
     name: Validate Codeowners
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v6
       # https://github.com/marketplace/actions/github-codeowners-validator
       - uses: mszostok/codeowners-validator@7f3f5e28c6d7b8dfae5731e54ce2272ca384592f # v0.7.4
         with:

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -14,9 +14,9 @@ jobs:
     name: Lint Markdown files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby 2.6
-        uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1.229.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.4.2
       - name: Install dependencies


### PR DESCRIPTION
Even at 60 minutes - our releases were timing out now - https://github.com/square/workflow-kotlin/actions/workflows/publish-release.yml .

They used to complete in < 45 minutes. Not _that_ many more tests were added so I think the runners are getting slower.

I increase again to 90 minutes here.

Also, I updated all the action versions that I could here to hope that some of the newer action versions are faster?