### PR TITLE
Make renderForTest teardown waiting opt-in

### DIFF
--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowRuntimeTeardown.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowRuntimeTeardown.kt
@@ -9,11 +9,13 @@ import kotlin.time.Duration.Companion.seconds
 public sealed interface WorkflowRuntimeTeardown {
   /**
    * Cancel the workflow runtime and return without waiting for cancellation cleanup to complete.
+   * This is the default `renderForTest` behavior.
    */
   public data object Cancel : WorkflowRuntimeTeardown
 
   /**
-   * Cancel the workflow runtime and wait for cancellation cleanup to complete.
+   * Cancel the workflow runtime and wait for cancellation cleanup to complete. Pass this to
+   * `renderForTest` when a test needs to observe effects that happen during runtime cancellation.
    *
    * @param timeout The maximum time to wait for the runtime job to complete after cancellation.
    * @param drainSchedulerAfterCancel Whether to drain the test scheduler after cancelling the

--- a/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTurbine.kt
+++ b/workflow-testing/src/main/java/com/squareup/workflow1/testing/WorkflowTurbine.kt
@@ -47,9 +47,9 @@ import kotlin.time.Duration.Companion.milliseconds
  * A [testTimeout] may be specified to override the default [WORKFLOW_TEST_DEFAULT_TIMEOUT_MS] for
  * any particular test. This is the max amount of time the test could spend waiting on a rendering.
  *
- * [WorkflowRuntimeTeardown.CancelAndAwait] means `renderForTest` will not return until the workflow
- * runtime has been cancelled and cancellation cleanup has either completed or timed out. This is the
- * default so callers can run external teardown checks after this function returns.
+ * By default, `renderForTest` cancels the workflow runtime and returns without waiting for
+ * cancellation cleanup. Pass [WorkflowRuntimeTeardown.CancelAndAwait] to wait until cancellation
+ * cleanup has either completed or timed out.
  *
  * This will start the Workflow runtime (with params as passed) rooted at whatever Workflow
  * it is called on and then create a [WorkflowTurbine] for its renderings and run [testCase] on that.
@@ -63,7 +63,7 @@ public fun <PropsT, StateT, OutputT, RenderingT>
     props: StateFlow<PropsT>,
     testParams: WorkflowTestParams<StateT> = WorkflowTestParams(),
     coroutineContext: CoroutineContext = StandardTestDispatcher(),
-    teardown: WorkflowRuntimeTeardown = WorkflowRuntimeTeardown.CancelAndAwait(),
+    teardown: WorkflowRuntimeTeardown = WorkflowRuntimeTeardown.Cancel,
     onOutput: suspend (OutputT) -> Unit = {},
     testTimeout: Long = WORKFLOW_TEST_DEFAULT_TIMEOUT_MS,
     testCase: suspend WorkflowTurbine<RenderingT, OutputT>.() -> Unit
@@ -207,7 +207,7 @@ public fun <StateT, OutputT, RenderingT>
   StatefulWorkflow<Unit, StateT, OutputT, RenderingT>.renderForTest(
     testParams: WorkflowTestParams<StateT> = WorkflowTestParams(),
     coroutineContext: CoroutineContext = StandardTestDispatcher(),
-    teardown: WorkflowRuntimeTeardown = WorkflowRuntimeTeardown.CancelAndAwait(),
+    teardown: WorkflowRuntimeTeardown = WorkflowRuntimeTeardown.Cancel,
     onOutput: suspend (OutputT) -> Unit = {},
     testTimeout: Long = WORKFLOW_TEST_DEFAULT_TIMEOUT_MS,
     testCase: suspend WorkflowTurbine<RenderingT, OutputT>.() -> Unit
@@ -240,7 +240,7 @@ public fun <PropsT, OutputT, RenderingT> Workflow<PropsT, OutputT, RenderingT>.r
   testParams: WorkflowTestParams<Nothing> = WorkflowTestParams(),
   coroutineContext: CoroutineContext = StandardTestDispatcher(),
   interceptors: List<WorkflowInterceptor> = emptyList(),
-  teardown: WorkflowRuntimeTeardown = WorkflowRuntimeTeardown.CancelAndAwait(),
+  teardown: WorkflowRuntimeTeardown = WorkflowRuntimeTeardown.Cancel,
   onOutput: suspend (OutputT) -> Unit = {},
   testTimeout: Long = WORKFLOW_TEST_DEFAULT_TIMEOUT_MS,
   testCase: suspend WorkflowTurbine<RenderingT, OutputT>.() -> Unit
@@ -264,7 +264,7 @@ public fun <OutputT, RenderingT> Workflow<Unit, OutputT, RenderingT>.renderForTe
   coroutineContext: CoroutineContext = StandardTestDispatcher(),
   testParams: WorkflowTestParams<Nothing> = WorkflowTestParams(),
   interceptors: List<WorkflowInterceptor> = emptyList(),
-  teardown: WorkflowRuntimeTeardown = WorkflowRuntimeTeardown.CancelAndAwait(),
+  teardown: WorkflowRuntimeTeardown = WorkflowRuntimeTeardown.Cancel,
   onOutput: suspend (OutputT) -> Unit = {},
   testTimeout: Long = WORKFLOW_TEST_DEFAULT_TIMEOUT_MS,
   testCase: suspend WorkflowTurbine<RenderingT, OutputT>.() -> Unit
@@ -299,7 +299,7 @@ public fun <PropsT, StateT, OutputT, RenderingT>
     props: StateFlow<PropsT>,
     initialState: StateT,
     coroutineContext: CoroutineContext = StandardTestDispatcher(),
-    teardown: WorkflowRuntimeTeardown = WorkflowRuntimeTeardown.CancelAndAwait(),
+    teardown: WorkflowRuntimeTeardown = WorkflowRuntimeTeardown.Cancel,
     onOutput: suspend (OutputT) -> Unit = {},
     testTimeout: Long = WORKFLOW_TEST_DEFAULT_TIMEOUT_MS,
     testCase: suspend WorkflowTurbine<RenderingT, OutputT>.() -> Unit
@@ -329,7 +329,7 @@ public fun <StateT, OutputT, RenderingT>
   StatefulWorkflow<Unit, StateT, OutputT, RenderingT>.renderForTestFromStateWith(
     initialState: StateT,
     coroutineContext: CoroutineContext = StandardTestDispatcher(),
-    teardown: WorkflowRuntimeTeardown = WorkflowRuntimeTeardown.CancelAndAwait(),
+    teardown: WorkflowRuntimeTeardown = WorkflowRuntimeTeardown.Cancel,
     onOutput: suspend (OutputT) -> Unit = {},
     testTimeout: Long = WORKFLOW_TEST_DEFAULT_TIMEOUT_MS,
     testCase: suspend WorkflowTurbine<RenderingT, OutputT>.() -> Unit

--- a/workflow-testing/src/test/java/com/squareup/workflow1/testing/WorkflowTurbineTest.kt
+++ b/workflow-testing/src/test/java/com/squareup/workflow1/testing/WorkflowTurbineTest.kt
@@ -144,27 +144,7 @@ class WorkflowTurbineTest {
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
-  fun `default teardown waits for runtime cancellation cleanup`() {
-    val dispatcher = StandardTestDispatcher()
-    val cleanupStarted = CompletableDeferred<Unit>()
-    var cleanupFinished = false
-
-    workflowWithCancellationCleanup(cleanupStarted) {
-      delay(1)
-      cleanupFinished = true
-    }.renderForTest(
-      coroutineContext = dispatcher
-    ) {
-      cleanupStarted.await()
-      assertFalse(cleanupFinished)
-    }
-
-    assertTrue(cleanupFinished)
-  }
-
-  @OptIn(ExperimentalCoroutinesApi::class)
-  @Test
-  fun `cancel teardown returns without awaiting runtime cancellation cleanup`() {
+  fun `default teardown returns without awaiting runtime cancellation cleanup`() {
     val dispatcher = StandardTestDispatcher()
     val cleanupStarted = CompletableDeferred<Unit>()
     val cleanupCanFinish = CompletableDeferred<Unit>()
@@ -174,8 +154,7 @@ class WorkflowTurbineTest {
       cleanupCanFinish.await()
       cleanupFinished = true
     }.renderForTest(
-      coroutineContext = dispatcher,
-      teardown = WorkflowRuntimeTeardown.Cancel
+      coroutineContext = dispatcher
     ) {
       cleanupStarted.await()
     }
@@ -183,6 +162,27 @@ class WorkflowTurbineTest {
     assertFalse(cleanupFinished)
     cleanupCanFinish.complete(Unit)
     dispatcher.scheduler.advanceUntilIdle()
+    assertTrue(cleanupFinished)
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun `cancel and await teardown waits for runtime cancellation cleanup`() {
+    val dispatcher = StandardTestDispatcher()
+    val cleanupStarted = CompletableDeferred<Unit>()
+    var cleanupFinished = false
+
+    workflowWithCancellationCleanup(cleanupStarted) {
+      delay(1)
+      cleanupFinished = true
+    }.renderForTest(
+      coroutineContext = dispatcher,
+      teardown = WorkflowRuntimeTeardown.CancelAndAwait()
+    ) {
+      cleanupStarted.await()
+      assertFalse(cleanupFinished)
+    }
+
     assertTrue(cleanupFinished)
   }
 


### PR DESCRIPTION
We added the new `WorkflowRuntimeTeardown.CancelAndAwait()` option in 1.27 - but making it the default was a mistake. The plan `WorkflowRuntimeTeardown.Cancel` should be the default to keep tests as short as possible and to prevent the need to migrate/update any existing tests that rely on that behaviour.