### PR TITLE
CLF-76 Fix docs markdown lint

### DIFF
--- a/workflow-ui/compose/README.md
+++ b/workflow-ui/compose/README.md
@@ -251,7 +251,7 @@ val contactUiFactory = ScreenComposableFactory<ContactScreen> { screen ->
 }
 ```
 
----
+----
 
 #### Previewing Compose-based (and non-Compose!) UI Factories
 


### PR DESCRIPTION
Fixes [CLF-76](https://linear.app/squareup/issue/CLF-76/fix-workflow-kotlin-docs-markdown-lint-failure).

PR #1517 exposed a main-head docs validation failure: `workflow-ui/compose/README.md` used one `---` divider while the rest of the file uses `----`.

This updates that divider so markdownlint `MD035` passes.
