### PR TITLE
Add stale worker output diagnostics

### DIFF
--- a/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/RuntimeUpdateLogLine.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/RuntimeUpdateLogLine.kt
@@ -71,6 +71,60 @@ public class ActionDroppedLogLine(
 }
 
 /**
+ * The monitor saw a worker output action but did not see the corresponding output handler action
+ * before another runtime boundary was reached.
+ */
+internal class StaleWorkerOutputLogLine(
+  val pendingWorkerName: String,
+  val detectionPoint: String,
+  val nextActionName: String?,
+  val nextWorkflowName: String?,
+  val renderIncomingCauses: List<RenderCause>,
+  val previousRenderCause: RenderCause?,
+) : RuntimeUpdateLogLine {
+  override fun log(builder: StringBuilder) {
+    builder
+      .append("STALE WORKER OUTPUT: R(")
+      .append(pendingWorkerName)
+      .append(") at ")
+      .append(detectionPoint)
+
+    if (nextActionName != null || nextWorkflowName != null) {
+      builder.append(" before ")
+      nextActionName?.let {
+        builder
+          .append("A(")
+          .append(it)
+          .append(")")
+      }
+      nextWorkflowName?.let {
+        builder
+          .append("/W(")
+          .append(it)
+          .append(")")
+      }
+    }
+    builder.append('\n')
+
+    builder.append("  renderIncomingCauses = ")
+    if (renderIncomingCauses.isEmpty()) {
+      builder.append("(empty)")
+    } else {
+      renderIncomingCauses.forEachIndexed { index, cause ->
+        if (index > 0) builder.append(", ")
+        builder.append(cause)
+      }
+    }
+    builder.append('\n')
+
+    builder
+      .append("  previousRenderCause = ")
+      .append(previousRenderCause ?: "(none)")
+      .append('\n')
+  }
+}
+
+/**
  * The Workflow runtime has applied an action.
  */
 public class ActionAppliedLogLine(

--- a/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/WorkflowRuntimeMonitor.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/WorkflowRuntimeMonitor.kt
@@ -74,6 +74,24 @@ public class WorkflowRuntimeMonitor(
     runtimeUpdates.logUpdate(event)
   }
 
+  private fun logStaleWorkerOutput(
+    detectionPoint: String,
+    nextActionName: String? = null,
+    nextWorkflowName: String? = null,
+  ) {
+    val pendingWorkerName = workerIncomingName ?: return
+    runtimeUpdates.logUpdate(
+      StaleWorkerOutputLogLine(
+        pendingWorkerName = pendingWorkerName,
+        detectionPoint = detectionPoint,
+        nextActionName = nextActionName,
+        nextWorkflowName = nextWorkflowName,
+        renderIncomingCauses = renderIncomingCauses.toList(),
+        previousRenderCause = previousRenderCause,
+      )
+    )
+  }
+
   /**
    * Called the first time any Workflow is rendered - which starts its 'session'.
    * @see [WorkflowSession] for more information on the lifecycle of a session.
@@ -306,11 +324,13 @@ public class WorkflowRuntimeMonitor(
       }
 
       RuntimeSettled -> {
+        logStaleWorkerOutput(detectionPoint = "RuntimeSettled")
         runtimeLoopListener?.onRuntimeLoopSettled(
           configSnapshot,
           runtimeUpdates
         )
         currentActionHandlingChangedState = false
+        workerIncomingName = null
         renderIncomingCauses.clear()
       }
     }
@@ -419,8 +439,17 @@ public class WorkflowRuntimeMonitor(
         // This is non-null when we are applying the action from the Worker Output handler, in that
         // case it is equal to the name of the underlying Worker workflow, which is the type of the
         // worker.
-        val workerLogName: String? = workerIncomingName
+        var workerLogName: String? = workerIncomingName
         if (actionType is QueuedAction) {
+          if (workerIncomingName != null) {
+            logStaleWorkerOutput(
+              detectionPoint = "QueuedAction",
+              nextActionName = actionName,
+              nextWorkflowName = workflowName,
+            )
+            workerIncomingName = null
+            workerLogName = null
+          }
           val newRenderingCause: RenderCause = if (isWorkerQueuedAction) {
             workerIncomingName = workflowName
             WaitingForOutput(workflowName)
@@ -433,9 +462,12 @@ public class WorkflowRuntimeMonitor(
           workerIncomingName != null
         ) {
           // WaitingForOutput should be the last cause added.
+          val renderIncomingCausesSnapshot = renderIncomingCauses.toList()
           val lastCause = renderIncomingCauses.removeLastOrNull()
-          check(lastCause!! is WaitingForOutput) {
-            "Expecting to receive action handling for worker output. Instead $lastCause."
+          check(lastCause is WaitingForOutput) {
+            "Expecting to receive action handling for worker output. Instead $lastCause. " +
+              "pendingWorker=$workerIncomingName, action=A($actionName)/W($workflowName), " +
+              "renderIncomingCauses=$renderIncomingCausesSnapshot"
           }
           // This is the real output handler action from the runningWorker call, thus the more
           // 'recognizable' cause of the render pass.

--- a/workflow-tracing/src/test/java/com/squareup/workflow1/tracing/WorkflowRuntimeMonitorTest.kt
+++ b/workflow-tracing/src/test/java/com/squareup/workflow1/tracing/WorkflowRuntimeMonitorTest.kt
@@ -17,6 +17,7 @@ import com.squareup.workflow1.WorkflowInterceptor.RenderingProduced
 import com.squareup.workflow1.WorkflowInterceptor.RuntimeSettled
 import com.squareup.workflow1.WorkflowInterceptor.RuntimeUpdate
 import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
+import com.squareup.workflow1.applyTo
 import com.squareup.workflow1.identifier
 import com.squareup.workflow1.tracing.RenderCause.RootCreation
 import com.squareup.workflow1.tracing.RenderCause.RootPropsChanged
@@ -316,6 +317,59 @@ internal class WorkflowRuntimeMonitorTest {
     assertTrue(fakeRuntimeTracer.onRuntimeUpdateEnhancedCalled)
     assertTrue(fakeRuntimeLoopListener.onRuntimeLoopSettledCalled)
     assertTrue(monitor.renderIncomingCauses.isEmpty())
+  }
+
+  @Test
+  fun `RuntimeSettled logs and clears stale worker output`() {
+    val runtimeListener = TestWorkflowRuntimeLoopListener()
+    val monitor = WorkflowRuntimeMonitor(
+      runtimeName = runtimeName,
+      runtimeLoopListener = runtimeListener
+    )
+    val testWorkflow = TestWorkflow()
+    val rootSession = testWorkflow.createRootSession()
+    val interceptor = monitor.createMonitoringInterceptor(rootSession)
+
+    interceptor.queuedAction("EmitWorkerOutputAction(worker=test, key=test)")
+      .applyTo("props", "state")
+
+    monitor.onRuntimeUpdate(RuntimeSettled)
+
+    val staleLogLines =
+      runtimeListener.runtimeUpdatesReceived!!.readAndClear()
+        .filterIsInstance<StaleWorkerOutputLogLine>()
+    assertEquals(1, staleLogLines.size)
+    assertEquals("RuntimeSettled", staleLogLines.single().detectionPoint)
+    assertTrue(staleLogLines.single().renderIncomingCauses.single() is RenderCause.WaitingForOutput)
+
+    interceptor.queuedAction("callbackAction").applyTo("props", "state")
+    interceptor.cascadeAction(testWorkflow, "parentHandler").applyTo("props", "state")
+  }
+
+  @Test
+  fun `queued callback logs and clears stale worker output`() {
+    val runtimeListener = TestWorkflowRuntimeLoopListener()
+    val monitor = WorkflowRuntimeMonitor(
+      runtimeName = runtimeName,
+      runtimeLoopListener = runtimeListener
+    )
+    val testWorkflow = TestWorkflow()
+    val rootSession = testWorkflow.createRootSession()
+    val interceptor = monitor.createMonitoringInterceptor(rootSession)
+
+    interceptor.queuedAction("EmitWorkerOutputAction(worker=test, key=test)")
+      .applyTo("props", "state")
+    interceptor.queuedAction("callbackAction").applyTo("props", "state")
+    interceptor.cascadeAction(testWorkflow, "parentHandler").applyTo("props", "state")
+    monitor.onRuntimeUpdate(RuntimeSettled)
+
+    val staleLogLines =
+      runtimeListener.runtimeUpdatesReceived!!.readAndClear()
+        .filterIsInstance<StaleWorkerOutputLogLine>()
+    assertEquals(1, staleLogLines.size)
+    assertEquals("QueuedAction", staleLogLines.single().detectionPoint)
+    assertEquals("callbackAction", staleLogLines.single().nextActionName)
+    assertTrue(staleLogLines.single().renderIncomingCauses.single() is RenderCause.WaitingForOutput)
   }
 
   @Test
@@ -841,6 +895,57 @@ internal class WorkflowRuntimeMonitorTest {
     assertEquals("firstAction", droppedLogLines[0].actionName)
     assertEquals("secondAction", droppedLogLines[1].actionName)
     assertEquals("thirdAction", droppedLogLines[2].actionName)
+  }
+
+  private fun WorkflowRuntimeMonitor.createMonitoringInterceptor(
+    rootSession: WorkflowSession
+  ): RenderContextInterceptor<String, String, String> {
+    val testScope = TestScope()
+
+    onSessionStarted(testScope, rootSession)
+    currentRenderCause = RootCreation(runtimeName, "TestWorkflow")
+
+    lateinit var interceptor: RenderContextInterceptor<String, String, String>
+    onRender(
+      renderProps = "props",
+      renderState = "state",
+      context = TestBaseRenderContext(),
+      proceed = { _, _, receivedInterceptor ->
+        interceptor = receivedInterceptor!!
+        "rendered"
+      },
+      session = rootSession
+    )
+    renderIncomingCauses.clear()
+    return interceptor
+  }
+
+  private fun RenderContextInterceptor<String, String, String>.queuedAction(
+    actionName: String
+  ): WorkflowAction<String, String, String> {
+    lateinit var interceptedAction: WorkflowAction<String, String, String>
+    onActionSent(TestAction(actionName)) { action ->
+      interceptedAction = action
+    }
+    return interceptedAction
+  }
+
+  private fun RenderContextInterceptor<String, String, String>.cascadeAction(
+    testWorkflow: TestWorkflow,
+    actionName: String
+  ): WorkflowAction<String, String, String> {
+    lateinit var interceptedAction: WorkflowAction<String, String, String>
+    onRenderChild(
+      child = testWorkflow,
+      childProps = "childProps",
+      key = "child",
+      handler = { TestAction(actionName) },
+      proceed = { _, _, _, handler ->
+        interceptedAction = handler("childOutput")
+        "childRendering"
+      }
+    )
+    return interceptedAction
   }
 
   // Test helper classes


### PR DESCRIPTION
Adds diagnostics for rare `WorkflowRuntimeMonitor` cases where a worker output is observed but the expected synchronous output-handler cascade is not seen before another runtime boundary.

## Details

- Logs a `STALE WORKER OUTPUT` runtime update when pending worker output state is still present at `RuntimeSettled`.
- Logs and clears stale worker output state before processing a new queued action, so a later callback does not get misclassified as the missing worker cascade.
- Enriches the remaining invariant failure message with the pending worker, current action, and render incoming causes.
- Adds regression coverage for stale state cleared at settlement and stale state cleared before a later queued callback.