### PR TITLE
Compile build-logic with JDK 17 so the build runs on a JDK 17 daemon [CLF-286]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,26 @@ and style in order to keep the code as readable as possible. Please also make
 sure your code compiles by running `./gradlew clean build`. If you're using IntelliJ IDEA,
 we use [Square's code style definitions][2].
 
+Building
+--------
+
+You need **JDK 17 or newer** to run Gradle, and **JDK 21 installed** for the build to compile
+against.
+
+The build uses three separate JDK versions, configured in `gradle/libs.versions.toml`:
+
+| Version | Purpose |
+|---|---|
+| `jdk-target` (11) | Bytecode version published to consumers |
+| `jdk-toolchain` (21) | JDK the libraries are compiled with, via a Gradle toolchain |
+| `jdk-buildLogic` (17) | JDK `build-logic` is compiled with — the floor for your Gradle daemon |
+
+Gradle forks a JDK 21 toolchain for compilation, so your `JAVA_HOME` does not need to be 21 — but a
+JDK 21 must be installed somewhere Gradle can [auto-detect][3] it. If you see
+`Cannot find a Java installation ... matching languageVersion=21`, install a JDK 21.
+
+ [3]: https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection
+
 Before your code can be accepted into the project you must also sign the
 [Individual Contributor License Agreement (CLA)][1].
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -81,5 +81,7 @@ dependencies {
 }
 
 java {
-  toolchain.languageVersion.set(JavaLanguageVersion.of(libs.versions.jdk.toolchain.get()))
+  // Deliberately not jdk-toolchain: build-logic is on the buildscript classpath, so the Gradle
+  // daemon loads these classes directly and can't read bytecode newer than its own JDK.
+  toolchain.languageVersion.set(JavaLanguageVersion.of(libs.versions.jdk.buildLogic.get()))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,15 @@ compileSdk = "36"
 minSdk = "24"
 targetSdk = "33"
 
+# The bytecode version published to consumers.
 jdk-target = "11"
+# The JDK used to compile the libraries, via a Gradle toolchain. Matches android-register's compile
+# JDK. Gradle forks this JDK for compilation, so it does not constrain the daemon's JDK.
 jdk-toolchain = "21"
+# The JDK used to compile build-logic. Unlike the above, this *does* constrain the daemon: build-logic
+# is on the buildscript classpath, so the daemon must be able to load its bytecode. Keep it at the
+# floor Gradle and AGP already require (17) so the build works on a stock JDK 17 environment.
+jdk-buildLogic = "17"
 
 androidx-activity = "1.11.0"
 androidx-appcompat = "1.7.1"


### PR DESCRIPTION
Building workflow-kotlin on a stock JDK 17 environment (e.g. Square's `sa-tools` default of Azul 17) fails immediately:

```
Could not resolve project :build-logic.
> Dependency requires at least JVM runtime version 21. This build uses a Java 17 JVM.
```

## Cause

`jdk-toolchain = "21"` was consumed in two structurally different places:

| Site | Effect | Constrains the daemon? |
|---|---|---|
| `KotlinCommonSettings.kt` — `jvmToolchain(21)` for library/sample modules | Real Gradle toolchain; the daemon forks a JDK 21 compiler | No |
| `build-logic/build.gradle.kts` — build-logic's own toolchain | build-logic is on the **buildscript classpath**, so the daemon loads its classes directly | **Yes** |

Only the second forces `JAVA_HOME` to be 21. Nothing in build-logic needs Java 21 language features — it just inherited the libraries' value, conflating "JDK the libraries compile with" and "JDK the daemon must be able to load".

This is why android-register builds fine on JDK 17 while workflow did not: android-register uses toolchains for compilation and keeps its daemon on 17.

## Fix

Split the two concepts in the version catalog:

| Version | Purpose |
|---|---|
| `jdk-target` (11) | Bytecode published to consumers — **unchanged** |
| `jdk-toolchain` (21) | JDK the libraries compile with, matches android-register — **unchanged** |
| `jdk-buildLogic` (17) | JDK build-logic compiles with — **new** |

17 is the natural floor, since Gradle 9.3.1 and AGP 8.13 both already require JDK 17+.

`CONTRIBUTING.md` previously documented no JDK requirement at all, which is what made this bite silently; it now explains all three versions.

## Verification

Run locally on both JDKs:

| Check | JDK 17 (Azul) | JDK 21 (Temurin) |
|---|---|---|
| `./gradlew test --continue` | ✅ 1582 tasks | ✅ 1582 tasks |
| `apiCheck artifactsCheck dependencyGuard` | — | ✅ |

Published bytecode is unchanged — `workflow-core` classes are still major version 55 (Java 11), matching `jdk-target`. `build-logic` moves from 65 (Java 21) to 61 (Java 17).

Fixes CLF-286.