### PR TITLE
Fix the JS test shard dropping results and never awaiting the snapshot tests [CLF-454]

### DIFF
--- a/build-logic/karma.config.d/newline-delimited-kotlin-reporter.js
+++ b/build-logic/karma.config.d/newline-delimited-kotlin-reporter.js
@@ -1,0 +1,29 @@
+// Appended to every generated karma.conf.js by KotlinMultiPlatformConventionPlugin.
+//
+// The Kotlin Gradle plugin's Karma reporter (kotlin-web-helpers/dist/karma-kotlin-reporter.js)
+// reports each test back to Gradle by writing a "##teamcity[...]" service message to stdout, but it
+// writes the messages back-to-back with no newline between them. Gradle's side of that protocol
+// (TCServiceMessageOutputStreamHandler) buffers stdout until it sees a newline and gives up on any
+// "line" longer than 1 MiB, logging "too long teamcity service message ... Event was lost". With
+// tens of thousands of tests in a module the whole run is a single line, so most of the results are
+// thrown away and Gradle records only a small, arbitrary subset of the tests that actually ran,
+// including missing failures. Wrapping the reporter so that every message ends with a newline gives
+// the parser the one-message-per-line stream it expects.
+(function (config) {
+  const KOTLIN_REPORTER_MODULE = 'kotlin-web-helpers/dist/karma-kotlin-reporter.js';
+  const REPORTER_KEY = 'reporter:karma-kotlin-reporter';
+  const KotlinReporter = require(KOTLIN_REPORTER_MODULE)[REPORTER_KEY][1];
+
+  function NewlineDelimitedKotlinReporter(baseReporterDecorator, karmaConfig, emitter) {
+    KotlinReporter.call(this, baseReporterDecorator, karmaConfig, emitter);
+    const write = this.write;
+    this.write = function (message) {
+      return write.call(this, message + '\n');
+    };
+  }
+  NewlineDelimitedKotlinReporter.$inject = KotlinReporter.$inject;
+
+  // Replace the plugin registration made by the generated config rather than adding a second one.
+  config.plugins = config.plugins.filter((plugin) => plugin !== KOTLIN_REPORTER_MODULE);
+  config.plugins.push({ [REPORTER_KEY]: ['type', NewlineDelimitedKotlinReporter] });
+})(config);

--- a/build-logic/src/main/java/com/squareup/workflow1/buildsrc/KotlinMultiPlatformConventionPlugin.kt
+++ b/build-logic/src/main/java/com/squareup/workflow1/buildsrc/KotlinMultiPlatformConventionPlugin.kt
@@ -8,7 +8,10 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
+import org.jetbrains.kotlin.gradle.targets.js.testing.karma.KotlinKarma
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
 
 class KotlinMultiPlatformConventionPlugin : Plugin<Project> {
@@ -36,6 +39,25 @@ class KotlinMultiPlatformConventionPlugin : Plugin<Project> {
     // task instead lets the report and any partial results be uploaded.
     target.tasks.withType(KotlinNativeTest::class.java).configureEach { test ->
       test.timeout.set(Duration.ofMinutes(15))
+    }
+
+    // Append the scripts in build-logic/karma.config.d to every generated karma.conf.js. See the
+    // comments in those scripts for what they fix.
+    target.extensions.configure(KotlinMultiplatformExtension::class.java) { kotlin ->
+      kotlin.targets.withType(KotlinJsIrTarget::class.java).configureEach { jsTarget ->
+        jsTarget.whenBrowserConfigured {
+          testTask { test ->
+            // KGP installs its default Karma framework after the project is evaluated, so hook the
+            // framework being set instead of calling useKarma, which would replace that default
+            // (and its browser configuration) with an empty one.
+            test.onTestFrameworkSet { framework ->
+              if (framework is KotlinKarma) {
+                framework.useConfigDirectory(target.rootDir.resolve("build-logic/karma.config.d"))
+              }
+            }
+          }
+        }
+      }
     }
 
     // Sets the JDK target for published artifacts.

--- a/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderWorkflowInSnapshotSaveRestoreTest.kt
+++ b/workflow-runtime/src/commonTest/kotlin/com/squareup/workflow1/RenderWorkflowInSnapshotSaveRestoreTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -16,10 +17,8 @@ import kotlinx.coroutines.test.runTest
 /**
  * This only contains the single test ([saves_to_and_restores_from_snapshot]) from
  * [RenderWorkflowInTest] that needs a second runtime config parameter (`runtime2`). It was split
- * out because Kotlin 2.3.10 crashed when `runtime2` was a test method parameter. Kotlin 2.4.0 still
- * crashes for some shapes of test body (see [saveAndRestoreSnapshot]), so the body is kept in a
- * helper function. With that workaround it may be possible to merge this test back into the main
- * suite.
+ * out because Kotlin 2.3.10 crashed when `runtime2` was a test method parameter. With the
+ * constraints below it may be possible to merge this test back into the main suite.
  *
  * `runtime2` MUST stay a test method parameter rather than a class parameter. Burst generates a
  * class per combination of class parameters, and Kotlin/Native's generated test registration code
@@ -28,6 +27,20 @@ import kotlinx.coroutines.test.runTest
  * [RuntimeOptions] entries, which overflows the 512KB stack of the worker threads that
  * Kotlin/Native runs module initializers on once N passes ~64, crashing the whole test binary with
  * SIGBUS.
+ *
+ * The test function MUST call [runTest] directly, and MUST NOT pass [runTest] any argument that
+ * refers to `this` (such as `runTest(dispatcherUsed)`):
+ * - Burst only generates specializations that return the `TestResult` when the test function itself
+ *   calls [runTest]. If [runTest] is hidden behind a helper function, the generated per-value test
+ *   functions call the original and discard its result. On JS that result is the Promise Mocha has
+ *   to await, so every one of those tests would complete immediately and pass without its body ever
+ *   having run to completion.
+ * - Burst copies the [runTest] arguments into each generated specialization, and in Kotlin 2.4.0
+ *   the Kotlin/Native backend crashes with a `NativeCodeGeneratorException` when a copied argument
+ *   expression refers to `this`.
+ *
+ * So instead of running the test body itself on the dispatcher under test, the body launches both
+ * runtimes in explicit [TestScope]s that use it.
  */
 @OptIn(ExperimentalCoroutinesApi::class, WorkflowExperimentalRuntime::class)
 @Burst
@@ -75,66 +88,61 @@ class RenderWorkflowInSnapshotSaveRestoreTest(
   }
 
   @Test
-  fun saves_to_and_restores_from_snapshot(runtime2: RuntimeOptions = NONE) =
-    saveAndRestoreSnapshot(runtime2)
+  fun saves_to_and_restores_from_snapshot(runtime2: RuntimeOptions = NONE) = runTest {
+    val workflow =
+      Workflow.stateful<Unit, String, Nothing, Pair<String, (String) -> Unit>>(
+        initialState = { _, snapshot ->
+          snapshot?.bytes?.parse { it.readUtf8WithLength() } ?: "initial state"
+        },
+        snapshot = { state -> Snapshot.write { it.writeUtf8WithLength(state) } },
+        render = { _, renderState ->
+          Pair(renderState, { newState -> actionSink.send(action("") { state = newState }) })
+        },
+      )
+    val props = MutableStateFlow(Unit)
+    // See the class KDoc for why this doesn't just use this test's own scope.
+    val renderScope = TestScope(dispatcherUsed)
+    val renderings =
+      renderWorkflowIn(
+        workflow = workflow,
+        scope = renderScope,
+        props = props,
+        runtimeConfig = runtimeConfig,
+        workflowTracer = null,
+      ) {}
+    advanceIfStandard()
 
-  /**
-   * The body of [saves_to_and_restores_from_snapshot] lives here instead of in the test function
-   * because the Burst-generated zero-arg specialization of a test function whose body evaluates
-   * `this` in an argument expression (e.g. `runTest(dispatcherUsed) { … }`) crashes the
-   * Kotlin/Native compiler with a `NativeCodeGeneratorException` (Kotlin 2.4.0, Burst 2.13.0).
-   */
-  private fun saveAndRestoreSnapshot(runtime2: RuntimeOptions) =
-    runTest(dispatcherUsed) {
-      val workflow =
-        Workflow.stateful<Unit, String, Nothing, Pair<String, (String) -> Unit>>(
-          initialState = { _, snapshot ->
-            snapshot?.bytes?.parse { it.readUtf8WithLength() } ?: "initial state"
-          },
-          snapshot = { state -> Snapshot.write { it.writeUtf8WithLength(state) } },
-          render = { _, renderState ->
-            Pair(renderState, { newState -> actionSink.send(action("") { state = newState }) })
-          },
-        )
-      val props = MutableStateFlow(Unit)
-      val renderings =
-        renderWorkflowIn(
-          workflow = workflow,
-          scope = backgroundScope,
-          props = props,
-          runtimeConfig = runtimeConfig,
-          workflowTracer = null,
-        ) {}
-      advanceIfStandard()
-
-      // Interact with the workflow to change the state.
-      renderings.value.rendering.let { (state, updateState) ->
-        assertEquals("initial state", state)
-        updateState("updated state")
-      }
-      advanceIfStandard()
-
-      val snapshot =
-        renderings.value.let { (rendering, snapshot) ->
-          val (state, updateState) = rendering
-          assertEquals("updated state", state)
-          updateState("ignored rendering")
-          return@let snapshot
-        }
-      advanceIfStandard()
-
-      // Create a new scope to launch a second runtime to restore.
-      val restoreScope = TestScope(dispatcherUsed)
-      val restoredRenderings =
-        renderWorkflowIn(
-          workflow = workflow,
-          scope = restoreScope,
-          props = props,
-          initialSnapshot = snapshot,
-          workflowTracer = null,
-          runtimeConfig = runtime2.runtimeConfig,
-        ) {}
-      advanceIfStandard()
-      assertEquals("updated state", restoredRenderings.value.rendering.first)
+    // Interact with the workflow to change the state.
+    renderings.value.rendering.let { (state, updateState) ->
+      assertEquals("initial state", state)
+      updateState("updated state")
     }
+    advanceIfStandard()
+
+    val snapshot =
+      renderings.value.let { (rendering, snapshot) ->
+        val (state, updateState) = rendering
+        assertEquals("updated state", state)
+        updateState("ignored rendering")
+        return@let snapshot
+      }
+    advanceIfStandard()
+
+    // Create a new scope to launch a second runtime to restore.
+    val restoreScope = TestScope(dispatcherUsed)
+    val restoredRenderings =
+      renderWorkflowIn(
+        workflow = workflow,
+        scope = restoreScope,
+        props = props,
+        initialSnapshot = snapshot,
+        workflowTracer = null,
+        runtimeConfig = runtime2.runtimeConfig,
+      ) {}
+    advanceIfStandard()
+    assertEquals("updated state", restoredRenderings.value.rendering.first)
+
+    renderScope.cancel()
+    restoreScope.cancel()
+  }
 }


### PR DESCRIPTION
The "JS Unit Tests for KMP Modules" shard has not been testing what it claims to. Two independent problems, both present on `main`:

### 1. Gradle throws away most of the Karma results

KGP's Karma reporter (`kotlin-web-helpers/dist/karma-kotlin-reporter.js`) writes its `##teamcity[...]` service messages to stdout back-to-back with **no newline between them**. KGP's Gradle-side parser (`TCServiceMessageOutputStreamHandler`) buffers stdout until it sees a newline and drops any "line" longer than 1 MiB, logging:

```
Cannot process output: too long teamcity service message (more than 1Mb). Event was lost.
java.lang.IllegalStateException: no running test
```

Since the whole run is a single line, every 1 MiB chunk is discarded and only the final remainder is parsed. On recent `main` runs Gradle recorded roughly 2,000 of the 27,955 `workflow-runtime` JS tests that actually run. Any failure inside a dropped chunk is invisible, so the shard is green regardless.

**Fix:** `build-logic/karma.config.d/newline-delimited-kotlin-reporter.js` wraps KGP's reporter so every message ends with a newline, and `KotlinMultiPlatformConventionPlugin` appends that directory to every generated `karma.conf.js` via `KotlinKarma.useConfigDirectory`. After this change all 27,955 `workflow-runtime` and 50 `workflow-core` tests are recorded and the overflow message is gone.

### 2. Burst never awaits `RenderWorkflowInSnapshotSaveRestoreTest` on JS

Burst 2.13.0 only generates specializations that `return runTest(...) { … }` when the parameterized test function's body calls `runTest` itself. When `runTest` is behind a helper (which #1568 introduced to dodge a Kotlin/Native compiler crash), the generated per-value functions call the original as a bare statement and return nothing. On JS that return value is the Promise Mocha has to await, so all 4,096 `saves_to_and_restores_from_snapshot_*` tests completed instantly and "passed" without their bodies ever finishing. Those thousands of un-awaited bodies then ran concurrently with the rest of the suite and starved the event loop, which is what made unrelated tests hit Mocha's 2 s timeout on #1442.

**Fix:** the test calls `runTest` directly again, but with no arguments that reference `this` (the shape that crashes Kotlin/Native), and launches both runtimes in explicit `TestScope(dispatcherUsed)` scopes instead. The class KDoc documents both constraints. Burst itself should also be fixed to return the delegate's value; that's a follow-up.

### Verification

Locally, with these changes on `main`:

| Task | Recorded | Failures |
|---|---|---|
| `:workflow-runtime:jvmTest` (this class) | 16,384 | 0 |
| `:workflow-runtime:iosSimulatorArm64Test` (this class) | 16,384 | 0 |
| `:workflow-runtime:jsBrowserTest` (full) | 27,955 | 0 |
| `:workflow-core:jsBrowserTest` (full) | 50 | 0 |

Ref: CLF-454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
