### PR TITLE
Fix setup gradle task config

### DIFF
--- a/.github/actions/gradle-task/action.yml
+++ b/.github/actions/gradle-task/action.yml
@@ -31,13 +31,6 @@ runs:
   using: 'composite'
   steps:
 
-    # Around March 2025 we've started seeing jobs fail with what looks like
-    # a race initialize version catalog (failure to resolve 'libs.', etc.).
-    # Forcing an initial run of `tasks` fixes that.
-    - name: Initial Gradle command
-      shell: bash
-      run: ./gradlew tasks
-
     - name: Set up JDK
       uses: actions/setup-java@v5
       with:
@@ -105,16 +98,14 @@ runs:
 
     - uses: gradle/actions/wrapper-validation@v5
 
-    # Run the actual task.  Note that this still uses setup-gradle for more fine-grained caching.
+    # Run the actual task.
     - name: Run ${{inputs.task}}
-      uses: gradle/actions/setup-gradle@v5
-      with:
-        working-directory: ${{inputs.build-root-directory}}
-        # These arguments need to be on a single line. If they're defined with wrapping (using `|`),
-        # something along the way to the actual CLI invocation gets confused and the jvmargs list
-        # winds up getting parsed as a single argument.
-        run: ./gradlew ${{steps.gradle-args.outputs.gradle-property-args}} ${{inputs.task}} '-Dorg.gradle.jvmargs=${{steps.gradle-args.outputs.gradle-jvm-args}}'
-        cache-read-only: false
+      shell: bash
+      working-directory: ${{inputs.build-root-directory}}
+      # These arguments need to be on a single line. If they're defined with wrapping (using `|`),
+      # something along the way to the actual CLI invocation gets confused and the jvmargs list
+      # winds up getting parsed as a single argument.
+      run: ./gradlew ${{steps.gradle-args.outputs.gradle-property-args}} ${{inputs.task}} '-Dorg.gradle.jvmargs=${{steps.gradle-args.outputs.gradle-jvm-args}}'
 
     # Save the build cache to `write-cache-key`.
     # Skip if we already had an exact match, or if the key is not set, or if this is a Windows runner.

--- a/.github/actions/gradle-tasks-with-emulator/action.yml
+++ b/.github/actions/gradle-tasks-with-emulator/action.yml
@@ -29,6 +29,12 @@ inputs:
   write-cache-key:
     description: 'The unique identifier for the associated cache.  Any other consumers or producers for this cache must use the same name.'
     default: 'null'
+  failure-path-upload:
+    description: 'The relative path to a desired log for upload if the task fails.'
+    default: 'null'
+  failure-upload-name:
+    description: 'The name for the upload of failure reports.'
+    default: 'specified-upload'
 
 runs:
   using: 'composite'
@@ -53,6 +59,8 @@ runs:
         restore-cache-key: ${{ inputs.restore-cache-key }}
         task: ${{ inputs.prepare-task }}
         write-cache-key: ${{ inputs.write-cache-key }}
+        failure-path-upload: ${{ inputs.failure-path-upload }}
+        failure-upload-name: ${{ inputs.failure-upload-name }}
 
     # Get the AVD if it's already cached.
     - name: AVD cache

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -211,10 +211,7 @@ jobs:
       - name: allTests via gradle
         uses: ./.github/actions/gradle-task
         with:
-          task: |
-            allTests
-            test
-            --continue
+          task: test --continue
           restore-cache-key: build-logic
           write-cache-key: main-build-artifacts
           failure-path-upload: '**/build/reports/tests/*[tT]est'
@@ -527,7 +524,7 @@ jobs:
           report_paths: '**/build/test-results/*[tT]est/TEST-*.xml'
 
   kmp-jvm-tests:
-    name: JVM Tests for KMP Modules
+    name: JVM Unit Tests for KMP Modules
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -550,7 +547,7 @@ jobs:
           report_paths: '**/build/test-results/*[tT]est/TEST-*.xml'
 
   kmp-ios-tests:
-    name: iOS Tests for KMP Modules
+    name: iOS Unit Tests for KMP Modules
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -573,7 +570,7 @@ jobs:
           report_paths: '**/build/test-results/*[tT]est/TEST-*.xml'
 
   kmp-js-tests:
-    name: JS Tests
+    name: JS Unit Tests for KMP Modules
     runs-on: macos-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Was using the new `setup-gradle` task with incorrect configuration and the tasks were not actually running.

Also fix a few errors:
- failure path uploads for `gradle-task-with-emulator`
- `allTests` was running the KMP tests (for iOS and JS) even though the job was designed to be solely running *non* KMP unit tests. We runt he iOS and JS ones in their own jobs.