### PR TITLE
Make dialogs drive Activity.onUserInteraction

### DIFF
--- a/workflow-ui/core-android/src/androidTest/AndroidManifest.xml
+++ b/workflow-ui/core-android/src/androidTest/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <activity
         android:name="com.squareup.workflow1.ui.navigation.fixtures.BackStackContainerLifecycleActivity"
         android:theme="@style/Theme.AppCompat.NoActionBar"/>
+    <activity android:name="com.squareup.workflow1.ui.navigation.DialogIntegrationTestActivity"/>
     <activity android:name="androidx.activity.ComponentActivity"/>
   </application>
 </manifest>

--- a/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/navigation/DialogIntegrationTest.kt
+++ b/workflow-ui/core-android/src/androidTest/java/com/squareup/workflow1/ui/navigation/DialogIntegrationTest.kt
@@ -9,6 +9,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.ComponentDialog
 import androidx.lifecycle.Lifecycle.State.DESTROYED
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -30,7 +31,8 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 internal class DialogIntegrationTest {
-  @get:Rule val scenarioRule = ActivityScenarioRule(ComponentActivity::class.java)
+  @get:Rule
+  val scenarioRule = ActivityScenarioRule(DialogIntegrationTestActivity::class.java)
   private val scenario get() = scenarioRule.scenario
 
   private data class ContentRendering(val name: String) :
@@ -82,6 +84,25 @@ internal class DialogIntegrationTest {
 
     assertThat(latestDialog).isNotNull()
     assertThat(latestDialog!!.isShowing).isTrue()
+  }
+
+  @Test fun dialogTouchNotifiesHostingActivityOfUserInteraction() {
+    val screen = BodyAndOverlaysScreen(
+      ContentRendering("body"),
+      listOf(DialogRendering("dialog", ContentRendering("content")))
+    )
+
+    scenario.onActivity { activity ->
+      activity.workflowContentView.show(screen)
+    }
+    onView(withText("content")).inRoot(isDialog()).check(matches(isDisplayed()))
+    scenario.onActivity { it.userInteractionCount = 0 }
+
+    onView(withText("content")).inRoot(isDialog()).perform(click())
+
+    scenario.onActivity { activity ->
+      assertThat(activity.userInteractionCount).isEqualTo(1)
+    }
   }
 
   /** https://github.com/square/workflow-kotlin/issues/825 */
@@ -176,5 +197,14 @@ internal class DialogIntegrationTest {
 
     scenario.moveToState(DESTROYED)
     assertThat(latestDialog?.isShowing).isFalse()
+  }
+}
+
+internal class DialogIntegrationTestActivity : ComponentActivity() {
+  var userInteractionCount = 0
+
+  override fun onUserInteraction() {
+    super.onUserInteraction()
+    userInteractionCount++
   }
 }

--- a/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/navigation/DialogSession.kt
+++ b/workflow-ui/core-android/src/main/java/com/squareup/workflow1/ui/navigation/DialogSession.kt
@@ -1,5 +1,8 @@
 package com.squareup.workflow1.ui.navigation
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
@@ -106,18 +109,39 @@ internal class DialogSession(
     val dialog = holder.dialog
 
     dialog.window?.let { window ->
+      val activity = dialog.context.activityOrNull()
       val realWindowCallback = window.callback
       window.callback = object : Callback by realWindowCallback {
         override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+          if (event.action == MotionEvent.ACTION_DOWN) {
+            activity?.onUserInteraction()
+          }
           return !allowEvents || realWindowCallback.dispatchTouchEvent(event)
         }
 
         override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+          activity?.onUserInteraction()
+
           // Consume all events if we've been told to do so.
           if (!allowEvents) return true
 
           // Allow the usual handling, including the usual call to Dialog.onBackPressed.
           return realWindowCallback.dispatchKeyEvent(event)
+        }
+
+        override fun dispatchKeyShortcutEvent(event: KeyEvent): Boolean {
+          activity?.onUserInteraction()
+          return realWindowCallback.dispatchKeyShortcutEvent(event)
+        }
+
+        override fun dispatchTrackballEvent(event: MotionEvent): Boolean {
+          activity?.onUserInteraction()
+          return realWindowCallback.dispatchTrackballEvent(event)
+        }
+
+        override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
+          activity?.onUserInteraction()
+          return realWindowCallback.dispatchGenericMotionEvent(event)
         }
       }
     }
@@ -290,4 +314,10 @@ internal class DialogSession(
       override fun newArray(size: Int): Array<KeyAndBundle?> = arrayOfNulls(size)
     }
   }
+}
+
+private tailrec fun Context.activityOrNull(): Activity? = when (this) {
+  is Activity -> this
+  is ContextWrapper -> baseContext.activityOrNull()
+  else -> null
 }


### PR DESCRIPTION
Closes #313

## Summary

- Notify the hosting Activity when a dialog window dispatches user input.
- Preserve existing modal event gating and add focused dialog-touch instrumentation coverage.

## Validation

- `:workflow-ui:core-android:build`
- `:workflow-ui:core-android:compileDebugAndroidTestKotlin`
- Complete `DialogIntegrationTest` class: 6 tests passed on Android API 36

The repository-wide build passed the affected module, but the unrelated `workflow-runtime` browser-test reporter hit a Kotlin/Gradle TeamCity service-message parsing limit after 21,040 tests.
