### PR TITLE
Wire test source sets into workflow-runtime's manual KMP hierarchy [CLF-453]

### DIFF
--- a/workflow-runtime/build.gradle.kts
+++ b/workflow-runtime/build.gradle.kts
@@ -111,6 +111,15 @@ kotlin {
     maybeCreate("iosX64Main").apply { dependsOn(iosMain) }
     maybeCreate("iosSimulatorArm64Main").apply { dependsOn(iosMain) }
 
+    // Test source sets mirror the main hierarchy. Without this, intermediate test source sets like
+    // iosTest are not compiled by any target and their tests silently never run.
+    val nativeTest = maybeCreate("nativeTest").apply { dependsOn(commonTest.get()) }
+    val appleTest = maybeCreate("appleTest").apply { dependsOn(nativeTest) }
+    val iosTest = maybeCreate("iosTest").apply { dependsOn(appleTest) }
+    maybeCreate("iosArm64Test").apply { dependsOn(iosTest) }
+    maybeCreate("iosX64Test").apply { dependsOn(iosTest) }
+    maybeCreate("iosSimulatorArm64Test").apply { dependsOn(iosTest) }
+
     // JS source set depends on commonMain
     maybeCreate("jsMain").apply { dependsOn(commonMain.get()) }
 

--- a/workflow-runtime/src/iosTest/kotlin/com/squareup/workflow1/internal/ThreadLocalTest.kt
+++ b/workflow-runtime/src/iosTest/kotlin/com/squareup/workflow1/internal/ThreadLocalTest.kt
@@ -1,41 +1,42 @@
 package com.squareup.workflow1.internal
 
-import platform.Foundation.NSCondition
-import platform.Foundation.NSThread
 import kotlin.concurrent.Volatile
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import platform.Foundation.NSCondition
+import platform.Foundation.NSThread
 
 class ThreadLocalTest {
 
-  @Volatile
-  private var valueFromThread: Int = -1
+  @Volatile private var valueFromThread: Int = -1
 
-  @Test fun initialValue() {
+  @Test
+  fun initialValue() {
     val threadLocal = ThreadLocal(initialValue = { 42 })
     assertEquals(42, threadLocal.get())
   }
 
-  @Test fun settingValue() {
+  @Test
+  fun settingValue() {
     val threadLocal = ThreadLocal(initialValue = { 42 })
     threadLocal.set(0)
     assertEquals(0, threadLocal.get())
   }
 
-  @Test fun initialValue_inSeparateThread_afterChanging() {
+  @Test
+  fun initialValue_inSeparateThread_afterChanging() {
     val threadLocal = ThreadLocal(initialValue = { 42 })
     threadLocal.set(0)
 
-    val thread = NSThread {
-      valueFromThread = threadLocal.get()
-    }
+    val thread = NSThread { valueFromThread = threadLocal.get() }
     thread.start()
     thread.join()
 
     assertEquals(42, valueFromThread)
   }
 
-  @Test fun set_fromDifferentThreads_doNotConflict() {
+  @Test
+  fun set_fromDifferentThreads_doNotConflict() {
     val threadLocal = ThreadLocal(initialValue = { 0 })
     // threadStartedLatch and firstReadLatch together form a barrier: the allow the background
     // to start up and get to the same point as the test thread, just before writing to the


### PR DESCRIPTION
## Problem

`workflow-runtime/build.gradle.kts` configures the KMP source-set hierarchy manually (f30439f1f, "Configure source sets manually, so we can share one for JVM and Android"), which disables Kotlin's default hierarchy template. It wires the main side (`nativeMain → appleMain → iosMain → ios*Main`) but never the test side.

So `workflow-runtime/src/iosTest`, which contains `com.squareup.workflow1.internal.ThreadLocalTest`, is an orphan source set that no target compiles:

```
$ nm workflow-runtime/build/bin/iosSimulatorArm64/debugTest/test.kexe | grep -c ThreadLocalTest
0
```

Those tests have silently never run since February. `workflow-core` is unaffected because it still uses the default template.

## Fix

Mirror the hierarchy for tests: `nativeTest → appleTest → iosTest → ios*Test`, with `nativeTest` depending on `commonTest`. Because `iosTest` is now compiled, ktfmt also picks it up for the first time, so the second commit is the formatter's reformat of `ThreadLocalTest.kt` (no logic changes).

## Verification

`:workflow-runtime:iosSimulatorArm64Test` now produces a `ThreadLocalTest` result with all 4 tests passing, alongside the rest of the suite.

Linear: [CLF-453](https://linear.app/squareup/issue/CLF-453)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
