### PR TITLE
Restore KeyedSavedStateRegistryOwners just in time, before consumers can see them [UISA-95]

### DIFF
--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/navigation/ViewStateCacheTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/navigation/ViewStateCacheTest.kt
@@ -85,10 +85,14 @@ internal class ViewStateCacheTest {
     firstView.viewState = "hello world"
 
     // Show the first screen.
-    cache.update(retainedRenderings = emptyList(), oldHolderMaybe = null, newHolder = firstView)
+    cache.updateOnMain(
+      retainedRenderings = emptyList(),
+      oldHolderMaybe = null,
+      newHolder = firstView
+    )
 
     // "Navigate" to the second screen, saving the first screen.
-    cache.update(
+    cache.updateOnMain(
       retainedRenderings = listOf(firstRendering),
       oldHolderMaybe = firstView,
       newHolder = secondView
@@ -99,7 +103,7 @@ internal class ViewStateCacheTest {
 
     // "Navigate" back to the first screen, restoring state.
     val firstViewRestored = createTestView(firstRendering, id = 1)
-    cache.update(listOf(), oldHolderMaybe = secondView, newHolder = firstViewRestored)
+    cache.updateOnMain(listOf(), oldHolderMaybe = secondView, newHolder = firstViewRestored)
 
     // Check that the state was restored.
     assertThat(firstViewRestored.viewState).isEqualTo("hello world")
@@ -117,10 +121,14 @@ internal class ViewStateCacheTest {
     firstView.viewState = "hello world"
 
     // Show the first screen.
-    cache.update(retainedRenderings = emptyList(), oldHolderMaybe = null, newHolder = firstView)
+    cache.updateOnMain(
+      retainedRenderings = emptyList(),
+      oldHolderMaybe = null,
+      newHolder = firstView
+    )
 
     // "Navigate" to the second screen, saving the first screen.
-    cache.update(
+    cache.updateOnMain(
       retainedRenderings = listOf(firstRendering),
       oldHolderMaybe = firstView,
       newHolder = secondView
@@ -130,7 +138,7 @@ internal class ViewStateCacheTest {
     val firstViewRestored = createTestView(firstRendering, id = 1, crashOnRestore = true)
     firstViewRestored.viewState = "should not be clobbered"
 
-    cache.update(listOf(), oldHolderMaybe = secondView, newHolder = firstViewRestored)
+    cache.updateOnMain(listOf(), oldHolderMaybe = secondView, newHolder = firstViewRestored)
     // We didn't crash, that's already a good sign.
 
     // Check that the "hard coded" view state is in tact due to the swallowed exception.
@@ -146,13 +154,17 @@ internal class ViewStateCacheTest {
     val secondView = createTestView(secondRendering)
 
     // Show the first screen.
-    cache.update(retainedRenderings = emptyList(), oldHolderMaybe = null, newHolder = firstView)
+    cache.updateOnMain(
+      retainedRenderings = emptyList(),
+      oldHolderMaybe = null,
+      newHolder = firstView
+    )
 
     // Set some state on the first view that will be saved.
     firstView.viewState = "hello world"
 
     // "Navigate" to the second screen, saving the first screen.
-    cache.update(
+    cache.updateOnMain(
       retainedRenderings = listOf(firstRendering),
       oldHolderMaybe = firstView,
       newHolder = secondView
@@ -170,7 +182,7 @@ internal class ViewStateCacheTest {
       ScreenViewHolder<NamedScreen<*>>(EMPTY, firstViewRestored) { _, _ -> }.also {
         it.show(firstRendering, viewEnvironment)
       }
-    cache.update(
+    cache.updateOnMain(
       listOf(firstRendering),
       oldHolderMaybe = secondView,
       newHolder = firstHolderRestored
@@ -191,17 +203,25 @@ internal class ViewStateCacheTest {
     firstView.viewState = "hello world"
 
     // Show the first screen.
-    cache.update(retainedRenderings = emptyList(), oldHolderMaybe = null, newHolder = firstView)
+    cache.updateOnMain(
+      retainedRenderings = emptyList(),
+      oldHolderMaybe = null,
+      newHolder = firstView
+    )
 
     // "Navigate" to the second screen, saving the first screen.
-    cache.update(listOf(firstRendering), oldHolderMaybe = firstView, newHolder = secondView)
+    cache.updateOnMain(listOf(firstRendering), oldHolderMaybe = firstView, newHolder = secondView)
 
     // Nothing should read this value again, but clear it to make sure.
     firstView.viewState = "ignored"
 
     // "Navigate" back to the first screen, restoring state.
     val firstViewRestored = createTestView(firstRendering)
-    cache.update(listOf(firstRendering), oldHolderMaybe = secondView, newHolder = firstViewRestored)
+    cache.updateOnMain(
+      listOf(firstRendering),
+      oldHolderMaybe = secondView,
+      newHolder = firstViewRestored
+    )
 
     // Check that the state was NOT restored.
     assertThat(firstViewRestored.viewState).isEqualTo("")
@@ -217,6 +237,22 @@ internal class ViewStateCacheTest {
       fail("Expected exception.")
     } catch (e: IllegalArgumentException) {
       assertThat(e.message).contains("Duplicate entries not allowed")
+    }
+  }
+
+  /**
+   * [ViewStateCache.update] installs a [com.squareup.workflow1.ui.androidx.KeyedSavedStateRegistryOwner]
+   * on the incoming view, which observes the view's lifecycle -- and
+   * [androidx.lifecycle.LifecycleRegistry] requires observers to be registered on the main
+   * thread, just as production callers (container views) always do.
+   */
+  private fun ViewStateCache.updateOnMain(
+    retainedRenderings: Collection<NamedScreen<*>>,
+    oldHolderMaybe: ScreenViewHolder<NamedScreen<*>>?,
+    newHolder: ScreenViewHolder<NamedScreen<*>>
+  ) {
+    instrumentation.runOnMainSync {
+      update(retainedRenderings, oldHolderMaybe, newHolder)
     }
   }
 

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/KeyedSavedStateRegistryOwner.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/KeyedSavedStateRegistryOwner.kt
@@ -1,6 +1,12 @@
 package com.squareup.workflow1.ui.androidx
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.Event.ON_CREATE
+import androidx.lifecycle.Lifecycle.Event.ON_DESTROY
+import androidx.lifecycle.Lifecycle.State.DESTROYED
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
 import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
@@ -18,17 +24,83 @@ import androidx.savedstate.findViewTreeSavedStateRegistryOwner
  *
  * To create an instance, call [WorkflowSavedStateRegistryAggregator.installChildRegistryOwnerOn].
  *
+ * ## Lifecycle
+ *
+ * This owner exposes its own [Lifecycle] rather than simply delegating to [lifecycleOwner]'s
+ * (typically the [WorkflowLifecycleOwner] of the view it is installed on). The local lifecycle
+ * mirrors [lifecycleOwner]'s, with one crucial difference: it is held at
+ * [INITIALIZED][Lifecycle.State.INITIALIZED] until this owner's [savedStateRegistry] has been
+ * restored, and only then advances.
+ *
+ * This enforces the androidx savedstate contract that a [SavedStateRegistry] is always restored
+ * before its owner's lifecycle moves to [CREATED][Lifecycle.State.CREATED]:
+ *
+ *  - [SavedStateRegistryController.performRestore] throws if the owner's lifecycle is at least
+ *    `STARTED`, so restoration stays legal no matter how far [lifecycleOwner]'s lifecycle has
+ *    advanced by the time the aggregator's state arrives.
+ *  - Consumers such as Compose UI's `DisposableSaveableStateRegistry` call
+ *    [SavedStateRegistry.consumeRestoredStateForKey], which throws if the registry has not been
+ *    restored. They are driven by lifecycle signals, so refusing to advance until restoration
+ *    makes it impossible for them to observe an unrestored registry.
+ *
+ * [WorkflowLifecycleOwner] lifecycles advance in a synchronous, depth-first cascade when a view
+ * tree attaches to a window. Observer dispatch order on those lifecycles depends on registration
+ * order, so a descendant's observers (e.g. a nested `ComposeView`'s composition) can run before
+ * the aggregator's own restoration observer ever fires. To close that race, when [lifecycleOwner]
+ * delivers `ON_CREATE` and this owner has not been restored yet, it synchronously asks the
+ * aggregator to restore it *now* via [onRestoreNeeded] — before the local lifecycle advances and
+ * any downstream consumer can see the registry. [installObserverOn] is called by the aggregator
+ * before the view can possibly attach, so this observer is always registered — and thus always
+ * dispatched — ahead of any consumer's.
+ *
  * @param key The key used to save and restore this controller from a [SavedStateRegistry].
- * @param lifecycleOwner The [LifecycleOwner] that will be delegated to by this instance.
- * (Required because [SavedStateRegistryOwner] extends [LifecycleOwner] for no clear reason.)
+ * @param lifecycleOwner The [LifecycleOwner] this owner's lifecycle follows. (Required because
+ * [SavedStateRegistryOwner] extends [LifecycleOwner] for no clear reason.)
+ * @param onRestoreNeeded Called at most once, when [lifecycleOwner]'s lifecycle is leaving
+ * `INITIALIZED` but this owner's registry has not been restored yet. The callee must restore
+ * [controller] (possibly with a null state) before returning.
  */
 internal class KeyedSavedStateRegistryOwner internal constructor(
   val key: String,
-  lifecycleOwner: LifecycleOwner
-) : SavedStateRegistryOwner, LifecycleOwner by lifecycleOwner {
+  private val lifecycleOwner: LifecycleOwner,
+  private val onRestoreNeeded: (KeyedSavedStateRegistryOwner) -> Unit
+) : SavedStateRegistryOwner {
+  private val localLifecycle = LifecycleRegistry(this)
+
+  override val lifecycle: Lifecycle get() = localLifecycle
+
   internal val controller: SavedStateRegistryController = SavedStateRegistryController.create(this)
   override val savedStateRegistry: SavedStateRegistry
     get() = controller.savedStateRegistry
+
+  private val lifecycleObserver = object : LifecycleEventObserver {
+    override fun onStateChanged(
+      source: LifecycleOwner,
+      event: Lifecycle.Event
+    ) {
+      // The delegate lifecycle is leaving INITIALIZED, so consumers keyed on our lifecycle are
+      // about to be able to read our registry. Restoration must happen first, and it is still
+      // legal because localLifecycle is INITIALIZED until we advance it below.
+      if (event == ON_CREATE && !savedStateRegistry.isRestored) {
+        onRestoreNeeded(this@KeyedSavedStateRegistryOwner)
+      }
+      localLifecycle.handleLifecycleEvent(event)
+      if (event == ON_DESTROY) {
+        source.lifecycle.removeObserver(this)
+      }
+    }
+  }
+
+  /**
+   * Starts mirroring [lifecycleOwner]'s lifecycle. Must be called after the aggregator has
+   * registered this owner, and before the view this owner is installed on can attach to a window.
+   */
+  internal fun installObserver() {
+    // A DESTROYED lifecycle will never advance, so nothing can ever legally consume this
+    // registry through lifecycle signals; observing would just throw.
+    if (lifecycleOwner.lifecycle.currentState == DESTROYED) return
+    lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
+  }
 
   override fun toString(): String {
     return "KeyedSavedStateRegistryOwner(key='$key', controller=$controller)"

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/KeyedSavedStateRegistryOwner.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/KeyedSavedStateRegistryOwner.kt
@@ -49,7 +49,7 @@ import androidx.savedstate.findViewTreeSavedStateRegistryOwner
  * the aggregator's own restoration observer ever fires. To close that race, when [lifecycleOwner]
  * delivers `ON_CREATE` and this owner has not been restored yet, it synchronously asks the
  * aggregator to restore it *now* via [onRestoreNeeded] — before the local lifecycle advances and
- * any downstream consumer can see the registry. [installObserverOn] is called by the aggregator
+ * any downstream consumer can see the registry. [installObserver] is called by the aggregator
  * before the view can possibly attach, so this observer is always registered — and thus always
  * dispatched — ahead of any consumer's.
  *
@@ -83,6 +83,9 @@ internal class KeyedSavedStateRegistryOwner internal constructor(
       // legal because localLifecycle is INITIALIZED until we advance it below.
       if (event == ON_CREATE && !savedStateRegistry.isRestored) {
         onRestoreNeeded(this@KeyedSavedStateRegistryOwner)
+        check(savedStateRegistry.isRestored) {
+          "onRestoreNeeded contract violation: registry for key '$key' was not restored"
+        }
       }
       localLifecycle.handleLifecycleEvent(event)
       if (event == ON_DESTROY) {

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/WorkflowSavedStateRegistryAggregator.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/WorkflowSavedStateRegistryAggregator.kt
@@ -1,6 +1,7 @@
 package com.squareup.workflow1.ui.androidx
 
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.lifecycle.Lifecycle.Event
 import androidx.lifecycle.Lifecycle.Event.ON_CREATE
@@ -297,6 +298,16 @@ public class WorkflowSavedStateRegistryAggregator {
       // savedstate contract is to restore it empty. Note that consuming from [states] here
       // would be wrong for a pruned child: its saved state must remain available for the
       // replacement view that will be installed under the same key.
+      val reason = if (states == null) {
+        "this aggregator (parent key '$parentKey') has not been restored yet"
+      } else {
+        "the child is no longer registered with this aggregator (already pruned?)"
+      }
+      Log.d(
+        "Workflow",
+        "WorkflowSavedStateRegistryAggregator restoring child '${child.key}' with no state " +
+          "because $reason. Any state saved under this key is not available."
+      )
       child.controller.performRestore(null)
     }
   }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/WorkflowSavedStateRegistryAggregator.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/androidx/WorkflowSavedStateRegistryAggregator.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.Lifecycle.Event
 import androidx.lifecycle.Lifecycle.Event.ON_CREATE
-import androidx.lifecycle.Lifecycle.State.INITIALIZED
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.findViewTreeLifecycleOwner
@@ -99,18 +98,23 @@ public class WorkflowSavedStateRegistryAggregator {
       // We don't care about the lifecycle anymore, we've got what we need.
       source.lifecycle.removeObserver(this)
 
-      val restoredState: Bundle?
-      try {
-        restoredState =
-          // These properties are guaranteed to be non-null because this observer is only registered
-          // while attached, and these properties are always non-null while attached.
-          parentRegistryOwner!!.savedStateRegistry.consumeRestoredStateForKey(parentKey!!)
-      } catch (e: IllegalStateException) {
-        // Exception thrown by SavedStateRegistryOwner is pretty useless.
-        throw IllegalStateException("Error consuming $parentKey from $parentRegistryOwner", e)
-          .withKey(parentKey.orEmpty())
-      }
-      restoreFromBundle(restoredState)
+      restoreFromBundle(consumeFromParent())
+    }
+  }
+
+  /**
+   * Consumes this aggregator's state from the attached parent registry. Only legal while
+   * attached and once the parent registry itself has been restored.
+   */
+  private fun consumeFromParent(): Bundle? {
+    return try {
+      // These properties are guaranteed to be non-null because this method is only called
+      // while attached, and these properties are always non-null while attached.
+      parentRegistryOwner!!.savedStateRegistry.consumeRestoredStateForKey(parentKey!!)
+    } catch (e: IllegalStateException) {
+      // Exception thrown by SavedStateRegistryOwner is pretty useless.
+      throw IllegalStateException("Error consuming $parentKey from $parentRegistryOwner", e)
+        .withKey(parentKey.orEmpty())
     }
   }
 
@@ -193,7 +197,9 @@ public class WorkflowSavedStateRegistryAggregator {
    * with its [LifecycleOwner]. (Use [WorkflowLifecycleOwner] to ensure
    * one is properly installed.)
    *
-   * **This method must be called before [view] is attached to a window.**
+   * **This method must be called on the main thread, before [view] is attached to a window.**
+   * (It observes [view]'s `ViewTreeLifecycleOwner` lifecycle, and
+   * [androidx.lifecycle.LifecycleRegistry] requires observer registration on the main thread.)
    *
    * Clean up requirements after making this call are nuanced. There is no need
    * to remove the [SavedStateRegistryOwner] from the [view] itself, but this
@@ -230,7 +236,7 @@ public class WorkflowSavedStateRegistryAggregator {
       "Expected $view($key) to have a ViewTreeLifecycleOwner. " +
         "Use WorkflowLifecycleOwner to fix that."
     }
-    val registryOwner = KeyedSavedStateRegistryOwner(key, lifecycleOwner)
+    val registryOwner = KeyedSavedStateRegistryOwner(key, lifecycleOwner, ::restoreChildNow)
     children.put(key, registryOwner)?.let {
       throw IllegalArgumentException("$key is already in use, it cannot be used to register $view")
         .withKey(key)
@@ -243,7 +249,56 @@ public class WorkflowSavedStateRegistryAggregator {
         ).withKey(key)
       }
     view.setViewTreeSavedStateRegistryOwner(registryOwner)
+    // Registered only after the child is in [children], so that if the lifecycle is already
+    // past INITIALIZED the resulting synchronous restoreChildNow call finds the child.
+    registryOwner.installObserver()
     restoreIfOwnerReady(registryOwner)
+  }
+
+  /**
+   * Called by a [child] whose lifecycle is about to leave `INITIALIZED` while its registry has
+   * not been restored yet. Restoration must happen now: as soon as the child's lifecycle moves,
+   * lifecycle-driven consumers (e.g. Compose UI's `DisposableSaveableStateRegistry`, created the
+   * moment a `ComposeView` under [child]'s view composes) will read the child's registry, and
+   * androidx throws if it is unrestored.
+   *
+   * This situation arises because [WorkflowLifecycleOwner] lifecycles advance in a synchronous
+   * depth-first cascade during window-attach, and lifecycle observer dispatch order follows
+   * registration order: a descendant's consumers can run before this aggregator's own
+   * [lifecycleObserver] receives the parent `ON_CREATE` that would normally have restored
+   * everything first (see https://github.com/square/workflow-kotlin/issues/570 and UISA-95).
+   *
+   * If this aggregator hasn't been restored yet, it first tries to restore itself synchronously
+   * from the parent registry. That is legal whenever the parent registry itself has been
+   * restored — [androidx.savedstate.SavedStateRegistry.consumeRestoredStateForKey] only requires
+   * the parent's *registry* to be restored, not its lifecycle to be `CREATED`. The parent is
+   * always restored by this point in practice: lifecycles advance strictly top-down, so every
+   * ancestor's lifecycle reached `CREATED` before [child]'s did, which (inductively, via this
+   * same mechanism one level up) restored every ancestor registry on the way down.
+   */
+  private fun restoreChildNow(child: KeyedSavedStateRegistryOwner) {
+    if (!isRestored && parentRegistryOwner?.savedStateRegistry?.isRestored == true) {
+      // Our own ON_CREATE observer hasn't fired yet, but the parent registry already has our
+      // state. Restore ourselves now instead of waiting out the rest of the dispatch cascade.
+      parentRegistryOwner?.lifecycle?.removeObserver(lifecycleObserver)
+      restoreFromBundle(consumeFromParent())
+    }
+
+    // restoreFromBundle above restores every unrestored child, including this one.
+    if (child.savedStateRegistry.isRestored) return
+
+    val states = states
+    if (states != null && children[child.key] === child) {
+      child.controller.performRestore(states.remove(child.key))
+    } else {
+      // Either this aggregator has no restored state to draw from (its own restoration is
+      // still pending), or the child has already been pruned. There is no state available for
+      // this child, and its lifecycle is advancing now, so the only way to uphold the
+      // savedstate contract is to restore it empty. Note that consuming from [states] here
+      // would be wrong for a pruned child: its saved state must remain available for the
+      // replacement view that will be installed under the same key.
+      child.controller.performRestore(null)
+    }
   }
 
   /**
@@ -277,6 +332,10 @@ public class WorkflowSavedStateRegistryAggregator {
   private fun restoreIfOwnerReady(
     child: KeyedSavedStateRegistryOwner
   ) {
+    // The child may already have been restored by restoreChildNow, if its lifecycle was
+    // already advancing when it was installed.
+    if (child.savedStateRegistry.isRestored) return
+
     doIfRestored { states ->
       val state = states.remove(child.key)
       child.controller.performRestore(state)
@@ -314,11 +373,9 @@ public class WorkflowSavedStateRegistryAggregator {
     restoredState?.keySet()?.forEach { key ->
       states!! += key to restoredState.getBundle(key)!!
     }
-    children.values.forEach {
-      // We're only allowed to restore from an INITIALIZED state, but this callback can also be
-      // invoked while the owner is already CREATED, at least on API 32.
-      // https://github.com/square/workflow-kotlin/issues/570
-      if (it.lifecycle.currentState == INITIALIZED) restoreIfOwnerReady(it)
-    }
+    // Any child whose lifecycle already advanced was restored at that moment by
+    // restoreChildNow; restoreIfOwnerReady skips those. Everything else is restored here.
+    // See https://github.com/square/workflow-kotlin/issues/570.
+    children.values.forEach { restoreIfOwnerReady(it) }
   }
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/navigation/ViewStateCache.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/navigation/ViewStateCache.kt
@@ -55,6 +55,11 @@ internal constructor(
   }
 
   /**
+   * **This method must be called on the main thread, before [newHolder]'s view is attached
+   * to a window.** It installs a [SavedStateRegistryOwner] on that view via
+   * [WorkflowSavedStateRegistryAggregator.installChildRegistryOwnerOn], which registers a
+   * lifecycle observer.
+   *
    * @param retainedRenderings the renderings to be considered hidden after this update. Any
    * associated view state will be retained in the cache, possibly to be restored to the view
    * of [newHolder] on a succeeding call to his method. Any other cached view state will be dropped.

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/androidx/KeyedSavedStateRegistryOwnerTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/androidx/KeyedSavedStateRegistryOwnerTest.kt
@@ -1,0 +1,38 @@
+package com.squareup.workflow1.ui.androidx
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.State.RESUMED
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertFailsWith
+
+@RunWith(RobolectricTestRunner::class)
+internal class KeyedSavedStateRegistryOwnerTest {
+
+  @Test fun `throws when onRestoreNeeded fails to restore the registry`() {
+    val delegateLifecycle = SimpleLifecycleOwner()
+    val owner = KeyedSavedStateRegistryOwner(
+      key = "childKey",
+      lifecycleOwner = delegateLifecycle,
+      // Broken callee: the contract requires restoring the controller before returning.
+      onRestoreNeeded = {}
+    )
+    owner.installObserver()
+
+    val error = assertFailsWith<IllegalStateException> {
+      delegateLifecycle.lifecycleRegistry.currentState = RESUMED
+    }
+    assertThat(error).hasMessageThat()
+      .contains("onRestoreNeeded contract violation: registry for key 'childKey' was not restored")
+  }
+
+  private class SimpleLifecycleOwner : LifecycleOwner {
+    val lifecycleRegistry = LifecycleRegistry(this)
+    override val lifecycle: Lifecycle
+      get() = lifecycleRegistry
+  }
+}

--- a/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/androidx/WorkflowSavedStateRegistryAggregatorTest.kt
+++ b/workflow-ui/core-android/src/test/java/com/squareup/workflow1/ui/androidx/WorkflowSavedStateRegistryAggregatorTest.kt
@@ -7,7 +7,9 @@ import androidx.activity.OnBackPressedDispatcherOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.Event.ON_CREATE
 import androidx.lifecycle.Lifecycle.State.RESUMED
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
@@ -316,6 +318,123 @@ internal class WorkflowSavedStateRegistryAggregatorTest {
     aggregator.detachFromParentRegistry()
   }
 
+  // https://github.com/square/workflow-kotlin/issues/570 / Compose 1.9.5 runDetachLifecycle
+  // teardown crash: WorkflowLifecycleOwner lifecycles advance in a depth-first cascade during
+  // window attach, so a child's lifecycle (and its lifecycle-driven consumers, like a nested
+  // ComposeView's composition) can advance before the aggregator's restore observer on the
+  // parent lifecycle ever fires. The child registry must nonetheless be restored -- with its
+  // real saved state -- by the time its lifecycle leaves INITIALIZED.
+  @Test fun `child advancing before parent ON_CREATE is restored just in time with saved state`() {
+    val aggregator = WorkflowSavedStateRegistryAggregator()
+    // Parent registry is restored (contains real state for our child), but its lifecycle is
+    // still INITIALIZED -- exactly the state observed in the failing scenario.
+    val parent = stateRegistryOf(
+      "parentKey" to bundleOf(
+        "childKey" to stateRegistryOf(
+          "key" to bundleOf("data" to "value")
+        ).saveToBundle()
+      )
+    )
+
+    val childLifecycle = SimpleLifecycleOwner()
+    val childView = View(ApplicationProvider.getApplicationContext()).apply {
+      setViewTreeLifecycleOwner(childLifecycle)
+    }
+    aggregator.installChildRegistryOwnerOn(childView, "childKey")
+    aggregator.attachToParentRegistry("parentKey", parent)
+    assertThat(childView.savedStateRegistry.isRestored).isFalse()
+
+    // Simulate the depth-first attach cascade reaching the child before the parent's own
+    // ON_CREATE dispatch reaches the aggregator's observer.
+    childLifecycle.lifecycleRegistry.currentState = RESUMED
+
+    val childOwner = childView.findViewTreeSavedStateRegistryOwner()!!
+    assertThat(childOwner.savedStateRegistry.isRestored).isTrue()
+    assertThat(childOwner.lifecycle.currentState).isEqualTo(RESUMED)
+    val childState = childOwner.savedStateRegistry.consumeRestoredStateForKey("key")!!
+    assertThat(childState.getString("data")).isEqualTo("value")
+  }
+
+  @Test fun `child owner lifecycle stays INITIALIZED until restored`() {
+    val aggregator = WorkflowSavedStateRegistryAggregator()
+    val parent = SimpleStateRegistry().apply {
+      stateRegistryController.performRestore(null)
+    }
+
+    val childLifecycle = SimpleLifecycleOwner()
+    val childView = View(ApplicationProvider.getApplicationContext()).apply {
+      setViewTreeLifecycleOwner(childLifecycle)
+    }
+    aggregator.installChildRegistryOwnerOn(childView, "childKey")
+    aggregator.attachToParentRegistry("parentKey", parent)
+
+    val childOwner = childView.findViewTreeSavedStateRegistryOwner()!!
+    assertThat(childOwner.lifecycle.currentState).isEqualTo(Lifecycle.State.INITIALIZED)
+
+    // Restoring the aggregator restores the child, but its lifecycle only follows its
+    // delegate's.
+    parent.lifecycleRegistry.currentState = RESUMED
+    assertThat(childOwner.savedStateRegistry.isRestored).isTrue()
+    assertThat(childOwner.lifecycle.currentState).isEqualTo(Lifecycle.State.INITIALIZED)
+
+    childLifecycle.lifecycleRegistry.currentState = RESUMED
+    assertThat(childOwner.lifecycle.currentState).isEqualTo(RESUMED)
+  }
+
+  @Test fun `child advancing with no attached parent restores empty without throwing`() {
+    val aggregator = WorkflowSavedStateRegistryAggregator()
+    val childLifecycle = SimpleLifecycleOwner()
+    val childView = View(ApplicationProvider.getApplicationContext()).apply {
+      setViewTreeLifecycleOwner(childLifecycle)
+    }
+    aggregator.installChildRegistryOwnerOn(childView, "childKey")
+
+    // There is nowhere to restore from, but the lifecycle is advancing now: the contract
+    // ("restored before CREATED") must still hold.
+    childLifecycle.lifecycleRegistry.currentState = RESUMED
+
+    val childOwner = childView.findViewTreeSavedStateRegistryOwner()!!
+    assertThat(childOwner.savedStateRegistry.isRestored).isTrue()
+    assertThat(childOwner.savedStateRegistry.consumeRestoredStateForKey("key")).isNull()
+    assertThat(childOwner.lifecycle.currentState).isEqualTo(RESUMED)
+  }
+
+  @Test fun `pruned child advancing late does not consume replacement's saved state`() {
+    val aggregator = WorkflowSavedStateRegistryAggregator()
+    val childALifecycle = SimpleLifecycleOwner()
+    val childViewA = View(ApplicationProvider.getApplicationContext()).apply {
+      setViewTreeLifecycleOwner(childALifecycle)
+    }
+    aggregator.installChildRegistryOwnerOn(childViewA, "childKey")
+    val childOwnerA = childViewA.findViewTreeSavedStateRegistryOwner()!!
+    aggregator.saveAndPruneChildRegistryOwner("childKey")
+
+    val childViewB = View(ApplicationProvider.getApplicationContext()).apply {
+      setViewTreeLifecycleOwner(SimpleLifecycleOwner())
+    }
+    aggregator.installChildRegistryOwnerOn(childViewB, "childKey")
+    val childOwnerB = childViewB.findViewTreeSavedStateRegistryOwner()!!
+
+    // The pruned child's lifecycle advances after its replacement was installed. It must be
+    // restored (to uphold the savedstate contract), but only ever empty -- the saved state
+    // under "childKey" belongs to its replacement.
+    childALifecycle.lifecycleRegistry.currentState = RESUMED
+    assertThat(childOwnerA.savedStateRegistry.isRestored).isTrue()
+
+    val parent = stateRegistryOf(
+      "parentKey" to bundleOf(
+        "childKey" to stateRegistryOf(
+          "key" to bundleOf("data" to "value")
+        ).saveToBundle()
+      )
+    )
+    aggregator.attachToParentRegistry("parentKey", parent)
+    parent.lifecycleRegistry.currentState = RESUMED
+
+    val childState = childOwnerB.savedStateRegistry.consumeRestoredStateForKey("key")!!
+    assertThat(childState.getString("data")).isEqualTo("value")
+  }
+
   /**
    * Creates a [SimpleStateRegistry] that is seeded with [pairs], where each key
    * in the pair is the state registry key passed to
@@ -345,6 +464,13 @@ internal class WorkflowSavedStateRegistryAggregatorTest {
     pairs.forEach { (key, string) ->
       putString(key, string)
     }
+  }
+
+  /** A [LifecycleOwner] whose state the test can drive directly. */
+  private class SimpleLifecycleOwner : LifecycleOwner {
+    val lifecycleRegistry = LifecycleRegistry(this)
+    override val lifecycle: Lifecycle
+      get() = lifecycleRegistry
   }
 
   private class SimpleStateRegistry : SavedStateRegistryOwner {


### PR DESCRIPTION
## Problem

`WorkflowSavedStateRegistryAggregator` restores its `KeyedSavedStateRegistryOwner` children from an observer on the parent `SavedStateRegistryOwner`'s lifecycle. Observer dispatch order on a `LifecycleRegistry` follows registration order, and `WorkflowLifecycleOwner` lifecycles advance in a synchronous depth-first cascade on window attach — so a descendant's lifecycle observers can run **before** the aggregator's restore observer ever fires.

Concretely: a nested `ComposeView`'s `WrappedComposition` consumes the view-tree `SavedStateRegistry` on `ON_CREATE`. If that dispatch wins the race against the aggregator's restore, the consumer reads an unrestored registry and throws:

```
IllegalStateException: You can 'consumeRestoredStateForKey' only after the corresponding
component has moved to the 'CREATED' state
```

On androidx.compose.ui 1.9.5 this is fatal in a second way: the exception is thrown mid-way through `LayoutNode.attach()`'s recursion during a lazy-item/pager subcompose, which leaves ancestor `LayoutNode`s half-attached (`markAsAttached` ran, `runAttachLifecycle` skipped). The tree then detonates at composition dispose with:

```
IllegalStateException: Must run runDetachLifecycle() once after runAttachLifecycle() and before markAsDetached()
```

Compose 1.7.x tolerated the poisoned state; 1.9.5 crashes the process on teardown. Reproduced deterministically (4/4) in Square's android-register with a workflow-hosted Compose screen containing a lazy list (`DemoV2HomeTest#payTabAndButtonAppears_withBillPayEnabled`); this crash currently blocks register's Compose 1.9.5 upgrade. (A minimal, workflow-free Compose repro of the downstream detonation exists and is being filed against androidx separately — but the state-restoration race fixed here is workflow's own bug regardless.)

## Fix

Two cooperating parts, both local to `workflow-ui/core-android`'s androidx integration:

1. **Lifecycle clamp.** `KeyedSavedStateRegistryOwner` no longer delegates its `Lifecycle` to the view's `WorkflowLifecycleOwner`. It now exposes its own `LifecycleRegistry` that mirrors the delegate's, but is held at `INITIALIZED` until the owner's registry has been restored. This enforces the androidx savedstate contract *by construction*: lifecycle-driven consumers (like Compose's `DisposableSaveableStateRegistry`) cannot observe an unrestored registry, and `performRestore()` remains legal no matter how far the delegate lifecycle has advanced (savedstate requires lifecycle < `STARTED`).

2. **Just-in-time restore.** When the delegate delivers `ON_CREATE` and the owner has not been restored yet, the owner synchronously asks the aggregator to restore it right then (`restoreChildNow`) — before the local lifecycle advances and any downstream consumer can see the registry. If the aggregator's own restore observer hasn't fired yet, it pulls its state from the parent registry on demand (`consumeRestoredStateForKey` only requires the parent registry to be restored, not the parent lifecycle to be `CREATED`). Children pruned from the aggregator restore empty rather than stealing a successor's saved state.

Because ancestors' lifecycles always advance before descendants', an owner's JIT restore can always find its parent's state — restoration order is preserved top-down and no state is lost.

This also structurally fixes #570: a child whose lifecycle is past `INITIALIZED` can now always be restored, because its local lifecycle *cannot* pass `INITIALIZED` unrestored.

### API note

`installChildRegistryOwnerOn` now registers a lifecycle observer at install time, which `LifecycleRegistry` requires to happen on the main thread. This was already true of every production caller (container views during render); the KDoc now documents it, and `ViewStateCacheTest` routes its `update()` calls through `runOnMainSync` accordingly.

## Testing

- New JVM regression tests in `WorkflowSavedStateRegistryAggregatorTest` covering: the dispatch-order race (child advancing before parent `ON_CREATE` is restored just in time *with* saved state), the lifecycle clamp, the detached-parent fallback (restores empty without throwing), and the pruned-child case (does not consume a replacement's state).
- `:workflow-ui:core-android:connectedDebugAndroidTest`: 39/39 pass (incl. `BackStackContainerPersistenceLifecycleTest`, `ViewStateCacheTest`, `WorkflowViewStubLifecycleTest`).
- `:workflow-ui:compose:connectedDebugAndroidTest`: 56/56 pass (incl. `ComposeViewTreeIntegrationTest` save/restore integration).
- Validated against the android-register repro via composite build: previously 4/4 crash, now 3/3 pass with zero occurrences of either crash signature in logcat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)