### PR TITLE
Fix the workflow-runtime iOS test suite [CLF-451]

### DIFF
--- a/build-logic/src/main/java/com/squareup/workflow1/buildsrc/KotlinMultiPlatformConventionPlugin.kt
+++ b/build-logic/src/main/java/com/squareup/workflow1/buildsrc/KotlinMultiPlatformConventionPlugin.kt
@@ -2,12 +2,14 @@ package com.squareup.workflow1.buildsrc
 
 import com.squareup.workflow1.buildsrc.internal.javaTargetInt
 import com.squareup.workflow1.buildsrc.internal.javaTargetVersion
+import java.time.Duration
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
 
 class KotlinMultiPlatformConventionPlugin : Plugin<Project> {
 
@@ -25,6 +27,15 @@ class KotlinMultiPlatformConventionPlugin : Plugin<Project> {
           // Add in a system property to the fork for the test.
           test.systemProperty(key, value!!)
         }
+    }
+
+    // Kotlin/Native test binaries have no per-test timeout, so one deadlocked test hangs the task
+    // forever. On CI that meant the "iOS Unit Tests for KMP Modules" job ran until its 45-minute
+    // limit and was cancelled without producing a test report. The whole workflow-runtime iOS suite
+    // takes well under a minute on CI, so anything approaching this limit is a hang. Failing the
+    // task instead lets the report and any partial results be uploaded.
+    target.tasks.withType(KotlinNativeTest::class.java).configureEach { test ->
+      test.timeout.set(Duration.ofMinutes(15))
     }
 
     // Sets the JDK target for published artifacts.

--- a/workflow-runtime/build.gradle.kts
+++ b/workflow-runtime/build.gradle.kts
@@ -111,6 +111,15 @@ kotlin {
     maybeCreate("iosX64Main").apply { dependsOn(iosMain) }
     maybeCreate("iosSimulatorArm64Main").apply { dependsOn(iosMain) }
 
+    // Test source sets mirror the main hierarchy. Without this, intermediate test source sets like
+    // iosTest are not compiled by any target and their tests silently never run.
+    val nativeTest = maybeCreate("nativeTest").apply { dependsOn(commonTest.get()) }
+    val appleTest = maybeCreate("appleTest").apply { dependsOn(nativeTest) }
+    val iosTest = maybeCreate("iosTest").apply { dependsOn(appleTest) }
+    maybeCreate("iosArm64Test").apply { dependsOn(iosTest) }
+    maybeCreate("iosX64Test").apply { dependsOn(iosTest) }
+    maybeCreate("iosSimulatorArm64Test").apply { dependsOn(iosTest) }
+
     // JS source set depends on commonMain
     maybeCreate("jsMain").apply { dependsOn(commonMain.get()) }
 

--- a/workflow-runtime/src/appleMain/kotlin/com/squareup/workflow1/internal/Synchronization.apple.kt
+++ b/workflow-runtime/src/appleMain/kotlin/com/squareup/workflow1/internal/Synchronization.apple.kt
@@ -4,6 +4,7 @@ import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSCopyingProtocol
 import platform.Foundation.NSLock
+import platform.Foundation.NSNull
 import platform.Foundation.NSThread
 import platform.Foundation.NSZone
 import platform.darwin.NSObject
@@ -27,6 +28,9 @@ internal actual inline fun <R> Lock.withLock(block: () -> R): R {
 /**
  * Implementation of [ThreadLocal] that works in a similar way to Java's, based on a thread-specific
  * map/dictionary.
+ *
+ * [NSMutableDictionary][platform.Foundation.NSMutableDictionary] can't store `nil`, so `null`
+ * values are stored as [NSNull] and converted back on read.
  */
 internal actual class ThreadLocal<T>(private val initialValue: () -> T) :
   NSObject(), NSCopyingProtocol {
@@ -36,11 +40,16 @@ internal actual class ThreadLocal<T>(private val initialValue: () -> T) :
 
   actual fun get(): T {
     @Suppress("UNCHECKED_CAST")
-    return (threadDictionary.objectForKey(aKey = this) as T?) ?: initialValue().also(::set)
+    return when (val stored = threadDictionary.objectForKey(aKey = this)) {
+      null -> initialValue().also(::set)
+      is NSNull -> null as T
+      else -> stored as T
+    }
   }
 
   actual fun set(value: T) {
-    threadDictionary.setObject(value, forKey = this)
+    // setObject:forKey: throws NSInvalidArgumentException when passed nil.
+    threadDictionary.setObject(value ?: NSNull(), forKey = this)
   }
 
   /**

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderWorkflowInSnapshotSaveRestoreTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderWorkflowInSnapshotSaveRestoreTest.kt
@@ -15,9 +15,19 @@ import kotlinx.coroutines.test.runTest
 
 /**
  * This only contains the single test ([saves_to_and_restores_from_snapshot]) from
- * [RenderWorkflowInTest] that uses [runtime2], since in Kotlin 2.3.10 passing [runtime2] as a test
- * method parameter causes a compiler crash. It should be possible to merge this test back into the
- * main suite once that bug is fixed.
+ * [RenderWorkflowInTest] that needs a second runtime config parameter (`runtime2`). It was split
+ * out because Kotlin 2.3.10 crashed when `runtime2` was a test method parameter. Kotlin 2.4.0 still
+ * crashes for some shapes of test body (see [saveAndRestoreSnapshot]), so the body is kept in a
+ * helper function. With that workaround it may be possible to merge this test back into the main
+ * suite.
+ *
+ * `runtime2` MUST stay a test method parameter rather than a class parameter. Burst generates a
+ * class per combination of class parameters, and Kotlin/Native's generated test registration code
+ * for a file reserves stack space for every test class in that file (about 32 bytes per class). As
+ * a class parameter this file expands to 2 × 2 × N² classes, where N is the number of
+ * [RuntimeOptions] entries, which overflows the 512KB stack of the worker threads that
+ * Kotlin/Native runs module initializers on once N passes ~64, crashing the whole test binary with
+ * SIGBUS.
  */
 @OptIn(ExperimentalCoroutinesApi::class, WorkflowExperimentalRuntime::class)
 @Burst
@@ -25,7 +35,6 @@ class RenderWorkflowInSnapshotSaveRestoreTest(
   useTracer: Boolean = false,
   private val useUnconfined: Boolean = true,
   private val runtime: RuntimeOptions = NONE,
-  private val runtime2: RuntimeOptions = NONE,
 ) {
 
   private val runtimeConfig = runtime.runtimeConfig
@@ -66,7 +75,16 @@ class RenderWorkflowInSnapshotSaveRestoreTest(
   }
 
   @Test
-  fun saves_to_and_restores_from_snapshot() =
+  fun saves_to_and_restores_from_snapshot(runtime2: RuntimeOptions = NONE) =
+    saveAndRestoreSnapshot(runtime2)
+
+  /**
+   * The body of [saves_to_and_restores_from_snapshot] lives here instead of in the test function
+   * because the Burst-generated zero-arg specialization of a test function whose body evaluates
+   * `this` in an argument expression (e.g. `runTest(dispatcherUsed) { … }`) crashes the
+   * Kotlin/Native compiler with a `NativeCodeGeneratorException` (Kotlin 2.4.0, Burst 2.13.0).
+   */
+  private fun saveAndRestoreSnapshot(runtime2: RuntimeOptions) =
     runTest(dispatcherUsed) {
       val workflow =
         Workflow.stateful<Unit, String, Nothing, Pair<String, (String) -> Unit>>(

--- a/workflow-runtime/src/iosTest/kotlin/com/squareup/workflow1/internal/ThreadLocalTest.kt
+++ b/workflow-runtime/src/iosTest/kotlin/com/squareup/workflow1/internal/ThreadLocalTest.kt
@@ -1,62 +1,85 @@
 package com.squareup.workflow1.internal
 
-import platform.Foundation.NSCondition
-import platform.Foundation.NSThread
 import kotlin.concurrent.Volatile
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import platform.Foundation.NSCondition
+import platform.Foundation.NSThread
 
 class ThreadLocalTest {
 
-  @Volatile
-  private var valueFromThread: Int = -1
+  @Volatile private var valueFromThread: Int = -1
 
-  @Test fun initialValue() {
+  @Test
+  fun initialValue() {
     val threadLocal = ThreadLocal(initialValue = { 42 })
     assertEquals(42, threadLocal.get())
   }
 
-  @Test fun settingValue() {
+  @Test
+  fun settingValue() {
     val threadLocal = ThreadLocal(initialValue = { 42 })
     threadLocal.set(0)
     assertEquals(0, threadLocal.get())
   }
 
-  @Test fun initialValue_inSeparateThread_afterChanging() {
+  @Test
+  fun nullInitialValue() {
+    val threadLocal = ThreadLocal<Int?>(initialValue = { null })
+    assertNull(threadLocal.get())
+  }
+
+  @Test
+  fun settingNull_overridesInitialValue() {
+    val threadLocal = ThreadLocal<Int?>(initialValue = { 42 })
+    threadLocal.set(null)
+    assertNull(threadLocal.get())
+  }
+
+  @Test
+  fun settingNull_thenNonNull() {
+    val threadLocal = ThreadLocal<Int?>(initialValue = { null })
+    threadLocal.set(null)
+    threadLocal.set(1)
+    assertEquals(1, threadLocal.get())
+  }
+
+  @Test
+  fun initialValue_inSeparateThread_afterChanging() {
     val threadLocal = ThreadLocal(initialValue = { 42 })
     threadLocal.set(0)
 
-    val thread = NSThread {
-      valueFromThread = threadLocal.get()
-    }
+    val thread = NSThread { valueFromThread = threadLocal.get() }
     thread.start()
     thread.join()
 
     assertEquals(42, valueFromThread)
   }
 
-  @Test fun set_fromDifferentThreads_doNotConflict() {
+  @Test
+  fun set_fromDifferentThreads_doNotConflict() {
     val threadLocal = ThreadLocal(initialValue = { 0 })
-    // threadStartedLatch and firstReadLatch together form a barrier: the allow the background
-    // to start up and get to the same point as the test thread, just before writing to the
+    // threadStartedLatch and firstReadLatch together form a barrier: they allow the background
+    // thread to start up and get to the same point as the test thread, just before writing to the
     // ThreadLocal, before allowing both threads to perform the write as close to the same time as
     // possible.
-    val threadStartedLatch = NSCondition()
-    val firstReadLatch = NSCondition()
-    val firstReadDoneLatch = NSCondition()
-    val secondReadLatch = NSCondition()
+    val threadStartedLatch = Latch()
+    val firstReadLatch = Latch()
+    val firstReadDoneLatch = Latch()
+    val secondReadLatch = Latch()
 
     val thread = NSThread {
       // Wait on the barrier to sync with the test thread.
-      threadStartedLatch.signal()
-      firstReadLatch.wait()
+      threadStartedLatch.open()
+      firstReadLatch.await()
       threadLocal.set(1)
 
       // Ensure we can see our read immediately, then wait for the test thread to verify. This races
       // with the set(2) in the test thread, but that's fine. We'll double-check the value later.
       valueFromThread = threadLocal.get()
-      firstReadDoneLatch.signal()
-      secondReadLatch.wait()
+      firstReadDoneLatch.open()
+      secondReadLatch.await()
 
       // Read one last time since now the test thread's second write is done.
       valueFromThread = threadLocal.get()
@@ -65,19 +88,19 @@ class ThreadLocalTest {
 
     // Wait for the other thread to start, then both threads set the value to something different
     // at the same time.
-    threadStartedLatch.wait()
-    firstReadLatch.signal()
+    threadStartedLatch.await()
+    firstReadLatch.open()
     threadLocal.set(2)
 
     // Wait for the background thread to finish setting value, then ensure that both threads see
     // independent values.
-    firstReadDoneLatch.wait()
+    firstReadDoneLatch.await()
     assertEquals(1, valueFromThread)
     assertEquals(2, threadLocal.get())
 
     // Change the value in this thread then read it again from the background thread.
     threadLocal.set(3)
-    secondReadLatch.signal()
+    secondReadLatch.open()
     thread.join()
     assertEquals(1, valueFromThread)
   }
@@ -87,6 +110,30 @@ class ThreadLocalTest {
       // Avoid being optimized out.
       // Time interval is in seconds.
       NSThread.sleepForTimeInterval(1.0 / 1000)
+    }
+  }
+
+  /**
+   * One-shot latch built on [NSCondition]. A bare `NSCondition.signal()` is lost if nobody is
+   * waiting yet, and `wait()` must be called with the lock held, so using the condition directly as
+   * a latch deadlocks whenever the opener gets there first (which happens regularly on CI runners).
+   * Guarding a flag with the lock makes [open] durable and [await] correct.
+   */
+  private class Latch {
+    private val condition = NSCondition()
+    private var isOpen = false
+
+    fun open() {
+      condition.lock()
+      isOpen = true
+      condition.broadcast()
+      condition.unlock()
+    }
+
+    fun await() {
+      condition.lock()
+      while (!isOpen) condition.wait()
+      condition.unlock()
     }
   }
 }


### PR DESCRIPTION
`:workflow-runtime:iosSimulatorArm64Test` never actually exercised its tests: the binary crashed before running anything, and the `iosTest` source set was never compiled at all. This PR contains every fix needed for that task to build, run, and pass, in a single commit.

## Fixes

**Wire the test source sets into the manual KMP hierarchy** (`build.gradle.kts`). The main hierarchy (`nativeMain → appleMain → iosMain → ios*Main`) is configured manually, which disables Kotlin's default hierarchy template, but the test side was never mirrored. `workflow-runtime/src/iosTest` was therefore an orphan that no target compiled, so `ThreadLocalTest` has silently never run. Now `nativeTest → appleTest → iosTest → ios*Test`, with `nativeTest` on `commonTest`. `ThreadLocalTest` is reformatted with ktfmt now that it is compiled.

**Make `runtime2` a test-function parameter in `RenderWorkflowInSnapshotSaveRestoreTest`.** As a class parameter, Burst expands the file to `2 × 2 × N²` test classes (N = `RuntimeOptions` entries). Kotlin/Native's per-file test-registration initializer reserves ~32 bytes of stack per class, runs on every new thread, and worker threads get a 512 KB stack. At N = 64 (`main` today) the frame is exactly 512 KB, so the first `runTest` that spawned a worker killed the whole binary with `SIGBUS`. The Compose runtime branch (N = 66) is over the line. The body lives in a private helper because the Burst-generated zero-arg specialization still crashes the K/N compiler (`NativeCodeGeneratorException`, Kotlin 2.4.0 / Burst 2.13.0) when it evaluates `this` in an argument expression such as `runTest(dispatcherUsed) { … }`; the KDoc records both constraints.

**Apple `ThreadLocal`: store `null` as `NSNull`.** `NSMutableDictionary.setObject:forKey:` throws `NSInvalidArgumentException` for nil, so `set(null)` crashed and a null initial value was recomputed on every `get()`. Nulls are stored as `NSNull` and translated back on read.

**`ThreadLocalTest` coverage** for null initial values, setting null, and setting null then non-null.

**Fix a lost-wakeup race in `ThreadLocalTest.set_fromDifferentThreads_doNotConflict`.** The test (which had never run, see above) used bare `NSCondition.signal()`/`wait()` as latches, without holding the lock and with no predicate. A signal that arrives before the other side reaches `wait()` is lost, and both threads block forever. Under load that reproduces locally in roughly 1 of 6 runs, and on the 3-core CI runner it hung the test binary until the job's 45-minute timeout. The latches now guard a flag with the condition's lock.

**Give Kotlin/Native test tasks a 15-minute Gradle task timeout** (`KotlinMultiPlatformConventionPlugin`). Kotlin/Native has no per-test timeout, so the hang above ran until the job's 45-minute limit cancelled it with no report. The iOS suite takes well under a minute on CI, so anything near 15 minutes is a hang. Verified locally with a 5-second timeout: the task fails with `Timeout has been exceeded`, the simulator process is killed, and the JUnit report is still written, so the failure-report upload in the workflow gets something to upload.

## Verification

Local `./gradlew :workflow-runtime:ktfmtCheck :workflow-runtime:iosSimulatorArm64Test --no-configuration-cache` on this commit: BUILD SUCCESSFUL, 27,962 tests, 0 failures, including all 7 `ThreadLocalTest` cases (which previously did not exist in the binary).

`ThreadLocalTest` stress-run 80 times, 4 concurrently, against the rebuilt test binary: 80 passes, 0 hangs (7 of 40 hung before the latch fix).

CI: the "iOS Unit Tests for KMP Modules" job was cancelled at 45 minutes before the latch fix and passed in 12 minutes with it.

Supersedes #1569, which carried the source-set wiring separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
