### PR TITLE
Remove JS KMP cache restore

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -619,7 +619,6 @@ jobs:
         uses: ./.github/actions/gradle-task
         with:
           task: jsBrowserTest
-          restore-cache-key: main-build-artifacts
           failure-path-upload: '**/build/reports/tests/*[tT]est'
           failure-upload-name: 'kmp-js-unit-tests-report'
 


### PR DESCRIPTION
Removes the `main-build-artifacts` restore from `JS Unit Tests for KMP Modules` because the restored build output can make the JS/Karma test job fail on PRs even when the same branch passes locally.

Changes:
- run `jsBrowserTest` without restoring `main-build-artifacts`
- keep all other Kotlin CI jobs and cache behavior unchanged

<details><summary>Additional context</summary>

PR #1534 and #1535 both failed JS KMP in Actions with `SimpleLoggingWorkflowInterceptorTest` annotations. The exact #1534 branch passed locally. This PR first ran as a cache-disabled experiment on the same branch; with only the JS KMP restore removed, `JS Unit Tests for KMP Modules` passed: https://github.com/square/workflow-kotlin/actions/runs/27289772815/job/80606859887

</details>