### PR TITLE
Remove empty ui-systems-android team from CODEOWNERS [CLF-292]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,4 @@
 # the repo, unless a later match takes precedence.
 * @square/mobile-foundation-android @zach-klippenstein
 
-# Any files under any of the compose directories should be reviewed by UI Systems as well.
-*compose*/ @square/mobile-foundation-android @square/ui-systems-android
+*compose*/ @square/mobile-foundation-android


### PR DESCRIPTION
The `@square/ui-systems-android` team still exists in the org but has 0 members, so every compose-related PR gets a pending review request from an empty team that can never be satisfied. This removes it from the `*compose*/` line, leaving `@square/mobile-foundation-android` as the owner of compose directories.

Linear: [CLF-292](https://linear.app/squareup/issue/CLF-292/remove-empty-ui-systems-android-team-from-workflow-kotlin-codeowners)

🤖 Generated with [Claude Code](https://claude.com/claude-code)