### PR TITLE
Isolate saved state for Android views hosted in Compose

### DIFF
--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/ComposeViewTreeIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.squareup.workflow1.ui.compose
 
 import android.content.Context
+import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -25,6 +26,10 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle.Event.ON_CREATE
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import com.google.common.truth.Truth.assertThat
 import com.squareup.workflow1.ui.AndroidScreen
 import com.squareup.workflow1.ui.Compatible
@@ -228,6 +233,21 @@ internal class ComposeViewTreeIntegrationTest {
     scenario.recreate()
 
     composeRule.onNodeWithTag(CounterTag).assertTextEquals("Counter: 1")
+  }
+
+  @Test
+  fun android_view_saved_state_is_restored_after_config_change() {
+    val child = SavedStateAndroidRendering("child")
+
+    scenario.onActivity { it.setRendering(ComposeAndroidHost(child)) }
+    composeRule.runOnIdle {
+      assertThat(child.restoredValues).containsExactly(0)
+      child.value = 41
+    }
+
+    scenario.recreate()
+
+    composeRule.runOnIdle { assertThat(child.restoredValues).containsExactly(0, 41).inOrder() }
   }
 
   @Test
@@ -712,6 +732,69 @@ internal class ComposeViewTreeIntegrationTest {
       }
   }
 
+  private data class ComposeAndroidHost(val child: Screen) : ComposeScreen {
+    @Composable
+    override fun Content() {
+      WorkflowRendering(child)
+    }
+  }
+
+  private class SavedStateAndroidRendering(override val compatibilityKey: String) :
+    Compatible, AndroidScreen<SavedStateAndroidRendering> {
+    val restoredValues = mutableListOf<Int>()
+    var value: Int
+      get() = checkNotNull(view).value
+      set(value) {
+        checkNotNull(view).value = value
+      }
+
+    private var view: SavedStateView? = null
+
+    override val viewFactory =
+      fromCode<SavedStateAndroidRendering> { rendering, initialEnvironment, context, _ ->
+        val view =
+          SavedStateView(context) { restoredValue -> rendering.restoredValues += restoredValue }
+        rendering.view = view
+        ScreenViewHolder(initialEnvironment, view) { _, _ -> }
+      }
+  }
+
+  private class SavedStateView(context: Context, private val onRestored: (Int) -> Unit) :
+    View(context) {
+    var value: Int = 0
+    private var owner: SavedStateRegistryOwner? = null
+    private var providerRegistered = false
+    private val lifecycleObserver = LifecycleEventObserver { _, event ->
+      if (event == ON_CREATE) {
+        val owner = checkNotNull(owner)
+        val registry = owner.savedStateRegistry
+        value = registry.consumeRestoredStateForKey(SAVED_VALUE_KEY)?.getInt(SAVED_VALUE_KEY) ?: 0
+        registry.registerSavedStateProvider(SAVED_VALUE_KEY) {
+          Bundle().apply { putInt(SAVED_VALUE_KEY, value) }
+        }
+        providerRegistered = true
+        onRestored(value)
+      }
+    }
+
+    override fun onAttachedToWindow() {
+      super.onAttachedToWindow()
+      val owner = checkNotNull(findViewTreeSavedStateRegistryOwner())
+      this.owner = owner
+      owner.lifecycle.addObserver(lifecycleObserver)
+    }
+
+    override fun onDetachedFromWindow() {
+      owner?.lifecycle?.removeObserver(lifecycleObserver)
+      if (providerRegistered) {
+        owner?.savedStateRegistry?.unregisterSavedStateProvider(SAVED_VALUE_KEY)
+      }
+      owner = null
+      providerRegistered = false
+      super.onDetachedFromWindow()
+    }
+  }
+
   /**
    * This is our own custom lovingly handcrafted implementation that creates [ComposeView] itself,
    * bypassing [ScreenComposableFactory] entirely. Allows us to mess with alternative
@@ -773,5 +856,6 @@ internal class ComposeViewTreeIntegrationTest {
     const val CounterTag = "counter"
     const val CounterTag2 = "counter2"
     const val CounterTag3 = "counter3"
+    const val SAVED_VALUE_KEY = "saved-value"
   }
 }

--- a/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/WorkflowRenderingTest.kt
+++ b/workflow-ui/compose/src/androidTest/java/com/squareup/workflow1/ui/compose/WorkflowRenderingTest.kt
@@ -2,6 +2,8 @@
 
 package com.squareup.workflow1.ui.compose
 
+import android.content.Context
+import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import androidx.compose.foundation.clickable
@@ -50,6 +52,9 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.compose.LocalSavedStateRegistryOwner
+import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -144,6 +149,77 @@ internal class WorkflowRenderingTest {
     onView(withText("two")).check(matches(isDisplayed()))
     wrapperText.value = "OWT"
     onView(withText("OWT")).check(matches(isDisplayed()))
+  }
+
+  @Test
+  fun incompatibleLegacyViewsHaveDistinctSavedStateRegistryOwners() {
+    val log = RegistryRegistrationLog()
+    lateinit var parentOwner: SavedStateRegistryOwner
+    var rendering: Screen by mutableStateOf(RegisteringRendering("outgoing", log))
+
+    composeRule.setContent {
+      parentOwner = LocalSavedStateRegistryOwner.current
+      env.RootScreen(rendering)
+    }
+
+    composeRule.runOnIdle { assertThat(log.owners).containsKey("outgoing") }
+
+    rendering = RegisteringRendering("incoming", log)
+
+    composeRule.runOnIdle {
+      assertThat(log.failures).isEmpty()
+      assertThat(log.owners.keys).containsExactly("outgoing", "incoming")
+      assertThat(log.owners.getValue("outgoing")).isNotSameInstanceAs(parentOwner)
+      assertThat(log.owners.getValue("incoming")).isNotSameInstanceAs(parentOwner)
+      assertThat(log.owners.getValue("outgoing"))
+        .isNotSameInstanceAs(log.owners.getValue("incoming"))
+      // This is the overlap that requires separate registry namespaces. If a future Compose
+      // release detaches the old AndroidView first, this assertion should be intentionally removed.
+      assertThat(log.maxSimultaneouslyAttached).isEqualTo(2)
+    }
+  }
+
+  @Test
+  fun siblingLegacyViewsHaveDistinctSavedStateRegistryOwners() {
+    val log = RegistryRegistrationLog()
+
+    class SiblingHost : ComposableRendering {
+      @Composable
+      override fun Content() {
+        Column {
+          WorkflowRendering(RegisteringRendering("first", log))
+          WorkflowRendering(RegisteringRendering("second", log))
+        }
+      }
+    }
+
+    composeRule.setContent { env.RootScreen(SiblingHost()) }
+
+    composeRule.runOnIdle {
+      assertThat(log.failures).isEmpty()
+      assertThat(log.owners.keys).containsExactly("first", "second")
+      assertThat(log.owners.getValue("first")).isNotSameInstanceAs(log.owners.getValue("second"))
+    }
+  }
+
+  @Test
+  fun composableRenderingKeepsParentSavedStateRegistryOwner() {
+    lateinit var parentOwner: SavedStateRegistryOwner
+    lateinit var renderingOwner: SavedStateRegistryOwner
+
+    class OwnerRecorder : ComposableRendering {
+      @Composable
+      override fun Content() {
+        renderingOwner = LocalSavedStateRegistryOwner.current
+      }
+    }
+
+    composeRule.setContent {
+      parentOwner = LocalSavedStateRegistryOwner.current
+      env.RootScreen(OwnerRecorder())
+    }
+
+    composeRule.runOnIdle { assertThat(renderingOwner).isSameInstanceAs(parentOwner) }
   }
 
   // https://github.com/square/workflow-kotlin/issues/538
@@ -546,5 +622,73 @@ internal class WorkflowRenderingTest {
         val view = TextView(context)
         ScreenViewHolder(initialEnvironment, view) { rendering, _ -> view.text = rendering.text }
       }
+  }
+
+  private class RegistryRegistrationLog {
+    val owners = mutableMapOf<String, SavedStateRegistryOwner>()
+    val failures = mutableListOf<String>()
+    var maxSimultaneouslyAttached = 0
+      private set
+
+    private val attached = mutableSetOf<String>()
+
+    fun onAttached(name: String) {
+      attached += name
+      maxSimultaneouslyAttached = maxOf(maxSimultaneouslyAttached, attached.size)
+    }
+
+    fun onDetached(name: String) {
+      attached -= name
+    }
+  }
+
+  private class RegisteringRendering(
+    private val name: String,
+    private val log: RegistryRegistrationLog,
+  ) : AndroidScreen<RegisteringRendering>, Compatible {
+    override val compatibilityKey: String = name
+
+    override val viewFactory =
+      ScreenViewFactory.fromCode<RegisteringRendering> { _, initialEnvironment, context, _ ->
+        ScreenViewHolder(initialEnvironment, RegisteringView(context, name, log)) { _, _ -> }
+      }
+  }
+
+  /** Simulates a Workflow container that registers state under its rendering compatibility key. */
+  private class RegisteringView(
+    context: Context,
+    private val name: String,
+    private val log: RegistryRegistrationLog,
+  ) : View(context) {
+    private var owner: SavedStateRegistryOwner? = null
+    private var providerRegistered = false
+
+    override fun onAttachedToWindow() {
+      super.onAttachedToWindow()
+      val owner = checkNotNull(findViewTreeSavedStateRegistryOwner())
+      this.owner = owner
+      log.owners[name] = owner
+
+      try {
+        owner.savedStateRegistry.registerSavedStateProvider(SHARED_PROVIDER_KEY) { Bundle() }
+        providerRegistered = true
+      } catch (e: IllegalArgumentException) {
+        // Let the composition finish applying so the test can report the actual namespace failure.
+        log.failures += "$name: ${e.message}"
+      }
+      log.onAttached(name)
+    }
+
+    override fun onDetachedFromWindow() {
+      if (providerRegistered) {
+        owner?.savedStateRegistry?.unregisterSavedStateProvider(SHARED_PROVIDER_KEY)
+      }
+      log.onDetached(name)
+      super.onDetachedFromWindow()
+    }
+
+    private companion object {
+      const val SHARED_PROVIDER_KEY = "shared-container-key"
+    }
   }
 }

--- a/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ScreenComposableFactory.kt
+++ b/workflow-ui/compose/src/main/java/com/squareup/workflow1/ui/compose/ScreenComposableFactory.kt
@@ -7,13 +7,16 @@ import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.activity.setViewTreeOnBackPressedDispatcherOwner
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.RememberObserver
+import androidx.compose.runtime.currentCompositeKeyHashCode
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.compose.LocalSavedStateRegistryOwner
-import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.squareup.workflow1.ui.Compatible
 import com.squareup.workflow1.ui.Screen
 import com.squareup.workflow1.ui.ScreenViewFactory
 import com.squareup.workflow1.ui.ScreenViewHolder
@@ -21,6 +24,7 @@ import com.squareup.workflow1.ui.ViewEnvironment
 import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.ViewRegistry.Key
 import com.squareup.workflow1.ui.androidx.OnBackPressedDispatcherOwnerKey
+import com.squareup.workflow1.ui.androidx.WorkflowSavedStateRegistryAggregator
 import com.squareup.workflow1.ui.show
 import com.squareup.workflow1.ui.startShowing
 import kotlin.reflect.KClass
@@ -185,7 +189,13 @@ public fun <ScreenT : Screen> ScreenViewFactory<ScreenT>.asComposableFactory():
     @Composable
     override fun Content(rendering: ScreenT) {
       val lifecycleOwner = LocalLifecycleOwner.current
-      val savedStateRegistryOwner = LocalSavedStateRegistryOwner.current
+      val renderingKey = Compatible.keyFor(rendering)
+      val parentSavedStateRegistryOwner = LocalSavedStateRegistryOwner.current
+      val savedStateRegistry =
+        rememberViewFactorySavedStateRegistry(
+          renderingKey = renderingKey,
+          parent = parentSavedStateRegistryOwner,
+        )
       val environment = LocalWorkflowEnvironment.current
 
       // Make sure any nested WorkflowViewStub will be able to propagate the
@@ -212,14 +222,9 @@ public fun <ScreenT : Screen> ScreenViewFactory<ScreenT>.asComposableFactory():
 
             // Unfortunately AndroidView doesn't propagate these itself.
             viewHolder.view.setViewTreeLifecycleOwner(lifecycleOwner)
-            viewHolder.view.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
+            savedStateRegistry.installOn(viewHolder.view)
             onBackOrNull?.let { viewHolder.view.setViewTreeOnBackPressedDispatcherOwner(it) }
 
-            // We don't propagate the (non-compose) SavedStateRegistryOwner, or the (compose)
-            // SaveableStateRegistry, because currently all our navigation is implemented as
-            // Android views, which ensures there is always an Android view between any state
-            // registry and any Android view shown as a child of it, even if there's a compose
-            // view in between.
             viewHolder.view
           }
         },
@@ -235,3 +240,54 @@ public fun <ScreenT : Screen> ScreenViewFactory<ScreenT>.asComposableFactory():
     }
   }
 }
+
+/**
+ * Gives each Android view hosted by [ScreenViewFactory.asComposableFactory] its own saved state
+ * namespace, just as view-based Workflow containers do for their children.
+ *
+ * [currentCompositeKeyHashCode] distinguishes multiple rendering call sites with the same
+ * [renderingKey]. Including [renderingKey] also distinguishes outgoing and incoming incompatible
+ * renderings while Compose briefly keeps both Android views attached during replacement.
+ */
+@Composable
+private fun rememberViewFactorySavedStateRegistry(
+  renderingKey: String,
+  parent: SavedStateRegistryOwner,
+): ViewFactorySavedStateRegistry {
+  val parentKey = "$VIEW_FACTORY_SAVED_STATE_KEY_PREFIX:$renderingKey#$currentCompositeKeyHashCode"
+  return remember(parent, parentKey) {
+    ViewFactorySavedStateRegistry(childKey = renderingKey, parentKey = parentKey, parent = parent)
+  }
+}
+
+/**
+ * Owns the view-oriented [WorkflowSavedStateRegistryAggregator] for one composition subtree.
+ * Attaching during construction makes restoration available before [AndroidView] attaches the
+ * child. [RememberObserver] guarantees that an abandoned or forgotten composition unregisters the
+ * aggregator from its parent.
+ */
+private class ViewFactorySavedStateRegistry(
+  private val childKey: String,
+  parentKey: String,
+  parent: SavedStateRegistryOwner,
+) : RememberObserver {
+  private val aggregator =
+    WorkflowSavedStateRegistryAggregator().apply { attachToParentRegistry(parentKey, parent) }
+
+  fun installOn(view: android.view.View) {
+    aggregator.installChildRegistryOwnerOn(view, childKey, force = true)
+  }
+
+  override fun onRemembered() = Unit
+
+  override fun onForgotten() {
+    aggregator.detachFromParentRegistry()
+  }
+
+  override fun onAbandoned() {
+    aggregator.detachFromParentRegistry()
+  }
+}
+
+private const val VIEW_FACTORY_SAVED_STATE_KEY_PREFIX =
+  "com.squareup.workflow1.ui.compose.ScreenViewFactory"


### PR DESCRIPTION
## Why

`ScreenViewFactory.asComposableFactory()` bridges a Workflow Android View into Compose. Unlike view-based Workflow containers, the bridge currently gives every hosted View the same parent `SavedStateRegistryOwner`.

Saved-state provider keys must be unique within one registry. Compose may keep outgoing and incoming incompatible `AndroidView`s attached simultaneously during replacement, and separate Compose call sites may host sibling Views with the same nested provider keys. Sharing the parent owner therefore allows otherwise independent View trees to collide and crash.

## What changed

- Give each Android View-backed rendering its own saved-state namespace under the parent registry, keyed by rendering compatibility and Compose call site.
- Install the child owner synchronously before `AndroidView` attaches and unregister it when the composition is abandoned or forgotten.
- Preserve the parent registry owner for pure Compose renderings.

## Adoption

This is the source-of-truth replacement for consumer-local wrappers that create child `SavedStateRegistryOwner`s around Android View-backed Workflow renderings in Compose. After adopting a release with this fix, consumers should delete those wrappers and retain their product-level regression tests as downstream verification.

## Testing

Android instrumentation tests prove that incompatible overlapping Views and sibling Views receive distinct owners, pure Compose retains its parent owner, and Android View state survives Activity recreation.