### PR TITLE
Update JVM toolchain to JDK 21, target JVM 11

### DIFF
--- a/.github/actions/gradle-task-with-commit/action.yml
+++ b/.github/actions/gradle-task-with-commit/action.yml
@@ -4,7 +4,7 @@ description: This action performs a "fix"-type Gradle task and commits/pushes ch
 inputs:
   java-version:
     description: 'The Java version to set up'
-    default: '17'
+    default: '21'
   distribution:
     description: 'The JDK distribution to use'
     default: 'zulu'

--- a/.github/actions/gradle-task/action.yml
+++ b/.github/actions/gradle-task/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
   java-version:
     description: 'The Java version to set up.'
-    default: '17'
+    default: '21'
   distribution:
     description: 'The JDK distribution to use.'
     default: 'zulu'

--- a/.github/actions/gradle-tasks-with-emulator/action.yml
+++ b/.github/actions/gradle-tasks-with-emulator/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
   java-version:
     description: 'The Java version to set up.'
-    default: '17'
+    default: '21'
   distribution:
     description: 'The JDK distribution to use.'
     default: 'zulu'

--- a/artifacts.json
+++ b/artifacts.json
@@ -5,7 +5,7 @@
     "artifactId": "com.squareup.workflow1.ai-context.gradle.plugin",
     "description": "Workflow AI Context",
     "packaging": "pom",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "ai-contextPluginMarkerMaven"
   },
   {
@@ -14,7 +14,7 @@
     "artifactId": "workflow-ai-context",
     "description": "Workflow AI Context",
     "packaging": "jar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "pluginMaven"
   },
   {
@@ -23,7 +23,7 @@
     "artifactId": "workflow-core-iosarm64",
     "description": "Workflow Core",
     "packaging": "klib",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "iosArm64"
   },
   {
@@ -32,7 +32,7 @@
     "artifactId": "workflow-core-iossimulatorarm64",
     "description": "Workflow Core",
     "packaging": "klib",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "iosSimulatorArm64"
   },
   {
@@ -41,7 +41,7 @@
     "artifactId": "workflow-core-iosx64",
     "description": "Workflow Core",
     "packaging": "klib",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "iosX64"
   },
   {
@@ -50,7 +50,7 @@
     "artifactId": "workflow-core-js",
     "description": "Workflow Core",
     "packaging": "klib",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "js"
   },
   {
@@ -59,7 +59,7 @@
     "artifactId": "workflow-core-jvm",
     "description": "Workflow Core",
     "packaging": "jar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "jvm"
   },
   {
@@ -68,7 +68,7 @@
     "artifactId": "workflow-core",
     "description": "Workflow Core",
     "packaging": "jar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "kotlinMultiplatform"
   },
   {
@@ -77,7 +77,7 @@
     "artifactId": "workflow-runtime-android",
     "description": "Workflow Runtime",
     "packaging": "aar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "android"
   },
   {
@@ -86,7 +86,7 @@
     "artifactId": "workflow-runtime-iosarm64",
     "description": "Workflow Runtime",
     "packaging": "klib",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "iosArm64"
   },
   {
@@ -95,7 +95,7 @@
     "artifactId": "workflow-runtime-iossimulatorarm64",
     "description": "Workflow Runtime",
     "packaging": "klib",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "iosSimulatorArm64"
   },
   {
@@ -104,7 +104,7 @@
     "artifactId": "workflow-runtime-iosx64",
     "description": "Workflow Runtime",
     "packaging": "klib",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "iosX64"
   },
   {
@@ -113,7 +113,7 @@
     "artifactId": "workflow-runtime-js",
     "description": "Workflow Runtime",
     "packaging": "klib",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "js"
   },
   {
@@ -122,7 +122,7 @@
     "artifactId": "workflow-runtime-jvm",
     "description": "Workflow Runtime",
     "packaging": "jar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "jvm"
   },
   {
@@ -131,7 +131,7 @@
     "artifactId": "workflow-runtime",
     "description": "Workflow Runtime",
     "packaging": "jar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "kotlinMultiplatform"
   },
   {
@@ -140,7 +140,7 @@
     "artifactId": "workflow-rx2",
     "description": "Workflow RxJava2",
     "packaging": "jar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "maven"
   },
   {
@@ -149,7 +149,7 @@
     "artifactId": "workflow-testing-jvm",
     "description": "Workflow Testing",
     "packaging": "jar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "maven"
   },
   {
@@ -158,7 +158,7 @@
     "artifactId": "workflow-tracing",
     "description": "Workflow Tracing",
     "packaging": "aar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "maven"
   },
   {
@@ -167,7 +167,7 @@
     "artifactId": "workflow-tracing-papa",
     "description": "Workflow Tracing Papa",
     "packaging": "aar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "maven"
   },
   {
@@ -176,7 +176,7 @@
     "artifactId": "workflow-config-android",
     "description": "Workflow Runtime Android Configuration",
     "packaging": "aar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "maven"
   },
   {
@@ -185,7 +185,7 @@
     "artifactId": "workflow-config-jvm",
     "description": "Workflow Runtime JVM Configuration",
     "packaging": "jar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "maven"
   },
   {
@@ -194,7 +194,7 @@
     "artifactId": "workflow-ui-compose",
     "description": "Workflow UI Compose",
     "packaging": "aar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "maven"
   },
   {
@@ -203,7 +203,7 @@
     "artifactId": "workflow-ui-compose-tooling",
     "description": "Workflow UI Compose Tooling",
     "packaging": "aar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "maven"
   },
   {
@@ -212,7 +212,7 @@
     "artifactId": "workflow-ui-core-android",
     "description": "Workflow UI Android",
     "packaging": "aar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "maven"
   },
   {
@@ -221,7 +221,7 @@
     "artifactId": "workflow-ui-core-common-jvm",
     "description": "Workflow UI Core",
     "packaging": "jar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "maven"
   },
   {
@@ -230,7 +230,7 @@
     "artifactId": "workflow-ui-radiography",
     "description": "Workflow UI Radiography Support",
     "packaging": "aar",
-    "javaVersion": 21,
+    "javaVersion": 11,
     "publicationName": "maven"
   }
 ]

--- a/artifacts.json
+++ b/artifacts.json
@@ -5,7 +5,7 @@
     "artifactId": "com.squareup.workflow1.ai-context.gradle.plugin",
     "description": "Workflow AI Context",
     "packaging": "pom",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "ai-contextPluginMarkerMaven"
   },
   {
@@ -14,7 +14,7 @@
     "artifactId": "workflow-ai-context",
     "description": "Workflow AI Context",
     "packaging": "jar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "pluginMaven"
   },
   {
@@ -23,7 +23,7 @@
     "artifactId": "workflow-core-iosarm64",
     "description": "Workflow Core",
     "packaging": "klib",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "iosArm64"
   },
   {
@@ -32,7 +32,7 @@
     "artifactId": "workflow-core-iossimulatorarm64",
     "description": "Workflow Core",
     "packaging": "klib",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "iosSimulatorArm64"
   },
   {
@@ -41,7 +41,7 @@
     "artifactId": "workflow-core-iosx64",
     "description": "Workflow Core",
     "packaging": "klib",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "iosX64"
   },
   {
@@ -50,7 +50,7 @@
     "artifactId": "workflow-core-js",
     "description": "Workflow Core",
     "packaging": "klib",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "js"
   },
   {
@@ -59,7 +59,7 @@
     "artifactId": "workflow-core-jvm",
     "description": "Workflow Core",
     "packaging": "jar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "jvm"
   },
   {
@@ -68,7 +68,7 @@
     "artifactId": "workflow-core",
     "description": "Workflow Core",
     "packaging": "jar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "kotlinMultiplatform"
   },
   {
@@ -77,7 +77,7 @@
     "artifactId": "workflow-runtime-android",
     "description": "Workflow Runtime",
     "packaging": "aar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "android"
   },
   {
@@ -86,7 +86,7 @@
     "artifactId": "workflow-runtime-iosarm64",
     "description": "Workflow Runtime",
     "packaging": "klib",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "iosArm64"
   },
   {
@@ -95,7 +95,7 @@
     "artifactId": "workflow-runtime-iossimulatorarm64",
     "description": "Workflow Runtime",
     "packaging": "klib",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "iosSimulatorArm64"
   },
   {
@@ -104,7 +104,7 @@
     "artifactId": "workflow-runtime-iosx64",
     "description": "Workflow Runtime",
     "packaging": "klib",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "iosX64"
   },
   {
@@ -113,7 +113,7 @@
     "artifactId": "workflow-runtime-js",
     "description": "Workflow Runtime",
     "packaging": "klib",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "js"
   },
   {
@@ -122,7 +122,7 @@
     "artifactId": "workflow-runtime-jvm",
     "description": "Workflow Runtime",
     "packaging": "jar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "jvm"
   },
   {
@@ -131,7 +131,7 @@
     "artifactId": "workflow-runtime",
     "description": "Workflow Runtime",
     "packaging": "jar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "kotlinMultiplatform"
   },
   {
@@ -140,7 +140,7 @@
     "artifactId": "workflow-rx2",
     "description": "Workflow RxJava2",
     "packaging": "jar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "maven"
   },
   {
@@ -149,7 +149,7 @@
     "artifactId": "workflow-testing-jvm",
     "description": "Workflow Testing",
     "packaging": "jar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "maven"
   },
   {
@@ -158,7 +158,7 @@
     "artifactId": "workflow-tracing",
     "description": "Workflow Tracing",
     "packaging": "aar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "maven"
   },
   {
@@ -167,7 +167,7 @@
     "artifactId": "workflow-tracing-papa",
     "description": "Workflow Tracing Papa",
     "packaging": "aar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "maven"
   },
   {
@@ -176,7 +176,7 @@
     "artifactId": "workflow-config-android",
     "description": "Workflow Runtime Android Configuration",
     "packaging": "aar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "maven"
   },
   {
@@ -185,7 +185,7 @@
     "artifactId": "workflow-config-jvm",
     "description": "Workflow Runtime JVM Configuration",
     "packaging": "jar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "maven"
   },
   {
@@ -194,7 +194,7 @@
     "artifactId": "workflow-ui-compose",
     "description": "Workflow UI Compose",
     "packaging": "aar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "maven"
   },
   {
@@ -203,7 +203,7 @@
     "artifactId": "workflow-ui-compose-tooling",
     "description": "Workflow UI Compose Tooling",
     "packaging": "aar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "maven"
   },
   {
@@ -212,7 +212,7 @@
     "artifactId": "workflow-ui-core-android",
     "description": "Workflow UI Android",
     "packaging": "aar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "maven"
   },
   {
@@ -221,7 +221,7 @@
     "artifactId": "workflow-ui-core-common-jvm",
     "description": "Workflow UI Core",
     "packaging": "jar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "maven"
   },
   {
@@ -230,7 +230,7 @@
     "artifactId": "workflow-ui-radiography",
     "description": "Workflow UI Radiography Support",
     "packaging": "aar",
-    "javaVersion": 8,
+    "javaVersion": 21,
     "publicationName": "maven"
   }
 ]

--- a/benchmarks/dungeon-benchmark/build.gradle.kts
+++ b/benchmarks/dungeon-benchmark/build.gradle.kts
@@ -42,7 +42,7 @@ android {
 
 kotlin {
   compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_21)
+    jvmTarget.set(JvmTarget.JVM_11)
     freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
   }
 }

--- a/benchmarks/dungeon-benchmark/build.gradle.kts
+++ b/benchmarks/dungeon-benchmark/build.gradle.kts
@@ -42,7 +42,7 @@ android {
 
 kotlin {
   compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_1_8)
+    jvmTarget.set(JvmTarget.JVM_21)
     freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
   }
 }

--- a/benchmarks/performance-poetry/complex-benchmark/build.gradle.kts
+++ b/benchmarks/performance-poetry/complex-benchmark/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 
 kotlin {
   compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_21)
+    jvmTarget.set(JvmTarget.JVM_11)
     freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
   }
 }

--- a/benchmarks/performance-poetry/complex-benchmark/build.gradle.kts
+++ b/benchmarks/performance-poetry/complex-benchmark/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 
 kotlin {
   compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_1_8)
+    jvmTarget.set(JvmTarget.JVM_21)
     freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
   }
 }

--- a/benchmarks/performance-poetry/complex-poetry/build.gradle.kts
+++ b/benchmarks/performance-poetry/complex-poetry/build.gradle.kts
@@ -49,7 +49,7 @@ android {
 
 kotlin {
   compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_1_8)
+    jvmTarget.set(JvmTarget.JVM_21)
   }
 }
 

--- a/benchmarks/performance-poetry/complex-poetry/build.gradle.kts
+++ b/benchmarks/performance-poetry/complex-poetry/build.gradle.kts
@@ -49,7 +49,7 @@ android {
 
 kotlin {
   compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_21)
+    jvmTarget.set(JvmTarget.JVM_11)
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ compileSdk = "36"
 minSdk = "24"
 targetSdk = "33"
 
-jdk-target = "21"
+jdk-target = "11"
 jdk-toolchain = "21"
 
 androidx-activity = "1.8.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,8 @@ compileSdk = "36"
 minSdk = "24"
 targetSdk = "33"
 
-jdk-target = "1.8"
-jdk-toolchain = "17"
+jdk-target = "21"
+jdk-toolchain = "21"
 
 androidx-activity = "1.8.2"
 androidx-appcompat = "1.7.1"

--- a/samples/tutorial/build.gradle
+++ b/samples/tutorial/build.gradle
@@ -69,7 +69,7 @@ subprojects {
   plugins.withId("org.jetbrains.kotlin.android")  {
     java {
       toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
       }
     }
   }

--- a/samples/tutorial/tutorial-1-complete/build.gradle
+++ b/samples/tutorial/tutorial-1-complete/build.gradle
@@ -17,11 +17,11 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_21
-    targetCompatibility JavaVersion.VERSION_21
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
   }
   kotlinOptions {
-    jvmTarget = '21'
+    jvmTarget = '11'
   }
   namespace 'workflow.tutorial'
 }

--- a/samples/tutorial/tutorial-1-complete/build.gradle
+++ b/samples/tutorial/tutorial-1-complete/build.gradle
@@ -17,11 +17,11 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_17
-    targetCompatibility JavaVersion.VERSION_17
+    sourceCompatibility JavaVersion.VERSION_21
+    targetCompatibility JavaVersion.VERSION_21
   }
   kotlinOptions {
-    jvmTarget = '17'
+    jvmTarget = '21'
   }
   namespace 'workflow.tutorial'
 }

--- a/samples/tutorial/tutorial-2-complete/build.gradle
+++ b/samples/tutorial/tutorial-2-complete/build.gradle
@@ -17,11 +17,11 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_21
-    targetCompatibility JavaVersion.VERSION_21
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
   }
   kotlinOptions {
-    jvmTarget = '21'
+    jvmTarget = '11'
   }
   namespace 'workflow.tutorial'
 }

--- a/samples/tutorial/tutorial-2-complete/build.gradle
+++ b/samples/tutorial/tutorial-2-complete/build.gradle
@@ -17,11 +17,11 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_17
-    targetCompatibility JavaVersion.VERSION_17
+    sourceCompatibility JavaVersion.VERSION_21
+    targetCompatibility JavaVersion.VERSION_21
   }
   kotlinOptions {
-    jvmTarget = '17'
+    jvmTarget = '21'
   }
   namespace 'workflow.tutorial'
 }

--- a/samples/tutorial/tutorial-3-complete/build.gradle
+++ b/samples/tutorial/tutorial-3-complete/build.gradle
@@ -17,11 +17,11 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_21
-    targetCompatibility JavaVersion.VERSION_21
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
   }
   kotlinOptions {
-    jvmTarget = '21'
+    jvmTarget = '11'
   }
   namespace 'workflow.tutorial'
 }

--- a/samples/tutorial/tutorial-3-complete/build.gradle
+++ b/samples/tutorial/tutorial-3-complete/build.gradle
@@ -17,11 +17,11 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_17
-    targetCompatibility JavaVersion.VERSION_17
+    sourceCompatibility JavaVersion.VERSION_21
+    targetCompatibility JavaVersion.VERSION_21
   }
   kotlinOptions {
-    jvmTarget = '17'
+    jvmTarget = '21'
   }
   namespace 'workflow.tutorial'
 }

--- a/samples/tutorial/tutorial-4-complete/build.gradle
+++ b/samples/tutorial/tutorial-4-complete/build.gradle
@@ -17,11 +17,11 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_21
-    targetCompatibility JavaVersion.VERSION_21
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
   }
   kotlinOptions {
-    jvmTarget = '21'
+    jvmTarget = '11'
   }
   namespace 'workflow.tutorial'
 }

--- a/samples/tutorial/tutorial-4-complete/build.gradle
+++ b/samples/tutorial/tutorial-4-complete/build.gradle
@@ -17,11 +17,11 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_17
-    targetCompatibility JavaVersion.VERSION_17
+    sourceCompatibility JavaVersion.VERSION_21
+    targetCompatibility JavaVersion.VERSION_21
   }
   kotlinOptions {
-    jvmTarget = '17'
+    jvmTarget = '21'
   }
   namespace 'workflow.tutorial'
 }

--- a/samples/tutorial/tutorial-base/build.gradle
+++ b/samples/tutorial/tutorial-base/build.gradle
@@ -17,11 +17,11 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_21
-    targetCompatibility JavaVersion.VERSION_21
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
   }
   kotlinOptions {
-    jvmTarget = '21'
+    jvmTarget = '11'
   }
   namespace 'workflow.tutorial'
 }

--- a/samples/tutorial/tutorial-base/build.gradle
+++ b/samples/tutorial/tutorial-base/build.gradle
@@ -17,11 +17,11 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_17
-    targetCompatibility JavaVersion.VERSION_17
+    sourceCompatibility JavaVersion.VERSION_21
+    targetCompatibility JavaVersion.VERSION_21
   }
   kotlinOptions {
-    jvmTarget = '17'
+    jvmTarget = '21'
   }
   namespace 'workflow.tutorial'
 }

--- a/samples/tutorial/tutorial-final/build.gradle
+++ b/samples/tutorial/tutorial-final/build.gradle
@@ -17,11 +17,11 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_21
-    targetCompatibility JavaVersion.VERSION_21
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
   }
   kotlinOptions {
-    jvmTarget = '21'
+    jvmTarget = '11'
   }
   namespace 'workflow.tutorial'
 }

--- a/samples/tutorial/tutorial-final/build.gradle
+++ b/samples/tutorial/tutorial-final/build.gradle
@@ -17,11 +17,11 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_17
-    targetCompatibility JavaVersion.VERSION_17
+    sourceCompatibility JavaVersion.VERSION_21
+    targetCompatibility JavaVersion.VERSION_21
   }
   kotlinOptions {
-    jvmTarget = '17'
+    jvmTarget = '21'
   }
   namespace 'workflow.tutorial'
 }

--- a/samples/tutorial/tutorial-views/build.gradle
+++ b/samples/tutorial/tutorial-views/build.gradle
@@ -14,12 +14,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_21
-    targetCompatibility JavaVersion.VERSION_21
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
   }
 
   kotlinOptions {
-    jvmTarget = '21'
+    jvmTarget = '11'
   }
 
   buildFeatures {

--- a/samples/tutorial/tutorial-views/build.gradle
+++ b/samples/tutorial/tutorial-views/build.gradle
@@ -14,12 +14,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_17
-    targetCompatibility JavaVersion.VERSION_17
+    sourceCompatibility JavaVersion.VERSION_21
+    targetCompatibility JavaVersion.VERSION_21
   }
 
   kotlinOptions {
-    jvmTarget = '17'
+    jvmTarget = '21'
   }
 
   buildFeatures {

--- a/workflow-trace-viewer/build.gradle.kts
+++ b/workflow-trace-viewer/build.gradle.kts
@@ -73,6 +73,6 @@ tasks.named<Test>("jvmTest") {
 
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_11)
+    jvmTarget.set(JvmTarget.JVM_21)
   }
 }

--- a/workflow-trace-viewer/build.gradle.kts
+++ b/workflow-trace-viewer/build.gradle.kts
@@ -73,6 +73,6 @@ tasks.named<Test>("jvmTest") {
 
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_21)
+    jvmTarget.set(JvmTarget.JVM_11)
   }
 }


### PR DESCRIPTION
## Summary
Aligns the project with android-register's setup:
- **Toolchain (compile JDK)**: `17` → `21`
- **Bytecode target**: `1.8` → `11`

Specifically:
- `gradle/libs.versions.toml`: `jdk-toolchain` `17` → `21`, `jdk-target` `1.8` → `11`
- `.github/actions/*` composite actions: `java-version` default `17` → `21`
- Hardcoded JVM targets in benchmarks (`JVM_1_8` → `JVM_11`), tutorial samples (`VERSION_17`/`'17'` → `VERSION_11`/`'11'`)
- Trace viewer was already `JVM_11`, no change to bytecode target there
- Tutorial root `build.gradle`: toolchain bumped from `17` → `21`
- `artifacts.json`: `javaVersion` `8` → `11`

## Test plan
- [x] `:workflow-core:jvmJar` builds locally
- [x] `artifactsCheck` passes locally
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)