### PR TITLE
Drop deprecated rememberSaveable(key = …) from RenderAsState [CLF-279]

### DIFF
--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/RenderAsStateTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/RenderAsStateTest.kt
@@ -127,8 +127,7 @@ internal class RenderAsStateTest {
           scope = scope,
           props = Unit,
           interceptors = emptyList(),
-          onOutput = {},
-          snapshotKey = SNAPSHOT_KEY
+          onOutput = {}
         ).value
       }
     }
@@ -143,11 +142,12 @@ internal class RenderAsStateTest {
 
     composeRule.runOnIdle {
       val savedValues = savedStateRegistry.performSave()
-      println("saved keys: ${savedValues.keys}")
-      // Relying on the int key across all runtimes is brittle, so use an explicit key.
+
+      // rememberSaveable generates its key from the call site's position in the composition, so
+      // the test can't know it. renderAsState saves exactly one value, so just take that one.
       @Suppress("UNCHECKED_CAST")
       val snapshot =
-        ByteString.of(*((savedValues.getValue(SNAPSHOT_KEY).single() as State<ByteArray>).value))
+        ByteString.of(*((savedValues.values.single().single() as State<ByteArray>).value))
       println("snapshot: ${snapshot.base64()}")
       assertThat(snapshot).isEqualTo(EXPECTED_SNAPSHOT)
     }
@@ -155,9 +155,16 @@ internal class RenderAsStateTest {
 
   @Test fun restoresSnapshot() {
     val workflow = SnapshottingWorkflow()
-    val restoreValues =
-      mapOf(SNAPSHOT_KEY to listOf(mutableStateOf(EXPECTED_SNAPSHOT.toByteArray())))
-    val savedStateRegistry = SaveableStateRegistry(restoreValues) { true }
+    // rememberSaveable generates its key from the call site's position in the composition, so the
+    // test can't seed the restore map with the right key. renderAsState restores exactly one
+    // value, so hand it the snapshot whatever key it asks for.
+    val savedStateRegistry = object : SaveableStateRegistry by SaveableStateRegistry(
+      restoredValues = emptyMap(),
+      canBeSaved = { true }
+    ) {
+      override fun consumeRestored(key: String): Any =
+        mutableStateOf(EXPECTED_SNAPSHOT.toByteArray())
+    }
     lateinit var rendering: SnapshottedRendering
 
     composeRule.setContent {
@@ -167,8 +174,7 @@ internal class RenderAsStateTest {
           scope = rememberCoroutineScope(),
           props = Unit,
           interceptors = emptyList(),
-          onOutput = {},
-          snapshotKey = "workflow-snapshot"
+          onOutput = {}
         ).value
       }
     }
@@ -205,6 +211,48 @@ internal class RenderAsStateTest {
 
     composeRule.runOnIdle {
       assertThat(rendering.string).isEqualTo("foo")
+    }
+  }
+
+  /**
+   * Multiple runtimes in the same composition each save and restore their own snapshot, rather
+   * than sharing or clobbering each other's.
+   */
+  @Test fun savesAndRestoresSnapshotsOfSiblingRuntimesIndependently() {
+    val stateRestorationTester = StateRestorationTester(composeRule)
+    val workflow = SnapshottingWorkflow()
+    lateinit var firstRendering: SnapshottedRendering
+    lateinit var secondRendering: SnapshottedRendering
+    val scope = TestScope()
+
+    stateRestorationTester.setContent {
+      firstRendering = workflow.renderAsState(
+        scope = scope,
+        props = Unit,
+        interceptors = emptyList(),
+        onOutput = {},
+      ).value
+      secondRendering = workflow.renderAsState(
+        scope = scope,
+        props = Unit,
+        interceptors = emptyList(),
+        onOutput = {},
+      ).value
+    }
+
+    composeRule.runOnIdle {
+      firstRendering.updateString("first")
+      secondRendering.updateString("second")
+    }
+
+    // Move along workflow before saving state!
+    scope.advanceUntilIdle()
+
+    stateRestorationTester.emulateSavedInstanceStateRestore()
+
+    composeRule.runOnIdle {
+      assertThat(firstRendering.string).isEqualTo("first")
+      assertThat(secondRendering.string).isEqualTo("second")
     }
   }
 
@@ -353,8 +401,6 @@ internal class RenderAsStateTest {
   }
 
   private companion object {
-    const val SNAPSHOT_KEY = "workflow-snapshot"
-
     /** Golden value from [savesSnapshot]. */
     val EXPECTED_SNAPSHOT = "AAAABwAAAANmb28AAAAA".decodeBase64()!!
   }

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/RenderAsState.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/RenderAsState.kt
@@ -1,6 +1,5 @@
 package com.squareup.workflow1.ui.compose
 
-import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.RememberObserver
@@ -11,7 +10,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.SaverScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -116,11 +114,6 @@ public fun <PropsT, OutputT : Any, RenderingT> Workflow<PropsT, OutputT, Renderi
   onOutput: suspend (OutputT) -> Unit
 ): State<RenderingT> = renderAsState(this, scope, props, interceptors, runtimeConfig, onOutput)
 
-/**
- * @param snapshotKey Allows tests to pass in a custom key to use to save/restore the snapshot from
- * the [LocalSaveableStateRegistry]. If null, will use the default key based on source location.
- */
-@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 @Composable
 internal fun <PropsT, OutputT : Any, RenderingT> renderAsState(
   workflow: Workflow<PropsT, OutputT, RenderingT>,
@@ -128,10 +121,11 @@ internal fun <PropsT, OutputT : Any, RenderingT> renderAsState(
   props: PropsT,
   interceptors: List<WorkflowInterceptor>,
   runtimeConfig: RuntimeConfig = RuntimeConfigOptions.DEFAULT_CONFIG,
-  onOutput: suspend (OutputT) -> Unit,
-  snapshotKey: String? = null
+  onOutput: suspend (OutputT) -> Unit
 ): State<RenderingT> {
-  val snapshotState = rememberTreeSnapshotState(snapshotKey)
+  val snapshotState = rememberSaveable(stateSaver = TreeSnapshotSaver) {
+    mutableStateOf<TreeSnapshot?>(null)
+  }
   val updatedOnOutput by rememberUpdatedState(onOutput)
 
   // We can't use DisposableEffect because it won't run until the composition is successfully
@@ -163,28 +157,6 @@ internal fun <PropsT, OutputT : Any, RenderingT> renderAsState(
 
   return state.rendering
 }
-
-@Composable
-private fun rememberTreeSnapshotState(
-  snapshotKey: String?
-): MutableState<TreeSnapshot?> {
-  return if (snapshotKey == null) {
-    rememberSaveable(stateSaver = TreeSnapshotSaver) {
-      mutableStateOf(null)
-    }
-  } else {
-    rememberTreeSnapshotStateWithKey(snapshotKey)
-  }
-}
-
-@Suppress("DEPRECATION")
-@Composable
-private fun rememberTreeSnapshotStateWithKey(
-  snapshotKey: String
-): MutableState<TreeSnapshot?> =
-  rememberSaveable(key = snapshotKey, stateSaver = TreeSnapshotSaver) {
-    mutableStateOf(null)
-  }
 
 /**
  * State hoisted out of [renderAsState].


### PR DESCRIPTION
Follow-up to #1558 (Compose 1.9.5). `renderAsState` was carrying a `@Suppress("DEPRECATION")` for `rememberSaveable(key = …)`, which Compose deprecated because it bypasses positional scoping ([r.android.com/3610053](https://r.android.com/3610053)). At Compose 1.9.5 that call is a hard build failure under `-Werror`, so the suppression is load-bearing on that upgrade.

## `key(…) { }` is not a workaround

The plan in CLF-278 was to wrap the call in `key(…)` instead. That does not work. `rememberSaveable` derives its registry key from `currentCompositeKeyHashCode.toString(36)` when no explicit `key` is passed, so `key("workflow-snapshot")` only perturbs that hash — the string never reaches the `SaveableStateRegistry`. Both tests that relied on the explicit key fail against it:

```
savesSnapshot     java.util.NoSuchElementException: Key workflow-snapshot is missing in the map.
restoresSnapshot  expected: foo but was an empty string
```

The second is the dangerous one: state is silently not restored.

## What this does instead

The `snapshotKey` parameter existed only to give tests a known registry key, and no variant of it survives the deprecation, so it is removed along with the two private helpers it needed. `renderAsState` now calls plain positional `rememberSaveable`, and the tests no longer depend on the key:

- `savesSnapshot` takes the registry’s single saved value instead of looking it up by name.
- `restoresSnapshot` hands back the golden snapshot for whatever key is asked for, so it still exercises the real restore path with the golden bytes.
- Added `savesAndRestoresSnapshotsOfSiblingRuntimesIndependently`, covering two runtimes in one composition.

The public API is unchanged; only the `internal` overload lost a parameter.

## Verification

Instrumented tests on an API 28 emulator, 57/57 in `:workflow-ui:compose` green, plus `assembleDebug` and `ktlintCheck`.

Because state persistence fails quietly, I ran two negative controls rather than trusting a green run:

- Forcing `initialSnapshot = null` fails all four restore-dependent tests, so they genuinely exercise restore.
- Compiling against Compose 1.9.5 (BOM 2025.11.01) with the old call and no suppression reproduces the `-Werror` failure; with this change the module compiles clean at 1.9.5.

One thing worth knowing: a shared explicit key did *not* break sibling restore, because `SaveableStateRegistry` keeps a list per key and consumes it in registration order. It works by ordering luck — exactly the fragility the deprecation is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)