### PR TITLE
Fix AGENTS.md eventHandler example to use `state` not `renderState`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ required `name` parameter:
 override fun render(renderProps: MyProps, renderState: MyState, context: RenderContext): MyScreen {
   return MyScreen(
     onClicked = context.eventHandler("onClicked") {
-      state = renderState.copy(loading = true)
+      state = state.copy(loading = true)
     },
     onItemSelected = context.eventHandler("onItemSelected") { item: Item ->
       setOutput(MyOutput.Selected(item))

--- a/samples/tutorial/AGENTS.md
+++ b/samples/tutorial/AGENTS.md
@@ -119,7 +119,7 @@ required `name` parameter:
 override fun render(renderProps: MyProps, renderState: MyState, context: RenderContext): MyScreen {
   return MyScreen(
     onClicked = context.eventHandler("onClicked") {
-      state = renderState.copy(loading = true)
+      state = state.copy(loading = true)
     },
     onItemSelected = context.eventHandler("onItemSelected") { item: Item ->
       setOutput(MyOutput.Selected(item))


### PR DESCRIPTION
## Summary

The Event Handling code snippet in `AGENTS.md` directly contradicts Common Pitfall #1 in the same document. The snippet captures `renderState.copy(...)` inside an `eventHandler` lambda — which Pitfall #1 explicitly calls out as the most common and dangerous mistake, because `renderState` is a snapshot from render time and may be stale by the time the handler fires.

This PR changes the example to read from `state` on the `Updater` receiver, matching the "GOOD" example in the pitfall section.

```diff
 onClicked = context.eventHandler("onClicked") {
-  state = renderState.copy(loading = true)
+  state = state.copy(loading = true)
 },
```

Applied to both the canonical root `AGENTS.md` (which is bundled into the published JAR via `META-INF/com.squareup.workflow1/AGENTS.md`) and the already-injected copy in `samples/tutorial/AGENTS.md`.

## Test plan

- [x] Visually verify the Event Handling snippet now matches the "GOOD" pattern in the Common Pitfalls section