### PR TITLE
Add configurable workflow runtime log limits

### DIFF
--- a/workflow-tracing/api/workflow-tracing.api
+++ b/workflow-tracing/api/workflow-tracing.api
@@ -173,12 +173,17 @@ public abstract interface class com/squareup/workflow1/tracing/WorkflowRuntimeLo
 }
 
 public final class com/squareup/workflow1/tracing/WorkflowRuntimeMonitor : com/squareup/workflow1/WorkflowInterceptor, com/squareup/workflow1/tracing/RuntimeTraceContext {
+	public static final field Companion Lcom/squareup/workflow1/tracing/WorkflowRuntimeMonitor$Companion;
+	public static final field DEFAULT_MAX_LOG_LINE_LENGTH I
 	public field configSnapshot Lcom/squareup/workflow1/tracing/ConfigSnapshot;
 	public fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/squareup/workflow1/tracing/WorkflowRenderPassTracker;Lcom/squareup/workflow1/tracing/WorkflowRuntimeLoopListener;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/squareup/workflow1/tracing/WorkflowRenderPassTracker;Lcom/squareup/workflow1/tracing/WorkflowRuntimeLoopListener;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/squareup/workflow1/tracing/WorkflowRenderPassTracker;Lcom/squareup/workflow1/tracing/WorkflowRuntimeLoopListener;IZ)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/squareup/workflow1/tracing/WorkflowRenderPassTracker;Lcom/squareup/workflow1/tracing/WorkflowRuntimeLoopListener;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addRuntimeUpdate (Lcom/squareup/workflow1/tracing/RuntimeUpdateLogLine;)V
 	public fun getConfigSnapshot ()Lcom/squareup/workflow1/tracing/ConfigSnapshot;
+	public final fun getCrashOnLogLineOverflow ()Z
 	public fun getCurrentRenderCause ()Lcom/squareup/workflow1/tracing/RenderCause;
+	public final fun getMaxLogLineLength ()I
 	public fun getPreviousRenderCause ()Lcom/squareup/workflow1/tracing/RenderCause;
 	public fun getRenderIncomingCauses ()Ljava/util/List;
 	public fun getRuntimeName ()Ljava/lang/String;
@@ -210,6 +215,9 @@ public final class com/squareup/workflow1/tracing/WorkflowRuntimeMonitor$ActionT
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow1/tracing/WorkflowRuntimeMonitor$Companion {
 }
 
 public abstract class com/squareup/workflow1/tracing/WorkflowRuntimeTracer : com/squareup/workflow1/WorkflowInterceptor {

--- a/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/RuntimeLoggingUtils.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/RuntimeLoggingUtils.kt
@@ -158,6 +158,57 @@ public fun String.wfEllipsizeEnd(maxLength: Int): String {
   }
 }
 
+internal fun StringBuilder.appendWfLogString(
+  log: Any?,
+  maxLength: Int,
+) {
+  require(maxLength > 0)
+  append(getWfLogString(log).wfEllipsizeEnd(maxLength))
+}
+
+internal fun StringBuilder.wfEllipsizeEndInPlace(
+  startIndex: Int,
+  maxLength: Int,
+) {
+  require(maxLength > 0)
+  require(startIndex >= 0 && startIndex <= length)
+
+  if (maxLength == Int.MAX_VALUE || length - startIndex <= maxLength) return
+
+  var endIndex = startIndex + maxLength - 1
+  while (endIndex > startIndex && this[endIndex - 1].isWhitespace()) {
+    endIndex--
+  }
+  setLength(endIndex)
+  append(Typography.ellipsis)
+}
+
+internal fun StringBuilder.wfEllipsizeEndInPlacePreservingFinalNewline(
+  startIndex: Int,
+  maxLength: Int,
+) {
+  require(maxLength > 0)
+  require(startIndex >= 0 && startIndex <= length)
+
+  if (maxLength == Int.MAX_VALUE || length - startIndex <= maxLength) return
+
+  val preserveFinalNewline = length > startIndex && this[length - 1] == '\n' && maxLength > 1
+  if (!preserveFinalNewline) {
+    wfEllipsizeEndInPlace(
+      startIndex = startIndex,
+      maxLength = maxLength
+    )
+    return
+  }
+
+  setLength(length - 1)
+  wfEllipsizeEndInPlace(
+    startIndex = startIndex,
+    maxLength = maxLength - 1
+  )
+  append('\n')
+}
+
 /**
  * Removes the string from kotlin.jvm.internal.Reflection#REFLECTION_NOT_AVAILABLE
  */

--- a/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/RuntimeUpdateLogLine.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/RuntimeUpdateLogLine.kt
@@ -20,19 +20,115 @@ public sealed interface RuntimeUpdateLogLine {
   fun log(builder: StringBuilder)
 }
 
+internal const val MAX_LOG_FIELD_LENGTH: Int = 1024
+
+internal fun RuntimeUpdateLogLine.withLogLimits(
+  maxLogLineLength: Int,
+  crashOnLogLineOverflow: Boolean,
+): RuntimeUpdateLogLine {
+  require(maxLogLineLength > 0)
+
+  return when (this) {
+    is UiUpdateLogLine -> copyWithLogLimits(maxLogLineLength, crashOnLogLineOverflow)
+    is ActionAppliedLogLine -> copyWithLogLimits(maxLogLineLength, crashOnLogLineOverflow)
+    is ActionDroppedLogLine -> copyWithLogLimits(maxLogLineLength, crashOnLogLineOverflow)
+    is StaleWorkerOutputLogLine -> copyWithLogLimits(maxLogLineLength, crashOnLogLineOverflow)
+    RenderLogLine,
+    SkipLogLine,
+    -> this
+  }
+}
+
+private data class LogLineLimits(
+  val maxLogLineLength: Int,
+  val crashOnLogLineOverflow: Boolean,
+)
+
+private val RuntimeUpdateLogLine.logLineType: String
+  get() = this::class.toWfLoggingName()
+
+private inline fun RuntimeUpdateLogLine.logWithLimits(
+  builder: StringBuilder,
+  logLineLimits: LogLineLimits?,
+  block: () -> Unit,
+) {
+  if (logLineLimits == null) {
+    block()
+    return
+  }
+
+  val lineStart = builder.length
+  block()
+  builder.enforceLogLineLimit(
+    lineStart = lineStart,
+    maxLogLineLength = logLineLimits.maxLogLineLength,
+    crashOnLogLineOverflow = logLineLimits.crashOnLogLineOverflow,
+    logLineType = logLineType
+  )
+}
+
+private fun StringBuilder.enforceLogLineLimit(
+  lineStart: Int,
+  maxLogLineLength: Int,
+  crashOnLogLineOverflow: Boolean,
+  logLineType: String,
+) {
+  val actualLength = length - lineStart
+  if (maxLogLineLength == Int.MAX_VALUE || actualLength <= maxLogLineLength) return
+
+  if (crashOnLogLineOverflow) {
+    setLength(lineStart)
+    throw logLineOverflowException(
+      logLineType = logLineType,
+      actualLength = actualLength.toLong(),
+      maxLogLineLength = maxLogLineLength
+    )
+  }
+  wfEllipsizeEndInPlacePreservingFinalNewline(
+    startIndex = lineStart,
+    maxLength = maxLogLineLength
+  )
+}
+
+private fun logLineOverflowException(
+  logLineType: String,
+  actualLength: Long,
+  maxLogLineLength: Int,
+): IllegalStateException {
+  return IllegalStateException(
+    "$logLineType exceeded maxLogLineLength=$maxLogLineLength with actualLength=$actualLength."
+  )
+}
+
 /**
  * The "UI" has updated, whatever that means for your app.
  * You must manually add this to the [WorkflowRuntimeMonitor]'s [RuntimeUpdates] by calling
  * [WorkflowRuntimeMonitor.addRuntimeUpdate].
  */
-public class UiUpdateLogLine(
-  val note: String
+public class UiUpdateLogLine private constructor(
+  val note: String,
+  private val logLineLimits: LogLineLimits?,
 ) : RuntimeUpdateLogLine {
+  public constructor(note: String) : this(
+    note = note,
+    logLineLimits = null
+  )
+
+  internal fun copyWithLogLimits(
+    maxLogLineLength: Int,
+    crashOnLogLineOverflow: Boolean,
+  ): UiUpdateLogLine = UiUpdateLogLine(
+    note = note,
+    logLineLimits = LogLineLimits(maxLogLineLength, crashOnLogLineOverflow)
+  )
+
   override fun log(builder: StringBuilder) {
-    builder
-      .append("UI UPDATE: ")
-      .append(note)
-      .append('\n')
+    logWithLimits(builder, logLineLimits) {
+      builder
+        .append("UI UPDATE: ")
+        .append(note)
+        .append('\n')
+    }
   }
 }
 
@@ -61,12 +157,29 @@ public data object SkipLogLine : RuntimeUpdateLogLine {
 /**
  * An action that was queued but got dropped because the Workflow session ended.
  */
-public class ActionDroppedLogLine(
+public class ActionDroppedLogLine private constructor(
   val actionName: String,
+  private val logLineLimits: LogLineLimits?,
 ) : RuntimeUpdateLogLine {
+  public constructor(actionName: String) : this(
+    actionName = actionName,
+    logLineLimits = null
+  )
+
+  internal fun copyWithLogLimits(
+    maxLogLineLength: Int,
+    crashOnLogLineOverflow: Boolean,
+  ): ActionDroppedLogLine = ActionDroppedLogLine(
+    actionName = actionName,
+    logLineLimits = LogLineLimits(maxLogLineLength, crashOnLogLineOverflow)
+  )
+
   override fun log(builder: StringBuilder) {
-    builder.append("DROPPED: $actionName")
-      .append('\n')
+    logWithLimits(builder, logLineLimits) {
+      builder.append("DROPPED: ")
+        .append(actionName)
+        .append('\n')
+    }
   }
 }
 
@@ -74,60 +187,93 @@ public class ActionDroppedLogLine(
  * The monitor saw a worker output action but did not see the corresponding output handler action
  * before another runtime boundary was reached.
  */
-internal class StaleWorkerOutputLogLine(
+internal class StaleWorkerOutputLogLine private constructor(
   val pendingWorkerName: String,
   val detectionPoint: String,
   val nextActionName: String?,
   val nextWorkflowName: String?,
   val renderIncomingCauses: List<RenderCause>,
   val previousRenderCause: RenderCause?,
+  private val logLineLimits: LogLineLimits?,
 ) : RuntimeUpdateLogLine {
+  constructor(
+    pendingWorkerName: String,
+    detectionPoint: String,
+    nextActionName: String?,
+    nextWorkflowName: String?,
+    renderIncomingCauses: List<RenderCause>,
+    previousRenderCause: RenderCause?,
+  ) : this(
+    pendingWorkerName = pendingWorkerName,
+    detectionPoint = detectionPoint,
+    nextActionName = nextActionName,
+    nextWorkflowName = nextWorkflowName,
+    renderIncomingCauses = renderIncomingCauses,
+    previousRenderCause = previousRenderCause,
+    logLineLimits = null
+  )
+
+  internal fun copyWithLogLimits(
+    maxLogLineLength: Int,
+    crashOnLogLineOverflow: Boolean,
+  ): StaleWorkerOutputLogLine = StaleWorkerOutputLogLine(
+    pendingWorkerName = pendingWorkerName,
+    detectionPoint = detectionPoint,
+    nextActionName = nextActionName,
+    nextWorkflowName = nextWorkflowName,
+    renderIncomingCauses = renderIncomingCauses,
+    previousRenderCause = previousRenderCause,
+    logLineLimits = LogLineLimits(maxLogLineLength, crashOnLogLineOverflow)
+  )
+
   override fun log(builder: StringBuilder) {
-    builder
-      .append("STALE WORKER OUTPUT: R(")
-      .append(pendingWorkerName)
-      .append(") at ")
-      .append(detectionPoint)
+    logWithLimits(builder, logLineLimits) {
+      builder
+        .append("STALE WORKER OUTPUT: R(")
+        .append(pendingWorkerName)
+        .append(") at ")
+        .append(detectionPoint)
 
-    if (nextActionName != null || nextWorkflowName != null) {
-      builder.append(" before ")
-      nextActionName?.let {
-        builder
-          .append("A(")
-          .append(it)
-          .append(")")
+      if (nextActionName != null || nextWorkflowName != null) {
+        builder.append(" before ")
+        nextActionName?.let {
+          builder
+            .append("A(")
+            .append(it)
+            .append(")")
+        }
+        nextWorkflowName?.let {
+          builder
+            .append("/W(")
+            .append(it)
+            .append(")")
+        }
       }
-      nextWorkflowName?.let {
-        builder
-          .append("/W(")
-          .append(it)
-          .append(")")
+      builder.append('\n')
+
+      builder.append("  renderIncomingCauses = ")
+      if (renderIncomingCauses.isEmpty()) {
+        builder.append("(empty)")
+      } else {
+        renderIncomingCauses.forEachIndexed { index, cause ->
+          if (index > 0) builder.append(", ")
+          builder.append(cause)
+        }
       }
+      builder.append('\n')
+
+      builder
+        .append("  previousRenderCause = ")
+        .append(previousRenderCause ?: "(none)")
+        .append('\n')
     }
-    builder.append('\n')
-
-    builder.append("  renderIncomingCauses = ")
-    if (renderIncomingCauses.isEmpty()) {
-      builder.append("(empty)")
-    } else {
-      renderIncomingCauses.forEachIndexed { index, cause ->
-        if (index > 0) builder.append(", ")
-        builder.append(cause)
-      }
-    }
-    builder.append('\n')
-
-    builder
-      .append("  previousRenderCause = ")
-      .append(previousRenderCause ?: "(none)")
-      .append('\n')
   }
 }
 
 /**
  * The Workflow runtime has applied an action.
  */
-public class ActionAppliedLogLine(
+public class ActionAppliedLogLine private constructor(
   val type: WorkflowActionLogType,
   val name: String,
   val actionName: String,
@@ -136,7 +282,43 @@ public class ActionAppliedLogLine(
   val newState: Any?,
   val outputOrNull: WorkflowOutput<*>?,
   val outputReceivedString: String?,
+  private val logLineLimits: LogLineLimits?,
 ) : RuntimeUpdateLogLine {
+  public constructor(
+    type: WorkflowActionLogType,
+    name: String,
+    actionName: String,
+    propsOrNull: Any?,
+    oldState: Any?,
+    newState: Any?,
+    outputOrNull: WorkflowOutput<*>?,
+    outputReceivedString: String?,
+  ) : this(
+    type = type,
+    name = name,
+    actionName = actionName,
+    propsOrNull = propsOrNull,
+    oldState = oldState,
+    newState = newState,
+    outputOrNull = outputOrNull,
+    outputReceivedString = outputReceivedString,
+    logLineLimits = null
+  )
+
+  internal fun copyWithLogLimits(
+    maxLogLineLength: Int,
+    crashOnLogLineOverflow: Boolean,
+  ): ActionAppliedLogLine = ActionAppliedLogLine(
+    type = type,
+    name = name,
+    actionName = actionName,
+    propsOrNull = propsOrNull,
+    oldState = oldState,
+    newState = newState,
+    outputOrNull = outputOrNull,
+    outputReceivedString = outputReceivedString,
+    logLineLimits = LogLineLimits(maxLogLineLength, crashOnLogLineOverflow)
+  )
 
   public enum class WorkflowActionLogType {
     RENDERING_CALLBACK,
@@ -145,53 +327,49 @@ public class ActionAppliedLogLine(
   }
 
   override fun log(builder: StringBuilder) {
-    val lineBuilder = StringBuilder().apply {
+    logWithLimits(builder, logLineLimits) {
       when (type) {
-        RENDERING_CALLBACK -> append("Rendering Callback: ")
-        WORKER_OUTPUT -> append("Worker Output: ")
-        CASCADE -> append("Cascade: ")
+        RENDERING_CALLBACK -> builder.append("Rendering Callback: ")
+        WORKER_OUTPUT -> builder.append("Worker Output: ")
+        CASCADE -> builder.append("Cascade: ")
       }
       if (outputReceivedString != null) {
-        append(outputReceivedString)
-        append(": ")
+        builder.append(outputReceivedString.wfEllipsizeEnd(MAX_LOG_FIELD_LENGTH))
+        builder.append(": ")
       }
       if (actionName.isNotBlank()) {
-        append("A(")
-        append(actionName)
-        append(")")
-        append("/")
+        builder.append("A(")
+        builder.append(actionName)
+        builder.append(")")
+        builder.append("/")
       }
-      append(name)
-      append(": ")
-      append(
-        if (outputOrNull != null) {
-          getWfLogString(outputOrNull.value)
-        } else {
-          "(no output)"
-        }
-      )
-      append('\n')
+      builder.append(name)
+      builder.append(": ")
+      if (outputOrNull != null) {
+        builder.appendWfLogString(outputOrNull.value, MAX_LOG_FIELD_LENGTH)
+      } else {
+        builder.append("(no output)")
+      }
+      builder.append('\n')
 
       propsOrNull?.let {
-        append("  props = ")
-        append(getWfLogString(it))
-        append('\n')
+        builder.append("  props = ")
+        builder.appendWfLogString(it, MAX_LOG_FIELD_LENGTH)
+        builder.append('\n')
       }
 
       if (oldState != newState) {
-        append("  oldState = ")
-        append(getWfLogString(oldState))
-        append('\n')
-        append("  newState = ")
-        append(getWfLogString(newState))
-        append('\n')
+        builder.append("  oldState = ")
+        builder.appendWfLogString(oldState, MAX_LOG_FIELD_LENGTH)
+        builder.append('\n')
+        builder.append("  newState = ")
+        builder.appendWfLogString(newState, MAX_LOG_FIELD_LENGTH)
+        builder.append('\n')
       } else {
-        append("  state = ")
-        append(getWfLogString(oldState))
-        append('\n')
+        builder.append("  state = ")
+        builder.appendWfLogString(oldState, MAX_LOG_FIELD_LENGTH)
+        builder.append('\n')
       }
     }
-
-    builder.append(lineBuilder)
   }
 }

--- a/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/WorkflowRuntimeLoopListener.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/WorkflowRuntimeLoopListener.kt
@@ -23,10 +23,22 @@ public fun interface WorkflowRuntimeLoopListener {
  * Simple wrapper object for a list of [RuntimeUpdateLogLine]s. This allows us to add updates
  * and provides a [readAndClear] API to clear the list after it is read.
  */
-public class RuntimeUpdates {
+public class RuntimeUpdates internal constructor(
+  private val maxLogLineLength: Int = WorkflowRuntimeMonitor.DEFAULT_MAX_LOG_LINE_LENGTH,
+  private val crashOnLogLineOverflow: Boolean = false,
+) {
+  init {
+    require(maxLogLineLength > 0) {
+      "maxLogLineLength must be greater than 0."
+    }
+  }
+
   private val updateLines = mutableListOf<RuntimeUpdateLogLine>()
   internal fun logUpdate(updateLine: RuntimeUpdateLogLine) {
-    updateLines += updateLine
+    updateLines += updateLine.withLogLimits(
+      maxLogLineLength = maxLogLineLength,
+      crashOnLogLineOverflow = crashOnLogLineOverflow
+    )
   }
 
   /**

--- a/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/WorkflowRuntimeMonitor.kt
+++ b/workflow-tracing/src/main/java/com/squareup/workflow1/tracing/WorkflowRuntimeMonitor.kt
@@ -47,7 +47,38 @@ public class WorkflowRuntimeMonitor(
   private val workflowRuntimeTracers: List<WorkflowRuntimeTracer> = emptyList(),
   private val renderPassTracker: WorkflowRenderPassTracker? = null,
   private val runtimeLoopListener: WorkflowRuntimeLoopListener? = null,
+  /**
+   * Maximum length for a single log line produced by [RuntimeUpdateLogLine.log].
+   * When a log line exceeds this length it will be truncated using [wfEllipsizeEnd].
+   * Set to [Int.MAX_VALUE] to disable truncation.
+   */
+  public val maxLogLineLength: Int = DEFAULT_MAX_LOG_LINE_LENGTH,
+  /**
+   * When true, throws an [IllegalStateException] if a log line exceeds [maxLogLineLength]
+   * instead of silently truncating.
+   */
+  public val crashOnLogLineOverflow: Boolean = false,
 ) : WorkflowInterceptor, RuntimeTraceContext {
+
+  public constructor(
+    runtimeName: String,
+    workflowRuntimeTracers: List<WorkflowRuntimeTracer>,
+    renderPassTracker: WorkflowRenderPassTracker?,
+    runtimeLoopListener: WorkflowRuntimeLoopListener?,
+  ) : this(
+    runtimeName = runtimeName,
+    workflowRuntimeTracers = workflowRuntimeTracers,
+    renderPassTracker = renderPassTracker,
+    runtimeLoopListener = runtimeLoopListener,
+    maxLogLineLength = DEFAULT_MAX_LOG_LINE_LENGTH,
+    crashOnLogLineOverflow = false
+  )
+
+  init {
+    require(maxLogLineLength > 0) {
+      "maxLogLineLength must be greater than 0."
+    }
+  }
 
   private val chainedWorkflowRuntimeTracer: WorkflowRuntimeTracer = workflowRuntimeTracers
     .chained().apply {
@@ -55,7 +86,10 @@ public class WorkflowRuntimeMonitor(
     }
 
   private var workerIncomingName: String? = null
-  private val runtimeUpdates = RuntimeUpdates()
+  private val runtimeUpdates = RuntimeUpdates(
+    maxLogLineLength = maxLogLineLength,
+    crashOnLogLineOverflow = crashOnLogLineOverflow
+  )
 
   private val rendering: Boolean
     get() = currentRenderCause != null
@@ -396,6 +430,7 @@ public class WorkflowRuntimeMonitor(
     ): CR {
       return proceed(child, childProps, key) { output ->
         val childOutputString = getWfLogString(output)
+          .wfEllipsizeEnd(MAX_LOG_FIELD_LENGTH)
         val delegateAction = handler(output)
         val actionName = delegateAction.toLoggingShortName()
         RuntimeMonitoringAction(
@@ -559,5 +594,9 @@ public class WorkflowRuntimeMonitor(
     public class CascadeAction(
       val childOutputString: String,
     ) : ActionType
+  }
+
+  public companion object {
+    public const val DEFAULT_MAX_LOG_LINE_LENGTH: Int = 4096
   }
 }

--- a/workflow-tracing/src/test/java/com/squareup/workflow1/tracing/WorkflowRuntimeMonitorTest.kt
+++ b/workflow-tracing/src/test/java/com/squareup/workflow1/tracing/WorkflowRuntimeMonitorTest.kt
@@ -17,8 +17,10 @@ import com.squareup.workflow1.WorkflowInterceptor.RenderingProduced
 import com.squareup.workflow1.WorkflowInterceptor.RuntimeSettled
 import com.squareup.workflow1.WorkflowInterceptor.RuntimeUpdate
 import com.squareup.workflow1.WorkflowInterceptor.WorkflowSession
+import com.squareup.workflow1.WorkflowOutput
 import com.squareup.workflow1.applyTo
 import com.squareup.workflow1.identifier
+import com.squareup.workflow1.tracing.ActionAppliedLogLine.WorkflowActionLogType.RENDERING_CALLBACK
 import com.squareup.workflow1.tracing.RenderCause.RootCreation
 import com.squareup.workflow1.tracing.RenderCause.RootPropsChanged
 import kotlinx.coroutines.CoroutineScope
@@ -31,6 +33,7 @@ import kotlin.reflect.KType
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -47,6 +50,11 @@ internal class WorkflowRuntimeMonitorTest {
     val monitor = WorkflowRuntimeMonitor(runtimeName)
     assertNotNull(monitor)
     assertEquals(runtimeName, monitor.runtimeName)
+    assertEquals(
+      WorkflowRuntimeMonitor.DEFAULT_MAX_LOG_LINE_LENGTH,
+      monitor.maxLogLineLength
+    )
+    assertFalse(monitor.crashOnLogLineOverflow)
   }
 
   @Test
@@ -55,10 +63,14 @@ internal class WorkflowRuntimeMonitorTest {
       runtimeName = runtimeName,
       workflowRuntimeTracers = listOf(fakeRuntimeTracer),
       renderPassTracker = fakeRenderPassTracker,
-      runtimeLoopListener = fakeRuntimeLoopListener
+      runtimeLoopListener = fakeRuntimeLoopListener,
+      maxLogLineLength = 2048,
+      crashOnLogLineOverflow = true
     )
     assertNotNull(monitor)
     assertEquals(runtimeName, monitor.runtimeName)
+    assertEquals(2048, monitor.maxLogLineLength)
+    assertTrue(monitor.crashOnLogLineOverflow)
   }
 
   @Test
@@ -411,7 +423,157 @@ internal class WorkflowRuntimeMonitorTest {
     monitor.addRuntimeUpdate(logLine)
     monitor.onRuntimeUpdate(RuntimeSettled)
 
-    assertContains(runtimeListener.runtimeUpdatesReceived!!.readAndClear(), logLine)
+    val received = runtimeListener.runtimeUpdatesReceived!!.readAndClear().single()
+    assertTrue(received is UiUpdateLogLine)
+    assertEquals(logLine.note, received.note)
+  }
+
+  @Test
+  fun `oversized runtime update log line is truncated when overflow crash is disabled`() {
+    val runtimeListener = TestWorkflowRuntimeLoopListener()
+    val monitor = WorkflowRuntimeMonitor(
+      runtimeName,
+      runtimeLoopListener = runtimeListener,
+      maxLogLineLength = 32,
+      crashOnLogLineOverflow = false
+    )
+    val testWorkflow = TestWorkflow()
+    val rootSession = testWorkflow.createRootSession()
+
+    monitor.onSessionStarted(TestScope(), rootSession)
+    monitor.addRuntimeUpdate(UiUpdateLogLine("x".repeat(128)))
+    monitor.onRuntimeUpdate(RuntimeSettled)
+
+    val logLine = runtimeListener.runtimeUpdatesReceived!!.readAndClear().single()
+    val builder = StringBuilder()
+
+    logLine.log(builder)
+
+    val log = builder.toString()
+    assertEquals(32, log.length)
+    assertTrue(log.startsWith("UI UPDATE: "))
+    assertTrue(log.endsWith("${Typography.ellipsis}\n"))
+  }
+
+  @Test
+  fun `configured log limits do not mutate added log lines`() {
+    val runtimeListener = TestWorkflowRuntimeLoopListener()
+    val monitor = WorkflowRuntimeMonitor(
+      runtimeName,
+      runtimeLoopListener = runtimeListener,
+      maxLogLineLength = 32,
+      crashOnLogLineOverflow = false
+    )
+    val testWorkflow = TestWorkflow()
+    val rootSession = testWorkflow.createRootSession()
+    val logLine = UiUpdateLogLine("x".repeat(128))
+
+    monitor.onSessionStarted(TestScope(), rootSession)
+    monitor.addRuntimeUpdate(logLine)
+    monitor.onRuntimeUpdate(RuntimeSettled)
+
+    val received = runtimeListener.runtimeUpdatesReceived!!.readAndClear().single()
+    val limitedBuilder = StringBuilder()
+    val originalBuilder = StringBuilder()
+
+    received.log(limitedBuilder)
+    logLine.log(originalBuilder)
+
+    assertEquals(32, limitedBuilder.length)
+    assertTrue(limitedBuilder.endsWith("${Typography.ellipsis}\n"))
+    assertTrue(originalBuilder.length > 32)
+    assertFalse(originalBuilder.endsWith("${Typography.ellipsis}\n"))
+  }
+
+  @Test
+  fun `fixed runtime update markers keep their concrete types under small limits`() {
+    val runtimeUpdates = RuntimeUpdates(
+      maxLogLineLength = 1,
+      crashOnLogLineOverflow = false
+    )
+
+    runtimeUpdates.logUpdate(RenderLogLine)
+    runtimeUpdates.logUpdate(SkipLogLine)
+
+    val updates = runtimeUpdates.readAndClear()
+    assertTrue(updates[0] is RenderLogLine)
+    assertTrue(updates[1] is SkipLogLine)
+  }
+
+  @Test
+  fun `oversized action log line is truncated with final newline preserved`() {
+    val logLine = ActionAppliedLogLine(
+      type = RENDERING_CALLBACK,
+      name = "W(TestWorkflow)",
+      actionName = "testAction",
+      propsOrNull = "props-" + "p".repeat(2048),
+      oldState = "old-" + "o".repeat(2048),
+      newState = "new-" + "n".repeat(2048),
+      outputOrNull = WorkflowOutput("output-" + "x".repeat(2048)),
+      outputReceivedString = null,
+    ).withLogLimits(
+      maxLogLineLength = 64,
+      crashOnLogLineOverflow = false
+    )
+    val builder = StringBuilder()
+
+    logLine.log(builder)
+
+    val log = builder.toString()
+    assertEquals(64, log.length)
+    assertTrue(log.endsWith("${Typography.ellipsis}\n"))
+  }
+
+  @Test
+  fun `oversized runtime update log line crashes when overflow crash is enabled`() {
+    val runtimeListener = TestWorkflowRuntimeLoopListener()
+    val monitor = WorkflowRuntimeMonitor(
+      runtimeName,
+      runtimeLoopListener = runtimeListener,
+      maxLogLineLength = 32,
+      crashOnLogLineOverflow = true
+    )
+    val testWorkflow = TestWorkflow()
+    val rootSession = testWorkflow.createRootSession()
+
+    monitor.onSessionStarted(TestScope(), rootSession)
+    monitor.addRuntimeUpdate(UiUpdateLogLine("x".repeat(128)))
+    monitor.onRuntimeUpdate(RuntimeSettled)
+
+    val logLine = runtimeListener.runtimeUpdatesReceived!!.readAndClear().single()
+
+    val error = assertFailsWith<IllegalStateException> {
+      logLine.log(StringBuilder())
+    }
+    assertContains(error.message!!, "UiUpdateLogLine")
+    assertContains(error.message!!, "maxLogLineLength=32")
+    assertContains(error.message!!, "actualLength=140")
+  }
+
+  @Test
+  fun `ActionAppliedLogLine truncates oversized output and state fields`() {
+    val oversizedOutput = "output-" + "o".repeat(2048)
+    val oversizedState = "state-" + "s".repeat(2048)
+    val stateLoggable = TestLoggable(oversizedState)
+    val logLine = ActionAppliedLogLine(
+      type = RENDERING_CALLBACK,
+      name = "W(TestWorkflow)",
+      actionName = "testAction",
+      propsOrNull = null,
+      oldState = stateLoggable,
+      newState = stateLoggable,
+      outputOrNull = WorkflowOutput(TestLoggable(oversizedOutput)),
+      outputReceivedString = null,
+    )
+    val builder = StringBuilder()
+
+    logLine.log(builder)
+
+    val log = builder.toString()
+    assertFalse(log.contains(oversizedOutput))
+    assertFalse(log.contains(oversizedState))
+    assertContains(log, oversizedOutput.wfEllipsizeEnd(1024))
+    assertContains(log, oversizedState.wfEllipsizeEnd(1024))
   }
 
   @Test
@@ -1050,6 +1212,12 @@ internal class WorkflowRuntimeMonitorTest {
     }
 
     override val debuggingName: String = name
+  }
+
+  private class TestLoggable(
+    private val value: String,
+  ) : Loggable {
+    override fun toLogString(): String = value
   }
 
   private class TestWorkflowRuntimeTracer : WorkflowRuntimeTracer() {


### PR DESCRIPTION
Adds configurable runtime log limits to `WorkflowRuntimeMonitor` so clients can cap breadcrumb log lines and optionally crash on overflow in debug builds.

This also bounds action-log fields to reduce oversized state/output logging risk, and preserves final newlines when truncating so consecutive runtime updates remain readable.