### PR TITLE
Separate key and name in eventHandler

### DIFF
--- a/workflow-core/api/workflow-core.api
+++ b/workflow-core/api/workflow-core.api
@@ -333,8 +333,8 @@ public final class com/squareup/workflow1/StatefulWorkflow$Companion {
 
 public final class com/squareup/workflow1/StatefulWorkflow$RenderContext : com/squareup/workflow1/BaseRenderContext {
 	public final fun asStatelessRenderContext ()Lcom/squareup/workflow1/StatelessWorkflow$RenderContext;
-	public final fun eventHandler (Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/StatefulWorkflow$RenderContext;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/jvm/functions/Function0;
+	public final fun eventHandler (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/StatefulWorkflow$RenderContext;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/jvm/functions/Function0;
 	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public fun getRuntimeConfig ()Ljava/util/Set;
 	public final fun getStableEventHandlers ()Z
@@ -353,8 +353,8 @@ public abstract class com/squareup/workflow1/StatelessWorkflow : com/squareup/wo
 }
 
 public final class com/squareup/workflow1/StatelessWorkflow$RenderContext : com/squareup/workflow1/BaseRenderContext {
-	public final fun eventHandler (Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
-	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/StatelessWorkflow$RenderContext;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/jvm/functions/Function0;
+	public final fun eventHandler (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+	public static synthetic fun eventHandler$default (Lcom/squareup/workflow1/StatelessWorkflow$RenderContext;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/jvm/functions/Function0;
 	public fun getActionSink ()Lcom/squareup/workflow1/Sink;
 	public fun getRuntimeConfig ()Ljava/util/Set;
 	public final fun getStableEventHandlers ()Z

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/HandlerBox.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/HandlerBox.kt
@@ -56,11 +56,12 @@ internal class HandlerBox2<E1, E2> {
 internal inline fun <P, S, O, reified E1, reified E2> BaseRenderContext<P, S, O>.eventHandler2(
   name: String,
   remember: Boolean,
+  key: String,
   noinline update: Updater<P, S, O>.(E1, E2) -> Unit
 ): (E1, E2) -> Unit {
-  val handler = { e1: E1, e2: E2 -> actionSink.send(action("eH: $name") { update(e1, e2) }) }
+  val handler = { e1: E1, e2: E2 -> actionSink.send(action(name) { update(e1, e2) }) }
   return if (remember) {
-    val box = remember(name, typeOf<E1>(), typeOf<E2>()) { HandlerBox2<E1, E2>() }
+    val box = remember(key, typeOf<E1>(), typeOf<E2>()) { HandlerBox2<E1, E2>() }
     box.handler = handler
     box.stableHandler
   } else {
@@ -85,13 +86,14 @@ internal inline fun <
   > BaseRenderContext<P, S, O>.eventHandler3(
   name: String,
   remember: Boolean,
+  key: String,
   noinline update: Updater<P, S, O>.(E1, E2, E3) -> Unit
 ): (E1, E2, E3) -> Unit {
   val handler =
-    { e1: E1, e2: E2, e3: E3 -> actionSink.send(action("eH: $name") { update(e1, e2, e3) }) }
+    { e1: E1, e2: E2, e3: E3 -> actionSink.send(action(name) { update(e1, e2, e3) }) }
   return if (remember) {
     val box =
-      remember(name, typeOf<E1>(), typeOf<E2>(), typeOf<E3>()) { HandlerBox3<E1, E2, E3>() }
+      remember(key, typeOf<E1>(), typeOf<E2>(), typeOf<E3>()) { HandlerBox3<E1, E2, E3>() }
     box.handler = handler
     box.stableHandler
   } else {
@@ -117,14 +119,15 @@ internal inline fun <
   > BaseRenderContext<P, S, O>.eventHandler4(
   name: String,
   remember: Boolean,
+  key: String,
   noinline update: Updater<P, S, O>.(E1, E2, E3, E4) -> Unit
 ): (E1, E2, E3, E4) -> Unit {
   val handler = { e1: E1, e2: E2, e3: E3, e4: E4 ->
-    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4) })
+    actionSink.send(action(name) { update(e1, e2, e3, e4) })
   }
   return if (remember) {
     val box = remember(
-      name,
+      key,
       typeOf<E1>(),
       typeOf<E2>(),
       typeOf<E3>(),
@@ -157,14 +160,15 @@ internal inline fun <
   > BaseRenderContext<P, S, O>.eventHandler5(
   name: String,
   remember: Boolean,
+  key: String,
   noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5) -> Unit
 ): (E1, E2, E3, E4, E5) -> Unit {
   val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5 ->
-    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5) })
+    actionSink.send(action(name) { update(e1, e2, e3, e4, e5) })
   }
   return if (remember) {
     val box = remember(
-      name,
+      key,
       typeOf<E1>(),
       typeOf<E2>(),
       typeOf<E3>(),
@@ -199,14 +203,15 @@ internal inline fun <
   > BaseRenderContext<P, S, O>.eventHandler6(
   name: String,
   remember: Boolean,
+  key: String,
   noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6) -> Unit
 ): (E1, E2, E3, E4, E5, E6) -> Unit {
   val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6 ->
-    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6) })
+    actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6) })
   }
   return if (remember) {
     val box = remember(
-      name,
+      key,
       typeOf<E1>(),
       typeOf<E2>(),
       typeOf<E3>(),
@@ -243,14 +248,15 @@ internal inline fun <
   > BaseRenderContext<P, S, O>.eventHandler7(
   name: String,
   remember: Boolean,
+  key: String,
   noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6, E7) -> Unit
 ): (E1, E2, E3, E4, E5, E6, E7) -> Unit {
   val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7 ->
-    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6, e7) })
+    actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6, e7) })
   }
   return if (remember) {
     val box = remember(
-      name,
+      key,
       typeOf<E1>(),
       typeOf<E2>(),
       typeOf<E3>(),
@@ -289,14 +295,15 @@ internal inline fun <
   > BaseRenderContext<P, S, O>.eventHandler8(
   name: String,
   remember: Boolean,
+  key: String,
   noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6, E7, E8) -> Unit
 ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit {
   val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7, e8: E8 ->
-    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6, e7, e8) })
+    actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6, e7, e8) })
   }
   return if (remember) {
     val box = remember(
-      name,
+      key,
       typeOf<E1>(),
       typeOf<E2>(),
       typeOf<E3>(),
@@ -337,14 +344,15 @@ internal inline fun <
   > BaseRenderContext<P, S, O>.eventHandler9(
   name: String,
   remember: Boolean,
+  key: String,
   noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit
 ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit {
   val handler = { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7, e8: E8, e9: E9 ->
-    actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6, e7, e8, e9) })
+    actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6, e7, e8, e9) })
   }
   return if (remember) {
     val box = remember(
-      name,
+      key,
       typeOf<E1>(),
       typeOf<E2>(),
       typeOf<E3>(),
@@ -387,15 +395,16 @@ internal inline fun <
   > BaseRenderContext<P, S, O>.eventHandler10(
   name: String,
   remember: Boolean,
+  key: String,
   noinline update: Updater<P, S, O>.(E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit
 ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit {
   val handler =
     { e1: E1, e2: E2, e3: E3, e4: E4, e5: E5, e6: E6, e7: E7, e8: E8, e9: E9, e10: E10 ->
-      actionSink.send(action("eH: $name") { update(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10) })
+      actionSink.send(action(name) { update(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10) })
     }
   return if (remember) {
     val box = remember(
-      name,
+      key,
       typeOf<E1>(),
       typeOf<E2>(),
       typeOf<E3>(),

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/HandlerBox.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/HandlerBox.kt
@@ -9,8 +9,8 @@ internal class HandlerBox0 {
 
 internal fun <P, S, O> BaseRenderContext<P, S, O>.eventHandler0(
   name: String,
-  key: String,
   remember: Boolean,
+  key: String,
   update: Updater<P, S, O>.() -> Unit
 ): () -> Unit {
   val handler = { actionSink.send(action(name, update)) }
@@ -32,8 +32,8 @@ internal class HandlerBox1<E> {
 @PublishedApi
 internal inline fun <P, S, O, reified EventT> BaseRenderContext<P, S, O>.eventHandler1(
   name: String,
-  key: String,
   remember: Boolean,
+  key: String,
   noinline update: Updater<P, S, O>.(EventT) -> Unit
 ): (EventT) -> Unit {
   val handler = { e: EventT -> actionSink.send(action(name) { update(e) }) }

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/HandlerBox.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/HandlerBox.kt
@@ -9,12 +9,13 @@ internal class HandlerBox0 {
 
 internal fun <P, S, O> BaseRenderContext<P, S, O>.eventHandler0(
   name: String,
+  key: String,
   remember: Boolean,
   update: Updater<P, S, O>.() -> Unit
 ): () -> Unit {
-  val handler = { actionSink.send(action("eH: $name", update)) }
+  val handler = { actionSink.send(action(name, update)) }
   return if (remember) {
-    val box = remember(name) { HandlerBox0() }
+    val box = remember(key) { HandlerBox0() }
     box.handler = handler
     box.stableHandler
   } else {
@@ -31,12 +32,13 @@ internal class HandlerBox1<E> {
 @PublishedApi
 internal inline fun <P, S, O, reified EventT> BaseRenderContext<P, S, O>.eventHandler1(
   name: String,
+  key: String,
   remember: Boolean,
   noinline update: Updater<P, S, O>.(EventT) -> Unit
 ): (EventT) -> Unit {
-  val handler = { e: EventT -> actionSink.send(action("eH: $name") { update(e) }) }
+  val handler = { e: EventT -> actionSink.send(action(name) { update(e) }) }
   return if (remember) {
-    val box = remember(name, typeOf<EventT>()) { HandlerBox1<EventT>() }
+    val box = remember(key, typeOf<EventT>()) { HandlerBox1<EventT>() }
     box.handler = handler
     box.stableHandler
   } else {

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
@@ -388,7 +388,7 @@ public abstract class StatefulWorkflow<
         OutputT
         >.Updater.(currentState: CurrentStateT) -> Unit
     ): () -> Unit =
-      eventHandler(name, remember) {
+      eventHandler(name, remember = remember) {
         CurrentStateT::class.safeCast(state)?.let { currentState -> this.update(currentState) }
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
@@ -407,7 +407,7 @@ public abstract class StatefulWorkflow<
         event: EventT
       ) -> Unit
     ): (EventT) -> Unit =
-      eventHandler(name, remember) { event ->
+      eventHandler(name, remember = remember) { event ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, event) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -432,7 +432,7 @@ public abstract class StatefulWorkflow<
         e2: E2
       ) -> Unit
     ): (E1, E2) -> Unit =
-      eventHandler(name, remember) { e1, e2 ->
+      eventHandler(name, remember = remember) { e1, e2 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -459,7 +459,7 @@ public abstract class StatefulWorkflow<
         e3: E3
       ) -> Unit
     ): (E1, E2, E3) -> Unit =
-      eventHandler(name, remember) { e1, e2, e3 ->
+      eventHandler(name, remember = remember) { e1, e2, e3 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -488,7 +488,7 @@ public abstract class StatefulWorkflow<
         e4: E4
       ) -> Unit
     ): (E1, E2, E3, E4) -> Unit =
-      eventHandler(name, remember) { e1, e2, e3, e4 ->
+      eventHandler(name, remember = remember) { e1, e2, e3, e4 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -519,7 +519,7 @@ public abstract class StatefulWorkflow<
         e5: E5
       ) -> Unit
     ): (E1, E2, E3, E4, E5) -> Unit =
-      eventHandler(name, remember) { e1, e2, e3, e4, e5 ->
+      eventHandler(name, remember = remember) { e1, e2, e3, e4, e5 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -552,7 +552,7 @@ public abstract class StatefulWorkflow<
         e6: E6
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6) -> Unit =
-      eventHandler(name, remember) { e1, e2, e3, e4, e5, e6 ->
+      eventHandler(name, remember = remember) { e1, e2, e3, e4, e5, e6 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5, e6) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -587,7 +587,7 @@ public abstract class StatefulWorkflow<
         e7: E7
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7) -> Unit =
-      eventHandler(name, remember) { e1, e2, e3, e4, e5, e6, e7 ->
+      eventHandler(name, remember = remember) { e1, e2, e3, e4, e5, e6, e7 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5, e6, e7) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -624,7 +624,7 @@ public abstract class StatefulWorkflow<
         e8: E8
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit =
-      eventHandler(name, remember) { e1, e2, e3, e4, e5, e6, e7, e8 ->
+      eventHandler(name, remember = remember) { e1, e2, e3, e4, e5, e6, e7, e8 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5, e6, e7, e8) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -663,7 +663,7 @@ public abstract class StatefulWorkflow<
         e9: E9
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit =
-      eventHandler(name, remember) { e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
+      eventHandler(name, remember = remember) { e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5, e6, e7, e8, e9) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -704,7 +704,7 @@ public abstract class StatefulWorkflow<
         e10: E10
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit =
-      eventHandler(name, remember) { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
+      eventHandler(name, remember = remember) { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState ->
             this.update(currentState, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10)

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
@@ -153,9 +153,12 @@ public abstract class StatefulWorkflow<
      *
      *    return SomeScreen(onclick)
      *
-     * @param name If [remember] is true, used as a unique key to distinguish
-     * event handlers with same number and type of parameters. Also used
-     * for descriptive logging and error messages.
+     * @param name Used for descriptive logging and error messages.
+     *
+     * @param key If [remember] is true, used as a unique key to distinguish
+     * event handlers with same number and type of parameters. Defaults to [name].
+     * Use a different value when uniqueness requires adding dynamic content (e.g. an id
+     * or uuid) to the key — keeping [name] clean for readability.
      *
      * @param remember When true uses [RenderContext.remember] to ensure
      * that the same lambda is returned across multiple render passes,
@@ -167,22 +170,24 @@ public abstract class StatefulWorkflow<
      * When `null` a default value of `false` is used unless
      * [STABLE_EVENT_HANDLERS] has been specified in the [runtimeConfig].
      *
-     * @throws IllegalArgumentException if [remember] is true and [name]
+     * @throws IllegalArgumentException if [remember] is true and [key]
      * has already been used in the current [render] call for a lambda of
      * the same shape
      */
     public fun eventHandler(
       name: String,
+      key: String = name,
       remember: Boolean? = null,
       update: Updater<PropsT, StateT, OutputT>.() -> Unit
-    ): () -> Unit = eventHandler0(name, remember ?: stableEventHandlers, update)
+    ): () -> Unit = eventHandler0(name, key, remember ?: stableEventHandlers, update)
 
     public inline fun <reified EventT> eventHandler(
       name: String,
+      key: String = name,
       remember: Boolean? = null,
       noinline update: Updater<PropsT, StateT, OutputT>.(EventT) -> Unit
     ): (EventT) -> Unit {
-      val eh = eventHandler1(name, remember ?: stableEventHandlers, update)
+      val eh = eventHandler1(name, key, remember ?: stableEventHandlers, update)
       return eh
     }
 

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
@@ -176,18 +176,18 @@ public abstract class StatefulWorkflow<
      */
     public fun eventHandler(
       name: String,
-      key: String = name,
       remember: Boolean? = null,
+      key: String = name,
       update: Updater<PropsT, StateT, OutputT>.() -> Unit
-    ): () -> Unit = eventHandler0(name, key, remember ?: stableEventHandlers, update)
+    ): () -> Unit = eventHandler0(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <reified EventT> eventHandler(
       name: String,
-      key: String = name,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, StateT, OutputT>.(EventT) -> Unit
     ): (EventT) -> Unit {
-      val eh = eventHandler1(name, key, remember ?: stableEventHandlers, update)
+      val eh = eventHandler1(name, remember ?: stableEventHandlers, key, update)
       return eh
     }
 
@@ -388,7 +388,7 @@ public abstract class StatefulWorkflow<
         OutputT
         >.Updater.(currentState: CurrentStateT) -> Unit
     ): () -> Unit =
-      eventHandler(name, remember = remember) {
+      eventHandler(name, remember) {
         CurrentStateT::class.safeCast(state)?.let { currentState -> this.update(currentState) }
           ?: onFailedCast(name, CurrentStateT::class, state)
       }
@@ -407,7 +407,7 @@ public abstract class StatefulWorkflow<
         event: EventT
       ) -> Unit
     ): (EventT) -> Unit =
-      eventHandler(name, remember = remember) { event ->
+      eventHandler(name, remember) { event ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, event) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -432,7 +432,7 @@ public abstract class StatefulWorkflow<
         e2: E2
       ) -> Unit
     ): (E1, E2) -> Unit =
-      eventHandler(name, remember = remember) { e1, e2 ->
+      eventHandler(name, remember) { e1, e2 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -459,7 +459,7 @@ public abstract class StatefulWorkflow<
         e3: E3
       ) -> Unit
     ): (E1, E2, E3) -> Unit =
-      eventHandler(name, remember = remember) { e1, e2, e3 ->
+      eventHandler(name, remember) { e1, e2, e3 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -488,7 +488,7 @@ public abstract class StatefulWorkflow<
         e4: E4
       ) -> Unit
     ): (E1, E2, E3, E4) -> Unit =
-      eventHandler(name, remember = remember) { e1, e2, e3, e4 ->
+      eventHandler(name, remember) { e1, e2, e3, e4 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -519,7 +519,7 @@ public abstract class StatefulWorkflow<
         e5: E5
       ) -> Unit
     ): (E1, E2, E3, E4, E5) -> Unit =
-      eventHandler(name, remember = remember) { e1, e2, e3, e4, e5 ->
+      eventHandler(name, remember) { e1, e2, e3, e4, e5 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -552,7 +552,7 @@ public abstract class StatefulWorkflow<
         e6: E6
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6) -> Unit =
-      eventHandler(name, remember = remember) { e1, e2, e3, e4, e5, e6 ->
+      eventHandler(name, remember) { e1, e2, e3, e4, e5, e6 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5, e6) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -587,7 +587,7 @@ public abstract class StatefulWorkflow<
         e7: E7
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7) -> Unit =
-      eventHandler(name, remember = remember) { e1, e2, e3, e4, e5, e6, e7 ->
+      eventHandler(name, remember) { e1, e2, e3, e4, e5, e6, e7 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5, e6, e7) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -624,7 +624,7 @@ public abstract class StatefulWorkflow<
         e8: E8
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit =
-      eventHandler(name, remember = remember) { e1, e2, e3, e4, e5, e6, e7, e8 ->
+      eventHandler(name, remember) { e1, e2, e3, e4, e5, e6, e7, e8 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5, e6, e7, e8) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -663,7 +663,7 @@ public abstract class StatefulWorkflow<
         e9: E9
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit =
-      eventHandler(name, remember = remember) { e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
+      eventHandler(name, remember) { e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState -> this.update(currentState, e1, e2, e3, e4, e5, e6, e7, e8, e9) }
           ?: onFailedCast(name, CurrentStateT::class, state)
@@ -704,7 +704,7 @@ public abstract class StatefulWorkflow<
         e10: E10
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit =
-      eventHandler(name, remember = remember) { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
+      eventHandler(name, remember) { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
         CurrentStateT::class.safeCast(state)
           ?.let { currentState ->
             this.update(currentState, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10)

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatefulWorkflow.kt
@@ -194,26 +194,31 @@ public abstract class StatefulWorkflow<
     public inline fun <reified E1, reified E2> eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, StateT, OutputT>.(E1, E2) -> Unit
-    ): (E1, E2) -> Unit = eventHandler2(name, remember ?: stableEventHandlers, update)
+    ): (E1, E2) -> Unit = eventHandler2(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <reified E1, reified E2, reified E3> eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, StateT, OutputT>.(E1, E2, E3) -> Unit
-    ): (E1, E2, E3) -> Unit = eventHandler3(name, remember ?: stableEventHandlers, update)
+    ): (E1, E2, E3) -> Unit = eventHandler3(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <reified E1, reified E2, reified E3, reified E4> eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, StateT, OutputT>.(E1, E2, E3, E4) -> Unit
-    ): (E1, E2, E3, E4) -> Unit = eventHandler4(name, remember ?: stableEventHandlers, update)
+    ): (E1, E2, E3, E4) -> Unit = eventHandler4(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <reified E1, reified E2, reified E3, reified E4, reified E5> eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, StateT, OutputT>.(E1, E2, E3, E4, E5) -> Unit
-    ): (E1, E2, E3, E4, E5) -> Unit = eventHandler5(name, remember ?: stableEventHandlers, update)
+    ): (E1, E2, E3, E4, E5) -> Unit =
+      eventHandler5(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <
       reified E1,
@@ -225,6 +230,7 @@ public abstract class StatefulWorkflow<
       > eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, StateT, OutputT>.(
         E1,
         E2,
@@ -234,7 +240,7 @@ public abstract class StatefulWorkflow<
         E6,
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6) -> Unit =
-      eventHandler6(name, remember ?: stableEventHandlers, update)
+      eventHandler6(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <
       reified E1,
@@ -247,6 +253,7 @@ public abstract class StatefulWorkflow<
       > eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, StateT, OutputT>.(
         E1,
         E2,
@@ -257,7 +264,7 @@ public abstract class StatefulWorkflow<
         E7,
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7) -> Unit {
-      return eventHandler7(name, remember ?: stableEventHandlers, update)
+      return eventHandler7(name, remember ?: stableEventHandlers, key, update)
     }
 
     public inline fun <
@@ -272,6 +279,7 @@ public abstract class StatefulWorkflow<
       > eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, StateT, OutputT>.(
         E1,
         E2,
@@ -283,7 +291,7 @@ public abstract class StatefulWorkflow<
         E8,
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit =
-      eventHandler8(name, remember ?: stableEventHandlers, update)
+      eventHandler8(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <
       reified E1,
@@ -298,6 +306,7 @@ public abstract class StatefulWorkflow<
       > eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, StateT, OutputT>.(
         E1,
         E2,
@@ -310,7 +319,7 @@ public abstract class StatefulWorkflow<
         E9,
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit =
-      eventHandler9(name, remember ?: stableEventHandlers, update)
+      eventHandler9(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <
       reified E1,
@@ -326,6 +335,7 @@ public abstract class StatefulWorkflow<
       > eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, StateT, OutputT>.(
         E1,
         E2,
@@ -339,7 +349,7 @@ public abstract class StatefulWorkflow<
         E10,
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit =
-      eventHandler10(name, remember ?: stableEventHandlers, update)
+      eventHandler10(name, remember ?: stableEventHandlers, key, update)
 
     /**
      * Like [eventHandler], but no-ops if [state][WorkflowAction.Updater.state] has

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
@@ -66,17 +66,17 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
      */
     public fun eventHandler(
       name: String,
-      key: String = name,
       remember: Boolean? = null,
+      key: String = name,
       update: Updater<PropsT, *, OutputT>.() -> Unit
-    ): () -> Unit = eventHandler0(name, key, remember ?: stableEventHandlers, update)
+    ): () -> Unit = eventHandler0(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <reified EventT> eventHandler(
       name: String,
-      key: String = name,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, *, OutputT>.(EventT) -> Unit
-    ): (EventT) -> Unit = eventHandler1(name, key, remember ?: stableEventHandlers, update)
+    ): (EventT) -> Unit = eventHandler1(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <reified E1, reified E2> eventHandler(
       name: String,

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
@@ -81,26 +81,31 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
     public inline fun <reified E1, reified E2> eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, *, OutputT>.(E1, E2) -> Unit
-    ): (E1, E2) -> Unit = eventHandler2(name, remember ?: stableEventHandlers, update)
+    ): (E1, E2) -> Unit = eventHandler2(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <reified E1, reified E2, reified E3> eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, *, OutputT>.(E1, E2, E3) -> Unit
-    ): (E1, E2, E3) -> Unit = eventHandler3(name, remember ?: stableEventHandlers, update)
+    ): (E1, E2, E3) -> Unit = eventHandler3(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <reified E1, reified E2, reified E3, reified E4> eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, *, OutputT>.(E1, E2, E3, E4) -> Unit
-    ): (E1, E2, E3, E4) -> Unit = eventHandler4(name, remember ?: stableEventHandlers, update)
+    ): (E1, E2, E3, E4) -> Unit = eventHandler4(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <reified E1, reified E2, reified E3, reified E4, reified E5> eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, *, OutputT>.(E1, E2, E3, E4, E5) -> Unit
-    ): (E1, E2, E3, E4, E5) -> Unit = eventHandler5(name, remember ?: stableEventHandlers, update)
+    ): (E1, E2, E3, E4, E5) -> Unit =
+      eventHandler5(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <
       reified E1,
@@ -112,6 +117,7 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
       > eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, *, OutputT>.(
         E1,
         E2,
@@ -121,7 +127,7 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
         E6,
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6) -> Unit =
-      eventHandler6(name, remember ?: stableEventHandlers, update)
+      eventHandler6(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <
       reified E1,
@@ -134,6 +140,7 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
       > eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, *, OutputT>.(
         E1,
         E2,
@@ -144,7 +151,7 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
         E7,
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7) -> Unit =
-      eventHandler7(name, remember ?: stableEventHandlers, update)
+      eventHandler7(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <
       reified E1,
@@ -158,6 +165,7 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
       > eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, *, OutputT>.(
         E1,
         E2,
@@ -169,7 +177,7 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
         E8,
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8) -> Unit =
-      eventHandler8(name, remember ?: stableEventHandlers, update)
+      eventHandler8(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <
       reified E1,
@@ -184,6 +192,7 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
       > eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, *, OutputT>.(
         E1,
         E2,
@@ -196,7 +205,7 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
         E9,
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8, E9) -> Unit =
-      eventHandler9(name, remember ?: stableEventHandlers, update)
+      eventHandler9(name, remember ?: stableEventHandlers, key, update)
 
     public inline fun <
       reified E1,
@@ -212,6 +221,7 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
       > eventHandler(
       name: String,
       remember: Boolean? = null,
+      key: String = name,
       noinline update: Updater<PropsT, *, OutputT>.(
         E1,
         E2,
@@ -225,7 +235,7 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
         E10,
       ) -> Unit
     ): (E1, E2, E3, E4, E5, E6, E7, E8, E9, E10) -> Unit =
-      eventHandler10(name, remember ?: stableEventHandlers, update)
+      eventHandler10(name, remember ?: stableEventHandlers, key, update)
   }
 
   /**

--- a/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
+++ b/workflow-core/src/commonMain/kotlin/com/squareup/workflow1/StatelessWorkflow.kt
@@ -43,9 +43,12 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
      * as an event handler on a rendered view model.
      * See [StatefulWorkflow.RenderContext.eventHandler] for details.
      *
-     * @param name If [remember] is true, used as a unique key to distinguish
-     * event handlers with same number and type of parameters. Also used
-     * for descriptive logging and error messages.
+     * @param name Used for descriptive logging and error messages.
+     *
+     * @param key If [remember] is true, used as a unique key to distinguish
+     * event handlers with same number and type of parameters. Defaults to [name].
+     * Use a different value when uniqueness requires adding dynamic content (e.g. an id
+     * or uuid) to the key — keeping [name] clean for readability.
      *
      * @param remember When true uses [RenderContext.remember] to ensure
      * that the same lambda is returned across multiple render passes,
@@ -57,21 +60,23 @@ public abstract class StatelessWorkflow<PropsT, OutputT, out RenderingT> :
      * When `null` a default value of `false` is used unless
      * [STABLE_EVENT_HANDLERS] has been specified in the [runtimeConfig].
      *
-     * @throws IllegalArgumentException if [remember] is true and [name]
+     * @throws IllegalArgumentException if [remember] is true and [key]
      * has already been used in the current [render] call for a lambda of
      * the same shape
      */
     public fun eventHandler(
       name: String,
+      key: String = name,
       remember: Boolean? = null,
       update: Updater<PropsT, *, OutputT>.() -> Unit
-    ): () -> Unit = eventHandler0(name, remember ?: stableEventHandlers, update)
+    ): () -> Unit = eventHandler0(name, key, remember ?: stableEventHandlers, update)
 
     public inline fun <reified EventT> eventHandler(
       name: String,
+      key: String = name,
       remember: Boolean? = null,
       noinline update: Updater<PropsT, *, OutputT>.(EventT) -> Unit
-    ): (EventT) -> Unit = eventHandler1(name, remember ?: stableEventHandlers, update)
+    ): (EventT) -> Unit = eventHandler1(name, key, remember ?: stableEventHandlers, update)
 
     public inline fun <reified E1, reified E2> eventHandler(
       name: String,

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/internal/WorkflowNodeTest.kt
@@ -1155,7 +1155,7 @@ internal class WorkflowNodeTest {
       node.render(workflow.asStatefulWorkflow(), Unit)
     }
     val expectedPrefix = "Expected sink to not be sent to until after the render pass. " +
-      "Received action: eH: eventHandler"
+      "Received action: eventHandler"
     assertTrue(
       error.message!!.startsWith(expectedPrefix),
       "Expected prefix: \"$expectedPrefix\", actually: \"${error.message}\""
@@ -1703,8 +1703,8 @@ internal class WorkflowNodeTest {
 
     assertEquals(2, capturedDroppedActions!!.size)
     // Event handler actions have a specific format
-    assertTrue(capturedDroppedActions[0].debuggingName.startsWith("eH: handler"))
-    assertTrue(capturedDroppedActions[1].debuggingName.startsWith("eH: handler"))
+    assertTrue(capturedDroppedActions[0].debuggingName.startsWith("handler"))
+    assertTrue(capturedDroppedActions[1].debuggingName.startsWith("handler"))
   }
 
   private class TestSession(override val sessionId: Long = 0) : WorkflowSession {

--- a/workflow-testing/src/test/java/com/squareup/workflow1/StatefulWorkflowEventHandlerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/StatefulWorkflowEventHandlerTest.kt
@@ -32,7 +32,7 @@ class StatefulWorkflowEventHandlerTest(
 
   @Test fun eventHandler0() {
     Workflow.stateful(Unit) {
-      eventHandler("", remember = remembering) { setOutput("yay") }
+      eventHandler("name", remember = remembering, key = "key") { setOutput("yay") }
     }.launchForTestingFromStartWith(
       testParams = WorkflowTestParams(runtimeConfig = runtimeConfig)
     ) {
@@ -50,7 +50,7 @@ class StatefulWorkflowEventHandlerTest(
 
   @Test fun eventHandler1() {
     Workflow.stateful<Unit, S, (S) -> Unit>(Unit) {
-      eventHandler("", remember = remembering) { e1 ->
+      eventHandler("name", remember = remembering, key = "key") { e1 ->
         setOutput(e1)
       }
     }.launchForTestingFromStartWith(
@@ -70,7 +70,7 @@ class StatefulWorkflowEventHandlerTest(
 
   @Test fun eventHandler2() {
     Workflow.stateful<Unit, S, (S, S) -> Unit>(Unit) {
-      eventHandler("", remember = remembering) { e1, e2 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2 ->
         setOutput("$e1-$e2")
       }
     }.launchForTestingFromStartWith(
@@ -90,7 +90,7 @@ class StatefulWorkflowEventHandlerTest(
 
   @Test fun eventHandler3() {
     Workflow.stateful<Unit, S, (S, S, S) -> Unit>(Unit) {
-      eventHandler("", remember = remembering) { e1, e2, e3 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2, e3 ->
         setOutput("$e1-$e2-$e3")
       }
     }.launchForTestingFromStartWith(
@@ -110,7 +110,7 @@ class StatefulWorkflowEventHandlerTest(
 
   @Test fun eventHandler4() {
     Workflow.stateful<Unit, S, (S, S, S, S) -> Unit>(Unit) {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2, e3, e4 ->
         setOutput("$e1-$e2-$e3-$e4")
       }
     }.launchForTestingFromStartWith(
@@ -130,7 +130,7 @@ class StatefulWorkflowEventHandlerTest(
 
   @Test fun eventHandler5() {
     Workflow.stateful<Unit, S, (S, S, S, S, S) -> Unit>(Unit) {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4, e5 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2, e3, e4, e5 ->
         setOutput("$e1-$e2-$e3-$e4-$e5")
       }
     }.launchForTestingFromStartWith(
@@ -150,7 +150,7 @@ class StatefulWorkflowEventHandlerTest(
 
   @Test fun eventHandler6() {
     Workflow.stateful<Unit, S, (S, S, S, S, S, S) -> Unit>(Unit) {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4, e5, e6 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2, e3, e4, e5, e6 ->
         setOutput("$e1-$e2-$e3-$e4-$e5-$e6")
       }
     }.launchForTestingFromStartWith(
@@ -170,7 +170,7 @@ class StatefulWorkflowEventHandlerTest(
 
   @Test fun eventHandler7() {
     Workflow.stateful<Unit, S, (S, S, S, S, S, S, S) -> Unit>(Unit) {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4, e5, e6, e7 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2, e3, e4, e5, e6, e7 ->
         setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7")
       }
     }.launchForTestingFromStartWith(
@@ -190,7 +190,7 @@ class StatefulWorkflowEventHandlerTest(
 
   @Test fun eventHandler8() {
     Workflow.stateful<Unit, S, (S, S, S, S, S, S, S, S) -> Unit>(Unit) {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4, e5, e6, e7, e8 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2, e3, e4, e5, e6, e7, e8 ->
         setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8")
       }
     }.launchForTestingFromStartWith(
@@ -210,7 +210,11 @@ class StatefulWorkflowEventHandlerTest(
 
   @Test fun eventHandler9() {
     Workflow.stateful<Unit, S, (S, S, S, S, S, S, S, S, S) -> Unit>(Unit) {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
+      eventHandler(
+        "name",
+        remember = remembering,
+        key = "key"
+      ) { e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
         setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8-$e9")
       }
     }.launchForTestingFromStartWith(
@@ -230,7 +234,11 @@ class StatefulWorkflowEventHandlerTest(
 
   @Test fun eventHandler10() {
     Workflow.stateful<Unit, S, (S, S, S, S, S, S, S, S, S, S) -> Unit>(Unit) {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
+      eventHandler(
+        "name",
+        remember = remembering,
+        key = "key"
+      ) { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
         setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8-$e9-$e10")
       }
     }.launchForTestingFromStartWith(

--- a/workflow-testing/src/test/java/com/squareup/workflow1/StatelessWorkflowEventHandlerTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/StatelessWorkflowEventHandlerTest.kt
@@ -32,7 +32,7 @@ class StatelessWorkflowEventHandlerTest(
 
   @Test fun eventHandler0() {
     Workflow.stateless<Unit, S, () -> Unit> {
-      eventHandler("", remember = remembering) { setOutput("yay") }
+      eventHandler("name", remember = remembering, key = "key") { setOutput("yay") }
     }.launchForTestingFromStartWith(
       testParams = WorkflowTestParams(runtimeConfig = runtimeConfig)
     ) {
@@ -50,7 +50,7 @@ class StatelessWorkflowEventHandlerTest(
 
   @Test fun eventHandler1() {
     Workflow.stateless<Unit, S, (S) -> Unit> {
-      eventHandler("", remember = remembering) { e1 ->
+      eventHandler("name", remember = remembering, key = "key") { e1 ->
         setOutput(e1)
       }
     }.launchForTestingFromStartWith(
@@ -70,7 +70,7 @@ class StatelessWorkflowEventHandlerTest(
 
   @Test fun eventHandler2() {
     Workflow.stateless<Unit, S, (S, S) -> Unit> {
-      eventHandler("", remember = remembering) { e1, e2 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2 ->
         setOutput("$e1-$e2")
       }
     }.launchForTestingFromStartWith(
@@ -90,7 +90,7 @@ class StatelessWorkflowEventHandlerTest(
 
   @Test fun eventHandler3() {
     Workflow.stateless<Unit, S, (S, S, S) -> Unit> {
-      eventHandler("", remember = remembering) { e1, e2, e3 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2, e3 ->
         setOutput("$e1-$e2-$e3")
       }
     }.launchForTestingFromStartWith(
@@ -110,7 +110,7 @@ class StatelessWorkflowEventHandlerTest(
 
   @Test fun eventHandler4() {
     Workflow.stateless<Unit, S, (S, S, S, S) -> Unit> {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2, e3, e4 ->
         setOutput("$e1-$e2-$e3-$e4")
       }
     }.launchForTestingFromStartWith(
@@ -130,7 +130,7 @@ class StatelessWorkflowEventHandlerTest(
 
   @Test fun eventHandler5() {
     Workflow.stateless<Unit, S, (S, S, S, S, S) -> Unit> {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4, e5 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2, e3, e4, e5 ->
         setOutput("$e1-$e2-$e3-$e4-$e5")
       }
     }.launchForTestingFromStartWith(
@@ -150,7 +150,7 @@ class StatelessWorkflowEventHandlerTest(
 
   @Test fun eventHandler6() {
     Workflow.stateless<Unit, S, (S, S, S, S, S, S) -> Unit> {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4, e5, e6 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2, e3, e4, e5, e6 ->
         setOutput("$e1-$e2-$e3-$e4-$e5-$e6")
       }
     }.launchForTestingFromStartWith(
@@ -170,7 +170,7 @@ class StatelessWorkflowEventHandlerTest(
 
   @Test fun eventHandler7() {
     Workflow.stateless<Unit, S, (S, S, S, S, S, S, S) -> Unit> {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4, e5, e6, e7 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2, e3, e4, e5, e6, e7 ->
         setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7")
       }
     }.launchForTestingFromStartWith(
@@ -190,7 +190,7 @@ class StatelessWorkflowEventHandlerTest(
 
   @Test fun eventHandler8() {
     Workflow.stateless<Unit, S, (S, S, S, S, S, S, S, S) -> Unit> {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4, e5, e6, e7, e8 ->
+      eventHandler("name", remember = remembering, key = "key") { e1, e2, e3, e4, e5, e6, e7, e8 ->
         setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8")
       }
     }.launchForTestingFromStartWith(
@@ -210,7 +210,11 @@ class StatelessWorkflowEventHandlerTest(
 
   @Test fun eventHandler9() {
     Workflow.stateless<Unit, S, (S, S, S, S, S, S, S, S, S) -> Unit> {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
+      eventHandler(
+        "name",
+        remember = remembering,
+        key = "key"
+      ) { e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
         setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8-$e9")
       }
     }.launchForTestingFromStartWith(
@@ -230,7 +234,11 @@ class StatelessWorkflowEventHandlerTest(
 
   @Test fun eventHandler10() {
     Workflow.stateless<Unit, S, (S, S, S, S, S, S, S, S, S, S) -> Unit> {
-      eventHandler("", remember = remembering) { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
+      eventHandler(
+        "name",
+        remember = remembering,
+        key = "key"
+      ) { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
         setOutput("$e1-$e2-$e3-$e4-$e5-$e6-$e7-$e8-$e9-$e10")
       }
     }.launchForTestingFromStartWith(


### PR DESCRIPTION
## Summary

- `eventHandler` now takes a `key` parameter (after `name`) used for `remember()`, while `name` is used for the action debug label — with the `"eH: "` prefix removed
- The public `eventHandler` overloads (0-arg and 1-arg) in `StatefulWorkflow.RenderContext` and `StatelessWorkflow.RenderContext` gain a `key: String = name` parameter.
- Motivation: when uniqueness requires adding dynamic content (e.g. an id or uuid) to the remember key, the debug name was previously polluted by that content. Now callers can set `key` and `name` independently — `key` gets the unique suffix, `name` stays readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)